### PR TITLE
Update num_proc handling for vllm and Ray mode

### DIFF
--- a/data_juicer/ops/mapper/text_tagging_by_prompt_mapper.py
+++ b/data_juicer/ops/mapper/text_tagging_by_prompt_mapper.py
@@ -114,7 +114,11 @@ class TextTaggingByPromptMapper(Mapper):
         """  # noqa
 
         super().__init__(*args, **kwargs)
-        self.num_proc = 1
+        if not enable_vllm or not is_ray_mode():
+            # In Ray mode with vllm, num_proc is left to the caller so Ray can
+            # schedule one actor per GPU for data parallelism.
+            self.num_proc = 1
+            
 
         self.prompt = prompt
         self.tag_list = tag_list
@@ -129,9 +133,6 @@ class TextTaggingByPromptMapper(Mapper):
         sampling_params = update_sampling_params(sampling_params, hf_model, self.enable_vllm)
 
         if enable_vllm:
-            if not is_ray_mode():
-                # cannot initialize vllm replicas on different GPUs
-                self.num_proc = 1
             self.model_key = prepare_model(
                 model_type="vllm",
                 pretrained_model_name_or_path=hf_model,

--- a/data_juicer/ops/mapper/text_tagging_by_prompt_mapper.py
+++ b/data_juicer/ops/mapper/text_tagging_by_prompt_mapper.py
@@ -114,11 +114,6 @@ class TextTaggingByPromptMapper(Mapper):
         """  # noqa
 
         super().__init__(*args, **kwargs)
-        if not enable_vllm or not is_ray_mode():
-            # In Ray mode with vllm, num_proc is left to the caller so Ray can
-            # schedule one actor per GPU for data parallelism.
-            self.num_proc = 1
-            
 
         self.prompt = prompt
         self.tag_list = tag_list
@@ -133,6 +128,9 @@ class TextTaggingByPromptMapper(Mapper):
         sampling_params = update_sampling_params(sampling_params, hf_model, self.enable_vllm)
 
         if enable_vllm:
+            if not is_ray_mode():
+                # cannot initialize vllm replicas on different GPUs
+                self.num_proc = 1
             self.model_key = prepare_model(
                 model_type="vllm",
                 pretrained_model_name_or_path=hf_model,


### PR DESCRIPTION
### Summary                                                                                                                                                                                                                                       
   
  `TextTaggingByPromptMapper` was unconditionally setting `self.num_proc = 1`, which in a                                                                                                                                                           
  Ray+vLLM run capped the actor pool to a single GPU. The only available multi-GPU strategy
  was tensor parallelism (`tensor_parallel_size=N`); data parallelism was silently broken.                                                                                                                                                          
                                                                                                                                                                                                                                                    
  This fix makes `num_proc = 1` conditional on the execution backend, so Ray can now schedule                                                                                                                                                       
  one vLLM actor per GPU — enabling both data parallelism, tensor parallelism, or a                                                                                                                                                                 
  combination of both.   