### PR TITLE
fix(tests): Specify top_level_dir to resolve tools module ambiguity in test discovery

### DIFF
--- a/tests/run.py
+++ b/tests/run.py
@@ -84,7 +84,7 @@ def gather_test_cases(test_dir, pattern, tag, mode='partial'):
     test_to_run = unittest.TestSuite()
     partial_test_files = get_partial_test_cases() if mode == 'partial' else None
     test_loader = TaggedTestLoader(tag, included_test_files=partial_test_files)
-    discover = test_loader.discover(test_dir, pattern=pattern, top_level_dir=None)
+    discover = test_loader.discover(test_dir, pattern=pattern, top_level_dir=file_dir)
     for suite_discovered in discover:
         print('suite_discovered', suite_discovered)
         for test_suite in suite_discovered:


### PR DESCRIPTION
## Problem

When running tests in regression mode, `unittest.TestLoader.discover()` fails to locate test modules under `tests/tools/` (e.g., `test_mcp_server.py`), resulting in test discovery returning `None` or empty test suites.

**Root Cause:**

The project has multiple `tools` directories that create namespace ambiguity:
- `tests/tools/` - Contains test modules
- `data_juicer/tools/` - Package module with dynamic import mechanism
- `tools/` - Project-level utility scripts

When `top_level_dir=None`, the test loader cannot correctly resolve the import path for `tests.tools.test_mcp_server`, causing module resolution to fail.

## Solution

Explicitly set `top_level_dir=file_dir` (project root) in `test_loader.discover()` to ensure unittest can correctly calculate the full import path for test modules, avoiding relative import resolution failures.