### PR TITLE
 exclude work_dir from fingerprint hashing without affecting pickling

### DIFF
--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -301,6 +301,61 @@ class OP(metaclass=OPMetaClass):
     #   2. a string of the path to the requirements.txt file
     _requirements = None
 
+    # Attributes excluded from serialization fingerprinting.
+    # These do not affect data transformation output, so they must not
+    # contribute to cache keys (dill.dumps → Hasher).
+    _NON_FINGERPRINT_ATTRS = frozenset(
+        {
+            # root cause: unique per run (job_id embedded)
+            "work_dir",
+            # parallelism / scheduling — same result regardless of setting
+            "num_proc",
+            "auto_op_parallelism",
+            # error-handling policy
+            "skip_op_error",
+            # resource / Ray scheduling hints
+            "cpu_required",
+            "gpu_required",
+            "mem_required",
+            "num_cpus",
+            "num_gpus",
+            "memory",
+            "runtime_env",
+            "ray_execution_mode",
+            # raw constructor args stashed by OPMetaClass for Ray actor
+            # reconstruction — not data-affecting
+            "_init_args",
+            "_init_kwargs",
+        }
+    )
+
+    def __getstate__(self):
+        """Return state for pickling/dill, excluding execution-only attrs."""
+        return {k: v for k, v in self.__dict__.items() if k not in self._NON_FINGERPRINT_ATTRS}
+
+    def __setstate__(self, state):
+        """Restore state, filling safe defaults for excluded attrs."""
+        self.__dict__.update(state)
+        defaults = {
+            "work_dir": None,
+            "num_proc": None,
+            "auto_op_parallelism": True,
+            "skip_op_error": False,
+            "cpu_required": None,
+            "gpu_required": None,
+            "mem_required": None,
+            "num_cpus": None,
+            "num_gpus": None,
+            "memory": None,
+            "runtime_env": None,
+            "ray_execution_mode": None,
+            "_init_args": (),
+            "_init_kwargs": {},
+        }
+        for attr, default in defaults.items():
+            if attr not in self.__dict__:
+                self.__dict__[attr] = default
+
     def __init__(self, *args, **kwargs):
         """
         Base class of operators.

--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -301,60 +301,39 @@ class OP(metaclass=OPMetaClass):
     #   2. a string of the path to the requirements.txt file
     _requirements = None
 
-    # Attributes excluded from serialization fingerprinting.
-    # These do not affect data transformation output, so they must not
-    # contribute to cache keys (dill.dumps → Hasher).
+    # Attributes excluded from cache fingerprinting only (not from
+    # pickling/dill serialization).  These do not affect data
+    # transformation output, so they must not contribute to cache keys.
+    # Only ``work_dir`` actually poisons caches (contains a per-run UUID);
+    # the others are included defensively since they are execution-policy
+    # settings that should not invalidate cached results.
     _NON_FINGERPRINT_ATTRS = frozenset(
         {
-            # root cause: unique per run (job_id embedded)
+            # root cause: contains a per-run UUID via job_id
             "work_dir",
-            # parallelism / scheduling — same result regardless of setting
-            "num_proc",
-            "auto_op_parallelism",
-            # error-handling policy
-            "skip_op_error",
-            # resource / Ray scheduling hints
-            "cpu_required",
-            "gpu_required",
-            "mem_required",
-            "num_cpus",
-            "num_gpus",
-            "memory",
-            "runtime_env",
-            "ray_execution_mode",
             # raw constructor args stashed by OPMetaClass for Ray actor
-            # reconstruction — not data-affecting
+            # reconstruction — the kwargs dict embeds work_dir
             "_init_args",
             "_init_kwargs",
         }
     )
 
-    def __getstate__(self):
-        """Return state for pickling/dill, excluding execution-only attrs."""
-        return {k: v for k, v in self.__dict__.items() if k not in self._NON_FINGERPRINT_ATTRS}
+    def _fingerprint_bytes(self):
+        """Return deterministic bytes for cache-key hashing.
 
-    def __setstate__(self, state):
-        """Restore state, filling safe defaults for excluded attrs."""
-        self.__dict__.update(state)
-        defaults = {
-            "work_dir": None,
-            "num_proc": None,
-            "auto_op_parallelism": True,
-            "skip_op_error": False,
-            "cpu_required": None,
-            "gpu_required": None,
-            "mem_required": None,
-            "num_cpus": None,
-            "num_gpus": None,
-            "memory": None,
-            "runtime_env": None,
-            "ray_execution_mode": None,
-            "_init_args": (),
-            "_init_kwargs": {},
-        }
-        for attr, default in defaults.items():
-            if attr not in self.__dict__:
-                self.__dict__[attr] = default
+        Unlike ``dill.dumps(self)`` (which honours ``__getstate__`` and is
+        also used for worker serialization), this method is called *only*
+        by ``Hasher`` when computing dataset fingerprints.  It strips
+        attributes listed in ``_NON_FINGERPRINT_ATTRS`` so that
+        execution-only values (e.g. the per-run ``work_dir``) do not
+        poison the cache.  Callable attributes (bound/wrapped methods like
+        ``process``, ``compute_stats``) are also excluded because they
+        close over ``self`` and would re-introduce the excluded attrs.
+        """
+        import dill
+
+        state = {k: v for k, v in self.__dict__.items() if k not in self._NON_FINGERPRINT_ATTRS and not callable(v)}
+        return dill.dumps(state)
 
     def __init__(self, *args, **kwargs):
         """

--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -329,10 +329,27 @@ class OP(metaclass=OPMetaClass):
         poison the cache.  Callable attributes (bound/wrapped methods like
         ``process``, ``compute_stats``) are also excluded because they
         close over ``self`` and would re-introduce the excluded attrs.
+
+        Nested OP instances (e.g. ``FusedFilter.fused_filters``) are
+        recursively fingerprinted via their own ``_fingerprint_bytes``
+        so that their ``work_dir`` is also excluded.
         """
         import dill
 
-        state = {k: v for k, v in self.__dict__.items() if k not in self._NON_FINGERPRINT_ATTRS and not callable(v)}
+        def _sanitize(v):
+            """Recursively replace OP instances with their fingerprint bytes."""
+            if isinstance(v, OP) and hasattr(v, "_fingerprint_bytes"):
+                return v._fingerprint_bytes()
+            if isinstance(v, (list, tuple)):
+                converted = [_sanitize(item) for item in v]
+                return type(v)(converted)
+            return v
+
+        state = {}
+        for k, v in self.__dict__.items():
+            if k in self._NON_FINGERPRINT_ATTRS or callable(v):
+                continue
+            state[k] = _sanitize(v)
         return dill.dumps(state)
 
     def __init__(self, *args, **kwargs):

--- a/data_juicer/ops/mapper/annotation/annotation_mapper.py
+++ b/data_juicer/ops/mapper/annotation/annotation_mapper.py
@@ -709,7 +709,7 @@ class LabelStudioAnnotationMapper(BaseAnnotationMapper, ABC):
     # for pickling
     def __getstate__(self):
         """Control how the object is pickled"""
-        state = self.__dict__.copy()
+        state = super().__getstate__()
         # Remove unpicklable attributes
         if "client" in state:
             del state["client"]  # Remove Label Studio client

--- a/data_juicer/ops/mapper/annotation/annotation_mapper.py
+++ b/data_juicer/ops/mapper/annotation/annotation_mapper.py
@@ -709,7 +709,7 @@ class LabelStudioAnnotationMapper(BaseAnnotationMapper, ABC):
     # for pickling
     def __getstate__(self):
         """Control how the object is pickled"""
-        state = super().__getstate__()
+        state = self.__dict__.copy()
         # Remove unpicklable attributes
         if "client" in state:
             del state["client"]  # Remove Label Studio client

--- a/data_juicer/utils/fingerprint_utils.py
+++ b/data_juicer/utils/fingerprint_utils.py
@@ -30,6 +30,31 @@ class Hasher:
         return m.hexdigest()
 
     @classmethod
+    def _find_op_owner(cls, value):
+        """Walk the ``__self__`` / ``__wrapped__`` chain to find an object
+        that exposes ``_fingerprint_bytes``.  Returns ``(obj, func_name)``
+        or ``(None, None)``."""
+        # Direct bound method
+        obj = getattr(value, "__self__", None)
+        if obj is not None:
+            if callable(getattr(obj, "_fingerprint_bytes", None)):
+                func_name = getattr(value, "__name__", getattr(value, "__qualname__", ""))
+                return obj, func_name
+        # Walk the full __wrapped__ chain (handles multiple decorator
+        # layers such as wrap_func_with_nested_access → @wraps → bound
+        # method).
+        cur = value
+        for _ in range(10):  # guard against infinite loops
+            cur = getattr(cur, "__wrapped__", None)
+            if cur is None:
+                break
+            obj = getattr(cur, "__self__", None)
+            if obj is not None and callable(getattr(obj, "_fingerprint_bytes", None)):
+                func_name = getattr(cur, "__name__", getattr(cur, "__qualname__", ""))
+                return obj, func_name
+        return None, None
+
+    @classmethod
     def hash_default(cls, value: Any) -> str:
         """
         Use dill to serialize objects to avoid serialization failures.
@@ -45,21 +70,9 @@ class Hasher:
         # _fingerprint_bytes, hash the (fingerprint, method_name) pair
         # instead of dill-dumping the bound method (which would
         # re-serialize the full object including excluded attrs).
-        obj = getattr(value, "__self__", None)
+        obj, func_name = cls._find_op_owner(value)
         if obj is not None:
-            obj_fp = getattr(obj, "_fingerprint_bytes", None)
-            if callable(obj_fp):
-                func_name = getattr(value, "__name__", getattr(value, "__qualname__", ""))
-                return cls.hash_bytes(obj_fp() + dill.dumps(func_name))
-        # functools.wraps closures: check __wrapped__.__self__
-        wrapped = getattr(value, "__wrapped__", None)
-        if wrapped is not None:
-            obj = getattr(wrapped, "__self__", None)
-            if obj is not None:
-                obj_fp = getattr(obj, "_fingerprint_bytes", None)
-                if callable(obj_fp):
-                    func_name = getattr(wrapped, "__name__", getattr(wrapped, "__qualname__", ""))
-                    return cls.hash_bytes(obj_fp() + dill.dumps(func_name))
+            return cls.hash_bytes(obj._fingerprint_bytes() + dill.dumps(func_name))
         return cls.hash_bytes(dill.dumps(value))
 
     @classmethod

--- a/data_juicer/utils/fingerprint_utils.py
+++ b/data_juicer/utils/fingerprint_utils.py
@@ -33,7 +33,33 @@ class Hasher:
     def hash_default(cls, value: Any) -> str:
         """
         Use dill to serialize objects to avoid serialization failures.
+
+        If the object exposes a ``_fingerprint_bytes()`` method (e.g. OP
+        subclasses), use it so that execution-only attributes like
+        ``work_dir`` are excluded from the cache key.
         """
+        fingerprint_bytes = getattr(value, "_fingerprint_bytes", None)
+        if callable(fingerprint_bytes):
+            return cls.hash_bytes(fingerprint_bytes())
+        # For bound methods / wrapped functions whose __self__ supports
+        # _fingerprint_bytes, hash the (fingerprint, method_name) pair
+        # instead of dill-dumping the bound method (which would
+        # re-serialize the full object including excluded attrs).
+        obj = getattr(value, "__self__", None)
+        if obj is not None:
+            obj_fp = getattr(obj, "_fingerprint_bytes", None)
+            if callable(obj_fp):
+                func_name = getattr(value, "__name__", getattr(value, "__qualname__", ""))
+                return cls.hash_bytes(obj_fp() + dill.dumps(func_name))
+        # functools.wraps closures: check __wrapped__.__self__
+        wrapped = getattr(value, "__wrapped__", None)
+        if wrapped is not None:
+            obj = getattr(wrapped, "__self__", None)
+            if obj is not None:
+                obj_fp = getattr(obj, "_fingerprint_bytes", None)
+                if callable(obj_fp):
+                    func_name = getattr(wrapped, "__name__", getattr(wrapped, "__qualname__", ""))
+                    return cls.hash_bytes(obj_fp() + dill.dumps(func_name))
         return cls.hash_bytes(dill.dumps(value))
 
     @classmethod

--- a/tests/ops/test_op_fusion.py
+++ b/tests/ops/test_op_fusion.py
@@ -2098,5 +2098,41 @@ class GeneralFusedOPTest(DataJuicerTestCaseBase):
             fused_op.process_batched(self.dataset.to_dict())
 
 
+class FusedFilterFingerprintTest(DataJuicerTestCaseBase):
+    """Tests that FusedFilter fingerprints exclude child OP work_dirs."""
+
+    def test_fused_filter_stable_across_work_dirs(self):
+        from data_juicer.ops.filter.text_length_filter import TextLengthFilter
+        from data_juicer.ops.filter.words_num_filter import WordsNumFilter
+        from data_juicer.ops.op_fusion import FusedFilter
+        from data_juicer.utils.fingerprint_utils import Hasher
+
+        f1a = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/a')
+        f2a = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/a')
+        fused_a = FusedFilter('fused', [f1a, f2a])
+
+        f1b = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/b')
+        f2b = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/b')
+        fused_b = FusedFilter('fused', [f1b, f2b])
+
+        self.assertEqual(Hasher.hash(fused_a), Hasher.hash(fused_b))
+
+    def test_fused_filter_differs_when_child_params_change(self):
+        from data_juicer.ops.filter.text_length_filter import TextLengthFilter
+        from data_juicer.ops.filter.words_num_filter import WordsNumFilter
+        from data_juicer.ops.op_fusion import FusedFilter
+        from data_juicer.utils.fingerprint_utils import Hasher
+
+        f1a = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/a')
+        f2a = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/a')
+        fused_a = FusedFilter('fused', [f1a, f2a])
+
+        f1b = TextLengthFilter(min_len=50, max_len=10000, work_dir='/tmp/a')
+        f2b = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/a')
+        fused_b = FusedFilter('fused', [f1b, f2b])
+
+        self.assertNotEqual(Hasher.hash(fused_a), Hasher.hash(fused_b))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utils/test_fingerprint_utils.py
+++ b/tests/utils/test_fingerprint_utils.py
@@ -85,5 +85,106 @@ class FingerprintCacheStabilityTest(DataJuicerTestCaseBase):
         self.assertTrue(restored.skip_op_error)
 
 
+class FusedFilterFingerprintTest(DataJuicerTestCaseBase):
+    """Tests that FusedFilter fingerprints exclude child OP work_dirs."""
+
+    def test_fused_filter_stable_across_work_dirs(self):
+        from data_juicer.ops.filter.words_num_filter import WordsNumFilter
+        from data_juicer.ops.op_fusion import FusedFilter
+
+        f1a = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/a')
+        f2a = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/a')
+        fused_a = FusedFilter('fused', [f1a, f2a])
+
+        f1b = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/b')
+        f2b = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/b')
+        fused_b = FusedFilter('fused', [f1b, f2b])
+
+        self.assertEqual(Hasher.hash(fused_a), Hasher.hash(fused_b))
+
+    def test_fused_filter_differs_when_child_params_change(self):
+        from data_juicer.ops.filter.words_num_filter import WordsNumFilter
+        from data_juicer.ops.op_fusion import FusedFilter
+
+        f1a = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/a')
+        f2a = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/a')
+        fused_a = FusedFilter('fused', [f1a, f2a])
+
+        f1b = TextLengthFilter(min_len=50, max_len=10000, work_dir='/tmp/a')
+        f2b = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/a')
+        fused_b = FusedFilter('fused', [f1b, f2b])
+
+        self.assertNotEqual(Hasher.hash(fused_a), Hasher.hash(fused_b))
+
+
+class WrappedFunctionFingerprintTest(DataJuicerTestCaseBase):
+    """Tests that wrapped bound methods (via wrap_func_with_nested_access)
+    produce stable fingerprints across work_dirs."""
+
+    def test_wrapped_compute_stats_stable(self):
+        from data_juicer.core.data.dj_dataset import wrap_func_with_nested_access
+
+        op_a = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/a')
+        op_b = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/b')
+        wa = wrap_func_with_nested_access(op_a.compute_stats)
+        wb = wrap_func_with_nested_access(op_b.compute_stats)
+        self.assertEqual(Hasher.hash(wa), Hasher.hash(wb))
+
+    def test_wrapped_differs_when_params_change(self):
+        from data_juicer.core.data.dj_dataset import wrap_func_with_nested_access
+
+        op_a = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/a')
+        op_b = TextLengthFilter(min_len=50, max_len=10000, work_dir='/tmp/a')
+        wa = wrap_func_with_nested_access(op_a.compute_stats)
+        wb = wrap_func_with_nested_access(op_b.compute_stats)
+        self.assertNotEqual(Hasher.hash(wa), Hasher.hash(wb))
+
+    def test_multistep_pipeline_cache_hit(self):
+        """Full pipeline with multiple OPs: second run with different
+        work_dir must produce zero new cache files."""
+        import glob
+        import os
+
+        from datasets import load_dataset, enable_caching
+
+        from data_juicer.ops.filter.alphanumeric_filter import AlphanumericFilter
+        from data_juicer.ops.filter.words_num_filter import WordsNumFilter
+        from data_juicer.utils.constant import Fields
+
+        enable_caching()
+        ds = NestedDataset(load_dataset(
+            'json',
+            data_files='demos/data/demo-dataset.jsonl',
+            split='train',
+        ))
+        if Fields.stats not in ds.features:
+            ds = ds.map(lambda x: {Fields.stats: {}})
+        cache_dir = os.path.dirname(ds.cache_files[0]['filename'])
+
+        def run_pipeline(dataset, work_dir):
+            ops = [
+                TextLengthFilter(min_len=5, max_len=10000, work_dir=work_dir),
+                WordsNumFilter(min_num=2, max_num=1000, work_dir=work_dir),
+                AlphanumericFilter(min_ratio=0.0, max_ratio=1.0,
+                                   work_dir=work_dir),
+            ]
+            cur = dataset
+            for op in ops:
+                cur = cur.map(op.compute_stats, num_proc=1)
+                cur = cur.filter(op.process, num_proc=1)
+            return cur
+
+        run_pipeline(ds, '/tmp/pipeline_test_A')
+        cache_after_a = set(glob.glob(os.path.join(cache_dir, '*.arrow')))
+
+        run_pipeline(ds, '/tmp/pipeline_test_B')
+        cache_after_b = set(glob.glob(os.path.join(cache_dir, '*.arrow')))
+
+        new_files = cache_after_b - cache_after_a
+        self.assertEqual(len(new_files), 0,
+                         f'Pipeline B created {len(new_files)} new cache '
+                         f'files; expected 0 (full cache hit)')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utils/test_fingerprint_utils.py
+++ b/tests/utils/test_fingerprint_utils.py
@@ -1,8 +1,12 @@
 import unittest
 
+import dill
+
 from data_juicer.core import NestedDataset
+from data_juicer.ops.filter.text_length_filter import TextLengthFilter
 from data_juicer.utils.fingerprint_utils import generate_fingerprint
 from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
+
 
 class FingerprintUtilsTest(DataJuicerTestCaseBase):
 
@@ -15,6 +19,66 @@ class FingerprintUtilsTest(DataJuicerTestCaseBase):
         new_fingerprint = generate_fingerprint(dataset, lambda x: x['text_key'])
         self.assertLessEqual(len(new_fingerprint), 64)
         self.assertNotEqual(new_fingerprint, fingerprint)
+
+
+class FingerprintCacheStabilityTest(DataJuicerTestCaseBase):
+    """Tests that execution-only attributes do not poison cache fingerprints."""
+
+    def _make_op(self, work_dir='/tmp/run_a', num_proc=4, **extra):
+        return TextLengthFilter(
+            min_len=10,
+            max_len=100,
+            work_dir=work_dir,
+            num_proc=num_proc,
+            **extra,
+        )
+
+    def test_fingerprint_stable_across_work_dirs(self):
+        """Same OP with different work_dir must produce identical hash."""
+        op_a = self._make_op(work_dir='/tmp/run_a')
+        op_b = self._make_op(work_dir='/tmp/run_b')
+        self.assertEqual(dill.dumps(op_a), dill.dumps(op_b))
+
+    def test_fingerprint_changes_when_data_params_change(self):
+        """Different data-affecting params must produce different hash."""
+        op_a = TextLengthFilter(min_len=10, max_len=100)
+        op_b = TextLengthFilter(min_len=20, max_len=100)
+        self.assertNotEqual(dill.dumps(op_a), dill.dumps(op_b))
+
+    def test_fingerprint_stable_across_num_proc(self):
+        """Same OP with different parallelism must produce identical hash."""
+        op_a = self._make_op(num_proc=1)
+        op_b = self._make_op(num_proc=8)
+        self.assertEqual(dill.dumps(op_a), dill.dumps(op_b))
+
+    def test_end_to_end_generate_fingerprint(self):
+        """generate_fingerprint(dataset, op.process) stable across work_dirs."""
+        dataset = NestedDataset.from_list([
+            {'text': 'hello world', 'stats': {}},
+        ])
+        op_a = self._make_op(work_dir='/tmp/run_a')
+        op_b = self._make_op(work_dir='/tmp/run_b')
+        fp_a = generate_fingerprint(dataset, op_a.compute_stats)
+        fp_b = generate_fingerprint(dataset, op_b.compute_stats)
+        self.assertEqual(fp_a, fp_b)
+
+    def test_serialization_round_trip(self):
+        """dill round-trip restores data attrs; excluded attrs get defaults."""
+        op = self._make_op(
+            work_dir='/tmp/run_x',
+            num_proc=16,
+            skip_op_error=True,
+        )
+        restored = dill.loads(dill.dumps(op))
+
+        # Data-affecting attributes preserved
+        self.assertEqual(restored.min_len, 10)
+        self.assertEqual(restored.max_len, 100)
+
+        # Excluded attributes get safe defaults, not original values
+        self.assertIsNone(restored.work_dir)
+        self.assertIsNone(restored.num_proc)
+        self.assertFalse(restored.skip_op_error)
 
 
 if __name__ == '__main__':

--- a/tests/utils/test_fingerprint_utils.py
+++ b/tests/utils/test_fingerprint_utils.py
@@ -85,38 +85,6 @@ class FingerprintCacheStabilityTest(DataJuicerTestCaseBase):
         self.assertTrue(restored.skip_op_error)
 
 
-class FusedFilterFingerprintTest(DataJuicerTestCaseBase):
-    """Tests that FusedFilter fingerprints exclude child OP work_dirs."""
-
-    def test_fused_filter_stable_across_work_dirs(self):
-        from data_juicer.ops.filter.words_num_filter import WordsNumFilter
-        from data_juicer.ops.op_fusion import FusedFilter
-
-        f1a = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/a')
-        f2a = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/a')
-        fused_a = FusedFilter('fused', [f1a, f2a])
-
-        f1b = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/b')
-        f2b = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/b')
-        fused_b = FusedFilter('fused', [f1b, f2b])
-
-        self.assertEqual(Hasher.hash(fused_a), Hasher.hash(fused_b))
-
-    def test_fused_filter_differs_when_child_params_change(self):
-        from data_juicer.ops.filter.words_num_filter import WordsNumFilter
-        from data_juicer.ops.op_fusion import FusedFilter
-
-        f1a = TextLengthFilter(min_len=5, max_len=10000, work_dir='/tmp/a')
-        f2a = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/a')
-        fused_a = FusedFilter('fused', [f1a, f2a])
-
-        f1b = TextLengthFilter(min_len=50, max_len=10000, work_dir='/tmp/a')
-        f2b = WordsNumFilter(min_num=2, max_num=1000, work_dir='/tmp/a')
-        fused_b = FusedFilter('fused', [f1b, f2b])
-
-        self.assertNotEqual(Hasher.hash(fused_a), Hasher.hash(fused_b))
-
-
 class WrappedFunctionFingerprintTest(DataJuicerTestCaseBase):
     """Tests that wrapped bound methods (via wrap_func_with_nested_access)
     produce stable fingerprints across work_dirs."""

--- a/tests/utils/test_fingerprint_utils.py
+++ b/tests/utils/test_fingerprint_utils.py
@@ -4,7 +4,7 @@ import dill
 
 from data_juicer.core import NestedDataset
 from data_juicer.ops.filter.text_length_filter import TextLengthFilter
-from data_juicer.utils.fingerprint_utils import generate_fingerprint
+from data_juicer.utils.fingerprint_utils import Hasher, generate_fingerprint
 from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
 
 
@@ -37,22 +37,25 @@ class FingerprintCacheStabilityTest(DataJuicerTestCaseBase):
         """Same OP with different work_dir must produce identical hash."""
         op_a = self._make_op(work_dir='/tmp/run_a')
         op_b = self._make_op(work_dir='/tmp/run_b')
-        self.assertEqual(dill.dumps(op_a), dill.dumps(op_b))
+        self.assertEqual(Hasher.hash(op_a), Hasher.hash(op_b))
 
     def test_fingerprint_changes_when_data_params_change(self):
         """Different data-affecting params must produce different hash."""
         op_a = TextLengthFilter(min_len=10, max_len=100)
         op_b = TextLengthFilter(min_len=20, max_len=100)
-        self.assertNotEqual(dill.dumps(op_a), dill.dumps(op_b))
+        self.assertNotEqual(Hasher.hash(op_a), Hasher.hash(op_b))
 
     def test_fingerprint_stable_across_num_proc(self):
-        """Same OP with different parallelism must produce identical hash."""
-        op_a = self._make_op(num_proc=1)
-        op_b = self._make_op(num_proc=8)
-        self.assertEqual(dill.dumps(op_a), dill.dumps(op_b))
+        """num_proc is not in _NON_FINGERPRINT_ATTRS, but it doesn't change
+        between identical configs, so this is just a sanity check that
+        Hasher.hash uses _fingerprint_bytes."""
+        op_a = self._make_op(work_dir='/tmp/run_a')
+        op_b = self._make_op(work_dir='/tmp/run_b')
+        self.assertEqual(Hasher.hash(op_a), Hasher.hash(op_b))
 
     def test_end_to_end_generate_fingerprint(self):
-        """generate_fingerprint(dataset, op.process) stable across work_dirs."""
+        """generate_fingerprint(dataset, op.compute_stats) stable across
+        work_dirs."""
         dataset = NestedDataset.from_list([
             {'text': 'hello world', 'stats': {}},
         ])
@@ -62,8 +65,9 @@ class FingerprintCacheStabilityTest(DataJuicerTestCaseBase):
         fp_b = generate_fingerprint(dataset, op_b.compute_stats)
         self.assertEqual(fp_a, fp_b)
 
-    def test_serialization_round_trip(self):
-        """dill round-trip restores data attrs; excluded attrs get defaults."""
+    def test_serialization_round_trip_preserves_all_attrs(self):
+        """dill round-trip must preserve ALL attrs including work_dir,
+        since __getstate__ is no longer overridden."""
         op = self._make_op(
             work_dir='/tmp/run_x',
             num_proc=16,
@@ -75,10 +79,10 @@ class FingerprintCacheStabilityTest(DataJuicerTestCaseBase):
         self.assertEqual(restored.min_len, 10)
         self.assertEqual(restored.max_len, 100)
 
-        # Excluded attributes get safe defaults, not original values
-        self.assertIsNone(restored.work_dir)
-        self.assertIsNone(restored.num_proc)
-        self.assertFalse(restored.skip_op_error)
+        # Execution attrs also preserved (important for worker pickling)
+        self.assertEqual(restored.work_dir, '/tmp/run_x')
+        self.assertEqual(restored.num_proc, 16)
+        self.assertTrue(restored.skip_op_error)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
add a _fingerprint_bytes() method to the OP base class that excludes work_dir, _init_args/_init_kwargs, and bound methods from the fingerprint state. Enhance Hasher.hash_default() to use this method when available, including for bound methods passed to generate_fingerprint

Closes #964