### PR TITLE
fix: unify schema across batches in JSONStreamDatasource to handle null → concrete type evolution

### DIFF
--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -427,62 +427,58 @@ class JSONStreamDatasource(_JSONDatasourceBase):
                 raise ValueError(f"Failed to read JSON file: {path}. Error: {e}") from e
             return
 
-        reader = open_json(
-            f,
-            read_options=self.read_options,
-            **self.arrow_json_args,
-        )
-        schema = None
-        buffered_batches = []
-        while True:
-            try:
-                batch = reader.read_next_batch()
-            except pyarrow.lib.ArrowInvalid:
-                yield from self._read_stream_with_schema_unify(path)
-                return
-            except StopIteration:
-                for b in buffered_batches:
-                    yield pyarrow.Table.from_batches([b])
-                return
+        import pyarrow.json as paj
 
-            if schema is None:
-                schema = batch.schema
-                buffered_batches.append(batch)
-            elif schema.equals(batch.schema):
-                buffered_batches.append(batch)
-            else:
-                try:
-                    unified = pyarrow.unify_schemas([schema, batch.schema])
-                except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError):
-                    yield from self._read_stream_with_schema_unify(path)
-                    return
-                try:
-                    casted = pyarrow.RecordBatch.from_arrays(batch.columns(), schema=batch.schema)
-                    casted = casted.cast(unified)
-                    buffered_batches = [b.cast(unified) for b in buffered_batches]
-                    schema = unified
-                    buffered_batches.append(casted)
-                except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError):
-                    yield from self._read_stream_with_schema_unify(path)
-                    return
-
-    def _read_stream_with_schema_unify(self, path: str):
-        import json as json_mod
-
-        fs = getattr(self, "_filesystem", None)
-        if fs is None:
-            fs = pyarrow.fs.LocalFileSystem()
+        def _full_file_fallback():
+            """Re-read the entire file with paj.read_json which handles
+            schema inference across all rows in a single pass."""
+            fs = getattr(self, "_filesystem", None)
+            if fs is not None:
+                with fs.open_input_file(path) as f2:
+                    return paj.read_json(
+                        f2,
+                        read_options=self.read_options,
+                        **self.arrow_json_args,
+                    )
+            return paj.read_json(
+                path,
+                read_options=self.read_options,
+                **self.arrow_json_args,
+            )
 
         try:
-            with fs.open_input_stream(path) as f:
-                content = f.read()
-            if isinstance(content, bytes):
-                content = content.decode("utf-8")
-            rows = [json_mod.loads(line) for line in content.strip().split("\n") if line.strip()]
-            if rows:
-                yield pyarrow.Table.from_pylist(rows)
-        except Exception as e:
-            raise ValueError(f"Failed to read JSON file: {path}. Error: {e}") from e
+            reader = open_json(
+                f,
+                read_options=self.read_options,
+                **self.arrow_json_args,
+            )
+            schema = None
+            batches = []
+            schema_evolved = False
+            while True:
+                try:
+                    batch = reader.read_next_batch()
+                except StopIteration:
+                    break
+                batches.append(batch)
+                if schema is None:
+                    schema = batch.schema
+                elif not schema.equals(batch.schema):
+                    schema = pyarrow.unify_schemas([schema, batch.schema])
+                    schema_evolved = True
+            # Yield all batches with consistent schema.
+            # Use .cast() when schema evolved (from_batches does NOT cast).
+            if schema_evolved:
+                for batch in batches:
+                    yield pyarrow.Table.from_batches([batch]).cast(schema)
+            else:
+                for batch in batches:
+                    yield pyarrow.Table.from_batches([batch])
+        except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError):
+            # PyArrow's streaming reader cannot handle schema evolution
+            # across block boundaries (e.g. null -> string). Fall back to
+            # paj.read_json() which infers schema across the entire file.
+            yield _full_file_fallback()
 
 
 def read_json_stream(

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -400,6 +400,12 @@ if _JSONDatasourceBase is None:
     )
 
 
+class _SchemaEvolutionDetected(Exception):
+    """Internal exception to trigger fallback to buffered schema unification."""
+
+    pass
+
+
 class JSONStreamDatasource(_JSONDatasourceBase):
     """
     A temp Datasource for reading json stream.
@@ -434,34 +440,58 @@ class JSONStreamDatasource(_JSONDatasourceBase):
                 **self.arrow_json_args,
             )
             schema = None
-            batches = []
             while True:
                 try:
                     batch = reader.read_next_batch()
-                    batches.append(batch)
                     if schema is None:
                         schema = batch.schema
-                    elif not schema.equals(batch.schema):
-                        try:
-                            schema = pyarrow.unify_schemas([schema, batch.schema])
-                        except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError) as e:
-                            raise ValueError(
-                                f"Schema incompatibility in {path}: {e}. " f"Cannot unify {schema} with {batch.schema}"
-                            ) from e
+                        yield pyarrow.Table.from_batches([batch])
+                    elif schema.equals(batch.schema):
+                        yield pyarrow.Table.from_batches([batch])
+                    else:
+                        raise _SchemaEvolutionDetected()
                 except StopIteration:
-                    break
-            for batch in batches:
-                yield pyarrow.Table.from_batches([batch], schema=schema)
-        except pyarrow.lib.ArrowInvalid as e:
-            if "changed from" in str(e):
-                import pyarrow.json as paj
+                    return
+        except (pyarrow.lib.ArrowInvalid, _SchemaEvolutionDetected):
+            yield from self._read_stream_with_schema_unify(path)
 
-                yield paj.read_json(
-                    path,
+    def _read_stream_with_schema_unify(self, path: str):
+        """Fallback: buffer all batches and unify schemas for schema evolution cases."""
+        import pyarrow.json as paj
+
+        fs = getattr(self, "_filesystem", None)
+        if fs is None:
+            fs = pyarrow.fs.LocalFileSystem()
+
+        try:
+            with fs.open_input_stream(path) as f:
+                reader = paj.open_json(
+                    f,
                     read_options=self.read_options,
                     **self.arrow_json_args,
                 )
-                return
+                schema = None
+                batches = []
+                while True:
+                    try:
+                        batch = reader.read_next_batch()
+                        batches.append(batch)
+                        if schema is None:
+                            schema = batch.schema
+                        elif not schema.equals(batch.schema):
+                            try:
+                                schema = pyarrow.unify_schemas([schema, batch.schema])
+                            except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError) as e:
+                                raise ValueError(
+                                    f"Schema incompatibility in {path}: {e}. "
+                                    f"Cannot unify {schema} with {batch.schema}"
+                                ) from e
+                    except StopIteration:
+                        break
+
+                for batch in batches:
+                    yield pyarrow.Table.from_batches([batch]).cast(schema)
+        except pyarrow.lib.ArrowInvalid as e:
             raise ValueError(f"Failed to read JSON file: {path}. Underlying PyArrow Error: {e}") from e
 
 

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -400,12 +400,6 @@ if _JSONDatasourceBase is None:
     )
 
 
-class _SchemaEvolutionDetected(Exception):
-    """Internal exception to trigger fallback to buffered schema unification."""
-
-    pass
-
-
 class JSONStreamDatasource(_JSONDatasourceBase):
     """
     A temp Datasource for reading json stream.
@@ -433,27 +427,40 @@ class JSONStreamDatasource(_JSONDatasourceBase):
                 raise ValueError(f"Failed to read JSON file: {path}. Error: {e}") from e
             return
 
-        try:
-            reader = open_json(
-                f,
-                read_options=self.read_options,
-                **self.arrow_json_args,
-            )
-            schema = None
-            while True:
+        reader = open_json(
+            f,
+            read_options=self.read_options,
+            **self.arrow_json_args,
+        )
+        schema = None
+        buffered_batches = []
+        while True:
+            try:
+                batch = reader.read_next_batch()
+            except pyarrow.lib.ArrowInvalid:
+                yield from self._read_stream_with_schema_unify(path)
+                return
+            except StopIteration:
+                for b in buffered_batches:
+                    yield pyarrow.Table.from_batches([b])
+                return
+
+            if schema is None:
+                schema = batch.schema
+                buffered_batches.append(batch)
+            elif schema.equals(batch.schema):
+                buffered_batches.append(batch)
+            else:
                 try:
-                    batch = reader.read_next_batch()
-                    if schema is None:
-                        schema = batch.schema
-                        yield pyarrow.Table.from_batches([batch])
-                    elif schema.equals(batch.schema):
-                        yield pyarrow.Table.from_batches([batch])
-                    else:
-                        raise _SchemaEvolutionDetected()
-                except StopIteration:
+                    unified = pyarrow.unify_schemas([schema, batch.schema])
+                except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError):
+                    yield from self._read_stream_with_schema_unify(path)
                     return
-        except (pyarrow.lib.ArrowInvalid, _SchemaEvolutionDetected):
-            yield from self._read_stream_with_schema_unify(path)
+                if unified.equals(schema):
+                    buffered_batches.append(pyarrow.RecordBatch.from_arrays(batch.columns(), schema=schema))
+                else:
+                    yield from self._read_stream_with_schema_unify(path)
+                    return
 
     def _read_stream_with_schema_unify(self, path: str):
         """Fallback: buffer all batches and unify schemas for schema evolution cases."""

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -434,9 +434,11 @@ class JSONStreamDatasource(_JSONDatasourceBase):
                 **self.arrow_json_args,
             )
             schema = None
+            batches = []
             while True:
                 try:
                     batch = reader.read_next_batch()
+                    batches.append(batch)
                     if schema is None:
                         schema = batch.schema
                     elif not schema.equals(batch.schema):
@@ -446,11 +448,20 @@ class JSONStreamDatasource(_JSONDatasourceBase):
                             raise ValueError(
                                 f"Schema incompatibility in {path}: {e}. " f"Cannot unify {schema} with {batch.schema}"
                             ) from e
-                    table = pyarrow.Table.from_batches([batch], schema=schema)
-                    yield table
                 except StopIteration:
-                    return
+                    break
+            for batch in batches:
+                yield pyarrow.Table.from_batches([batch], schema=schema)
         except pyarrow.lib.ArrowInvalid as e:
+            if "changed from" in str(e):
+                import pyarrow.json as paj
+
+                yield paj.read_json(
+                    path,
+                    read_options=self.read_options,
+                    **self.arrow_json_args,
+                )
+                return
             raise ValueError(f"Failed to read JSON file: {path}. Underlying PyArrow Error: {e}") from e
 
 

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -444,8 +444,7 @@ class JSONStreamDatasource(_JSONDatasourceBase):
                             schema = pyarrow.unify_schemas([schema, batch.schema])
                         except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError) as e:
                             raise ValueError(
-                                f"Schema incompatibility in {path}: {e}. "
-                                f"Cannot unify {schema} with {batch.schema}"
+                                f"Schema incompatibility in {path}: {e}. " f"Cannot unify {schema} with {batch.schema}"
                             ) from e
                     table = pyarrow.Table.from_batches([batch], schema=schema)
                     yield table

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -439,17 +439,15 @@ class JSONStreamDatasource(_JSONDatasourceBase):
                     batch = reader.read_next_batch()
                     if schema is None:
                         schema = batch.schema
-                        table = pyarrow.Table.from_batches([batch])
-                    elif schema.equals(batch.schema):
-                        table = pyarrow.Table.from_batches([batch], schema=schema)
-                    else:
+                    elif not schema.equals(batch.schema):
                         try:
                             schema = pyarrow.unify_schemas([schema, batch.schema])
                         except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError) as e:
                             raise ValueError(
-                                f"Schema incompatibility in {path}: {e}. " f"Cannot unify {schema} with {batch.schema}"
+                                f"Schema incompatibility in {path}: {e}. "
+                                f"Cannot unify {schema} with {batch.schema}"
                             ) from e
-                        table = pyarrow.Table.from_batches([batch], schema=schema)
+                    table = pyarrow.Table.from_batches([batch], schema=schema)
                     yield table
                 except StopIteration:
                     return

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -491,7 +491,7 @@ class JSONStreamDatasource(_JSONDatasourceBase):
 
                 for batch in batches:
                     yield pyarrow.Table.from_batches([batch]).cast(schema)
-        except pyarrow.lib.ArrowInvalid as e:
+        except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError) as e:
             raise ValueError(f"Failed to read JSON file: {path}. Underlying PyArrow Error: {e}") from e
 
 

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -437,9 +437,27 @@ class JSONStreamDatasource(_JSONDatasourceBase):
             while True:
                 try:
                     batch = reader.read_next_batch()
-                    table = pyarrow.Table.from_batches([batch], schema=schema)
                     if schema is None:
-                        schema = table.schema
+                        schema = batch.schema
+                        table = pyarrow.Table.from_batches([batch])
+                    elif schema.equals(batch.schema):
+                        table = pyarrow.Table.from_batches(
+                            [batch], schema=schema
+                        )
+                    else:
+                        try:
+                            schema = pyarrow.unify_schemas(
+                                [schema, batch.schema]
+                            )
+                        except (pyarrow.lib.ArrowInvalid,
+                                pyarrow.lib.ArrowTypeError) as e:
+                            raise ValueError(
+                                f"Schema incompatibility in {path}: {e}. "
+                                f"Cannot unify {schema} with {batch.schema}"
+                            ) from e
+                        table = pyarrow.Table.from_batches(
+                            [batch], schema=schema
+                        )
                     yield table
                 except StopIteration:
                     return

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -441,23 +441,15 @@ class JSONStreamDatasource(_JSONDatasourceBase):
                         schema = batch.schema
                         table = pyarrow.Table.from_batches([batch])
                     elif schema.equals(batch.schema):
-                        table = pyarrow.Table.from_batches(
-                            [batch], schema=schema
-                        )
+                        table = pyarrow.Table.from_batches([batch], schema=schema)
                     else:
                         try:
-                            schema = pyarrow.unify_schemas(
-                                [schema, batch.schema]
-                            )
-                        except (pyarrow.lib.ArrowInvalid,
-                                pyarrow.lib.ArrowTypeError) as e:
+                            schema = pyarrow.unify_schemas([schema, batch.schema])
+                        except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError) as e:
                             raise ValueError(
-                                f"Schema incompatibility in {path}: {e}. "
-                                f"Cannot unify {schema} with {batch.schema}"
+                                f"Schema incompatibility in {path}: {e}. " f"Cannot unify {schema} with {batch.schema}"
                             ) from e
-                        table = pyarrow.Table.from_batches(
-                            [batch], schema=schema
-                        )
+                        table = pyarrow.Table.from_batches([batch], schema=schema)
                     yield table
                 except StopIteration:
                     return

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -456,15 +456,18 @@ class JSONStreamDatasource(_JSONDatasourceBase):
                 except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError):
                     yield from self._read_stream_with_schema_unify(path)
                     return
-                if unified.equals(schema):
-                    buffered_batches.append(pyarrow.RecordBatch.from_arrays(batch.columns(), schema=schema))
-                else:
+                try:
+                    casted = pyarrow.RecordBatch.from_arrays(batch.columns(), schema=batch.schema)
+                    casted = casted.cast(unified)
+                    buffered_batches = [b.cast(unified) for b in buffered_batches]
+                    schema = unified
+                    buffered_batches.append(casted)
+                except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError):
                     yield from self._read_stream_with_schema_unify(path)
                     return
 
     def _read_stream_with_schema_unify(self, path: str):
-        """Fallback: buffer all batches and unify schemas for schema evolution cases."""
-        import pyarrow.json as paj
+        import json as json_mod
 
         fs = getattr(self, "_filesystem", None)
         if fs is None:
@@ -472,34 +475,14 @@ class JSONStreamDatasource(_JSONDatasourceBase):
 
         try:
             with fs.open_input_stream(path) as f:
-                reader = paj.open_json(
-                    f,
-                    read_options=self.read_options,
-                    **self.arrow_json_args,
-                )
-                schema = None
-                batches = []
-                while True:
-                    try:
-                        batch = reader.read_next_batch()
-                        batches.append(batch)
-                        if schema is None:
-                            schema = batch.schema
-                        elif not schema.equals(batch.schema):
-                            try:
-                                schema = pyarrow.unify_schemas([schema, batch.schema])
-                            except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError) as e:
-                                raise ValueError(
-                                    f"Schema incompatibility in {path}: {e}. "
-                                    f"Cannot unify {schema} with {batch.schema}"
-                                ) from e
-                    except StopIteration:
-                        break
-
-                for batch in batches:
-                    yield pyarrow.Table.from_batches([batch]).cast(schema)
-        except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowTypeError) as e:
-            raise ValueError(f"Failed to read JSON file: {path}. Underlying PyArrow Error: {e}") from e
+                content = f.read()
+            if isinstance(content, bytes):
+                content = content.decode("utf-8")
+            rows = [json_mod.loads(line) for line in content.strip().split("\n") if line.strip()]
+            if rows:
+                yield pyarrow.Table.from_pylist(rows)
+        except Exception as e:
+            raise ValueError(f"Failed to read JSON file: {path}. Error: {e}") from e
 
 
 def read_json_stream(

--- a/tests/core/data/test_ray_dataset.py
+++ b/tests/core/data/test_ray_dataset.py
@@ -143,6 +143,28 @@ class RayDatasetFuncsTest(DataJuicerTestCaseBase):
         dataset = read_json_stream(jsonl_path, read_options=read_options)
         self.assertEqual(len(dataset.take(3)[2]["text"]), len(_text))
 
+    @TEST_TAG("ray")
+    def test_read_json_stream_schema_evolution(self):
+        """Regression test for #936: null -> concrete type schema evolution."""
+        from data_juicer.core.data.ray_dataset import read_json_stream
+        import pyarrow.json as js
+
+        jsonl_path = os.path.join(self.tmp_dir, "schema_evolution.jsonl")
+        rows = [{"id": i, "meta": {"url": None}} for i in range(30)]
+        rows.append({"id": 999, "meta": {"url": "https://example.com"}})
+        with open(jsonl_path, "w") as f:
+            for row in rows:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+        read_options = js.ReadOptions(use_threads=False, block_size=256)
+        dataset = read_json_stream(
+            jsonl_path, override_num_blocks=1, read_options=read_options
+        )
+        result = dataset.take_all()
+        self.assertEqual(len(result), 31)
+        self.assertEqual(result[-1]["id"], 999)
+        self.assertEqual(result[-1]["meta"]["url"], "https://example.com")
+
 
 class TestRayDataset(DataJuicerTestCaseBase):
     def setUp(self):
@@ -303,27 +325,5 @@ class TestRayDataset(DataJuicerTestCaseBase):
         self.assertIsInstance(row["score"], int)
 
 
-  
-      @TEST_TAG("ray")
-      def test_read_json_stream_schema_evolution(self):
-          """Regression test for #936: null -> concrete type schema evolution."""
-          from data_juicer.core.data.ray_dataset import read_json_stream
-          import pyarrow.json as js
-  
-          jsonl_path = os.path.join(self.tmp_dir, "schema_evolution.jsonl")
-          rows = [{"id": i, "meta": {"url": None}} for i in range(30)]
-          rows.append({"id": 999, "meta": {"url": "https://example.com"}})
-          with open(jsonl_path, "w") as f:
-              for row in rows:
-                  f.write(json.dumps(row, ensure_ascii=False) + "\n")
-  
-          read_options = js.ReadOptions(use_threads=False, block_size=256)
-          dataset = read_json_stream(
-              jsonl_path, override_num_blocks=1, read_options=read_options
-          )
-          result = dataset.take_all()
-          self.assertEqual(len(result), 31)
-          self.assertEqual(result[-1]["id"], 999)
-          self.assertEqual(result[-1]["meta"]["url"], "https://example.com")
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/data/test_ray_dataset.py
+++ b/tests/core/data/test_ray_dataset.py
@@ -303,5 +303,27 @@ class TestRayDataset(DataJuicerTestCaseBase):
         self.assertIsInstance(row["score"], int)
 
 
+  
+      @TEST_TAG("ray")
+      def test_read_json_stream_schema_evolution(self):
+          """Regression test for #936: null -> concrete type schema evolution."""
+          from data_juicer.core.data.ray_dataset import read_json_stream
+          import pyarrow.json as js
+  
+          jsonl_path = os.path.join(self.tmp_dir, "schema_evolution.jsonl")
+          rows = [{"id": i, "meta": {"url": None}} for i in range(30)]
+          rows.append({"id": 999, "meta": {"url": "https://example.com"}})
+          with open(jsonl_path, "w") as f:
+              for row in rows:
+                  f.write(json.dumps(row, ensure_ascii=False) + "\n")
+  
+          read_options = js.ReadOptions(use_threads=False, block_size=256)
+          dataset = read_json_stream(
+              jsonl_path, override_num_blocks=1, read_options=read_options
+          )
+          result = dataset.take_all()
+          self.assertEqual(len(result), 31)
+          self.assertEqual(result[-1]["id"], 999)
+          self.assertEqual(result[-1]["meta"]["url"], "https://example.com")
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/data/test_ray_dataset.py
+++ b/tests/core/data/test_ray_dataset.py
@@ -194,6 +194,25 @@ class RayDatasetFuncsTest(DataJuicerTestCaseBase):
         self.assertEqual(result[-1]["id"], 999)
         self.assertEqual(result[-1]["meta"]["url"], "https://example.com")
 
+    @TEST_TAG("ray")
+    def test_read_json_stream_stable_schema_no_fallback(self):
+        """Verify stable-schema files stream without buffering (no fallback)."""
+        from data_juicer.core.data.ray_dataset import read_json_stream
+        import pyarrow.json as js
+
+        jsonl_path = os.path.join(self.tmp_dir, "stable_schema.jsonl")
+        rows = [{"id": i, "meta": {"url": f"https://example.com/{i}"}} for i in range(100)]
+        with open(jsonl_path, "w") as f:
+            for row in rows:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+        read_options = js.ReadOptions(use_threads=False, block_size=256)
+        dataset = read_json_stream(jsonl_path, override_num_blocks=1, read_options=read_options)
+        result = dataset.take_all()
+        self.assertEqual(len(result), 100)
+        self.assertEqual(result[0]["id"], 0)
+        self.assertEqual(result[99]["meta"]["url"], "https://example.com/99")
+
 
 class TestRayDataset(DataJuicerTestCaseBase):
     def setUp(self):

--- a/tests/core/data/test_ray_dataset.py
+++ b/tests/core/data/test_ray_dataset.py
@@ -39,7 +39,9 @@ class RayDatasetFuncsTest(DataJuicerTestCaseBase):
     def tearDown(self) -> None:
         super().tearDown()
         if os.path.exists(self.tmp_dir):
-            import shutil; shutil.rmtree(self.tmp_dir)
+            import shutil
+
+            shutil.rmtree(self.tmp_dir)
 
     def _touch_a_file(self, path):
         """Create a file at the given path"""
@@ -157,8 +159,35 @@ class RayDatasetFuncsTest(DataJuicerTestCaseBase):
                 f.write(json.dumps(row, ensure_ascii=False) + "\n")
 
         read_options = js.ReadOptions(use_threads=False, block_size=256)
+        dataset = read_json_stream(jsonl_path, override_num_blocks=1, read_options=read_options)
+        result = dataset.take_all()
+        self.assertEqual(len(result), 31)
+        self.assertEqual(result[-1]["id"], 999)
+        self.assertEqual(result[-1]["meta"]["url"], "https://example.com")
+
+    @TEST_TAG("ray")
+    def test_read_json_stream_schema_evolution_with_filesystem(self):
+        """Regression test: schema evolution fallback works with filesystem abstraction."""
+        from data_juicer.core.data.ray_dataset import read_json_stream
+        import pyarrow.json as js
+        import pyarrow.fs as pafs
+
+        jsonl_path = os.path.join(self.tmp_dir, "schema_evolution_fs.jsonl")
+        rows = [{"id": i, "meta": {"url": None}} for i in range(30)]
+        rows.append({"id": 999, "meta": {"url": "https://example.com"}})
+        with open(jsonl_path, "w") as f:
+            for row in rows:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+        fs = pafs.SubTreeFileSystem(self.tmp_dir, pafs.LocalFileSystem())
+        relative_path = "schema_evolution_fs.jsonl"
+
+        read_options = js.ReadOptions(use_threads=False, block_size=256)
         dataset = read_json_stream(
-            jsonl_path, override_num_blocks=1, read_options=read_options
+            relative_path,
+            filesystem=fs,
+            override_num_blocks=1,
+            read_options=read_options,
         )
         result = dataset.take_all()
         self.assertEqual(len(result), 31)


### PR DESCRIPTION
## Summary

  Fixes #936

  `JSONStreamDatasource._read_stream` locks the schema from the first batch and reuses it for all subsequent batches. When an
  early batch infers a nested field as `null` (e.g. `meta.url = null`) and a later batch introduces a concrete type (e.g.
  `string`), the forced cast from `string` to `null` fails with `ArrowInvalid`.

  This is a **correctness bug** in DJ's custom JSON streaming ingestion path. Ray's native `ray.data.read_json` handles the same input correctly.

  ## Root Cause

  ```python
  # Before: first batch locks schema, all subsequent batches forced to it
  table = pyarrow.Table.from_batches([batch], schema=schema)
  if schema is None:
      schema = table.schema  # locked forever
```
  Fix

  1. Remove the first-batch schema lock — create table without forced schema
  2. Use pyarrow.unify_schemas to merge schemas across batches, allowing null → concrete type promotion
  3. After unification, cast the batch to the unified schema for consistency

```python
  # After: schema evolves across batches
  table = pyarrow.Table.from_batches([batch])
  if schema is None:
      schema = table.schema
  else:
      unified = pyarrow.unify_schemas([schema, table.schema])
      if not unified.equals(schema):
          schema = unified
      table = pyarrow.Table.from_batches([batch], schema=schema)
```

  unify_schemas internally delegates to Arrow C++ UnifyTypes, which promotes null to the concrete type and recursively handles nested structs.

  Test Plan

  - Verify the minimal repro from #936 passes with this fix
  - Verify ray.data.read_json and read_json_stream produce consistent results on mixed-null JSONL
  - Verify no regression on JSONL files with uniform schema
  - Verify no regression on JSONL files with nested structs

  See #936 for the minimal reproduction script.