### PR TITLE
fix(core): replace exit(1) with raise in dataset processing for library-safe error handling

### DIFF
--- a/data_juicer/core/data/dj_dataset.py
+++ b/data_juicer/core/data/dj_dataset.py
@@ -320,7 +320,7 @@ class NestedDataset(Dataset, DJDataset):
         except:  # noqa: E722
             logger.error(f"An error occurred during Op [{op._name}].")
             traceback.print_exc()
-            exit(1)
+            raise
         finally:
             if checkpointer and dataset is not self:
                 logger.info("Writing checkpoint of dataset processed by " "last op...")

--- a/data_juicer/core/data/dj_dataset.py
+++ b/data_juicer/core/data/dj_dataset.py
@@ -318,8 +318,7 @@ class NestedDataset(Dataset, DJDataset):
                     )
                     adapter.analyze_small_batch(dataset, f"{idx}_{op._name}")
         except:  # noqa: E722
-            logger.error(f"An error occurred during Op [{op._name}].")
-            traceback.print_exc()
+            logger.exception(f"An error occurred during Op [{op._name}].")
             raise
         finally:
             if checkpointer and dataset is not self:

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -346,7 +346,7 @@ class RayDataset(DJDataset):
             import traceback
 
             traceback.print_exc()
-            exit(1)
+            raise
 
         return cached_columns
 

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -342,10 +342,7 @@ class RayDataset(DJDataset):
                 logger.error("Ray executor only support Filter, Mapper, Deduplicator and Pipeline OPs for now")
                 raise NotImplementedError
         except:  # noqa: E722
-            logger.error(f"An error occurred during Op [{op._name}].")
-            import traceback
-
-            traceback.print_exc()
+            logger.exception(f"An error occurred during Op [{op._name}].")
             raise
 
         return cached_columns

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -174,8 +174,6 @@ class RayDataset(DJDataset):
             row_count = 0
 
         if row_count == 0:
-            from loguru import logger
-
             logger.warning("Dataset is empty (0 rows), skipping operator processing")
             return self
 
@@ -184,8 +182,6 @@ class RayDataset(DJDataset):
         columns_result = self.data.columns()
         # Handle empty dataset case where columns() returns None
         if columns_result is None:
-            from loguru import logger
-
             logger.warning("Dataset has unknown schema (likely empty), skipping operator processing")
             return self
         cached_columns = set(columns_result)

--- a/tests/core/data/test_dataset_error_propagation.py
+++ b/tests/core/data/test_dataset_error_propagation.py
@@ -85,7 +85,8 @@ class TestRayDatasetErrorPropagation(DataJuicerTestCaseBase):
         import ray
         from data_juicer.core.data.ray_dataset import RayDataset
 
-        dataset = RayDataset(ray.data.from_items([{'text': 'hello'}]))
+        dataset = RayDataset(ray.data.from_items([{'text': 'hello'}]),
+                             auto_op_parallelism=False)
         op = self._make_failing_op(
             error=RuntimeError('env setup failed'),
             runtime_env={'pip': ['nonexistent-pkg']},
@@ -109,7 +110,8 @@ class TestRayDatasetErrorPropagation(DataJuicerTestCaseBase):
         import ray
         from data_juicer.core.data.ray_dataset import RayDataset
 
-        dataset = RayDataset(ray.data.from_items([{'text': 'hello'}]))
+        dataset = RayDataset(ray.data.from_items([{'text': 'hello'}]),
+                             auto_op_parallelism=False)
         op = self._make_failing_op(
             error=ValueError('processing error'),
             runtime_env=None,

--- a/tests/core/data/test_dataset_error_propagation.py
+++ b/tests/core/data/test_dataset_error_propagation.py
@@ -3,7 +3,11 @@ from unittest.mock import MagicMock, patch
 from datasets import Dataset
 
 from data_juicer.core.data import NestedDataset
-from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
+from data_juicer.ops import Deduplicator
+from data_juicer.utils.unittest_utils import (
+    TEST_TAG,
+    DataJuicerTestCaseBase,
+)
 
 
 class TestDjDatasetErrorPropagation(DataJuicerTestCaseBase):
@@ -43,6 +47,77 @@ class TestDjDatasetErrorPropagation(DataJuicerTestCaseBase):
             with self.assertRaises(ValueError):
                 self.dataset.process([failing_op])
             mock_exit.assert_not_called()
+
+
+class TestRayDatasetErrorPropagation(DataJuicerTestCaseBase):
+    """Test that RayDataset._run_single_op() propagates exceptions and
+    that the runtime_env fallback in process() works correctly."""
+
+    def setUp(self):
+        super().setUp()
+
+    def _make_failing_op(self, error=None, runtime_env=None):
+        """Create a mock operator that passes isinstance(op, Deduplicator)
+        and raises on run()."""
+        op = MagicMock(spec=Deduplicator)
+        op._name = 'test_failing_dedup'
+        op.runtime_env = runtime_env
+        op.run.side_effect = error or RuntimeError('dedup failed')
+        return op
+
+    @TEST_TAG('ray')
+    def test_run_single_op_propagates_exception(self):
+        """_run_single_op should propagate exceptions instead of exit(1)."""
+        import ray
+        from data_juicer.core.data.ray_dataset import RayDataset
+
+        dataset = RayDataset(ray.data.from_items([{'text': 'hello'}]))
+        op = self._make_failing_op()
+
+        with self.assertRaises(RuntimeError) as ctx:
+            dataset._run_single_op(op)
+        self.assertIn('dedup failed', str(ctx.exception))
+
+    @TEST_TAG('ray')
+    def test_process_fallback_on_runtime_env_failure(self):
+        """When an op with runtime_env fails, process() should retry
+        without runtime_env (fallback logic at lines 194-207)."""
+        import ray
+        from data_juicer.core.data.ray_dataset import RayDataset
+
+        dataset = RayDataset(ray.data.from_items([{'text': 'hello'}]))
+        op = self._make_failing_op(
+            error=RuntimeError('env setup failed'),
+            runtime_env={'pip': ['nonexistent-pkg']},
+        )
+        # Make the retry (with runtime_env=None) succeed
+        op.run.side_effect = [
+            RuntimeError('env setup failed'),  # first call fails
+            ray.data.from_items([{'text': 'hello'}]),  # retry succeeds
+        ]
+
+        # Should not raise because the fallback succeeds
+        result = dataset.process([op])
+        self.assertIsNotNone(result)
+        # Verify runtime_env was restored after fallback
+        self.assertEqual(op.runtime_env, {'pip': ['nonexistent-pkg']})
+
+    @TEST_TAG('ray')
+    def test_process_raises_when_no_runtime_env_fallback(self):
+        """When an op without runtime_env fails, process() should
+        propagate the exception (no fallback available)."""
+        import ray
+        from data_juicer.core.data.ray_dataset import RayDataset
+
+        dataset = RayDataset(ray.data.from_items([{'text': 'hello'}]))
+        op = self._make_failing_op(
+            error=ValueError('processing error'),
+            runtime_env=None,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            dataset.process([op])
+        self.assertIn('processing error', str(ctx.exception))
 
 
 if __name__ == '__main__':

--- a/tests/core/data/test_dataset_error_propagation.py
+++ b/tests/core/data/test_dataset_error_propagation.py
@@ -62,6 +62,9 @@ class TestRayDatasetErrorPropagation(DataJuicerTestCaseBase):
         op = MagicMock(spec=Deduplicator)
         op._name = 'test_failing_dedup'
         op.runtime_env = runtime_env
+        op.num_cpus = None
+        op.num_gpus = None
+        op.memory = None
         op.run.side_effect = error or RuntimeError('dedup failed')
         return op
 

--- a/tests/core/data/test_dataset_error_propagation.py
+++ b/tests/core/data/test_dataset_error_propagation.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from datasets import Dataset
+
+from data_juicer.core.data import NestedDataset
+from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
+
+
+class TestDjDatasetErrorPropagation(DataJuicerTestCaseBase):
+    """Test that NestedDataset.process() propagates exceptions instead of
+    calling exit(1), making it safe for library usage."""
+
+    def setUp(self):
+        super().setUp()
+        self.data = [
+            {'text': 'Hello', 'score': 1},
+            {'text': 'World', 'score': 2},
+        ]
+        self.dataset = NestedDataset(Dataset.from_list(self.data))
+
+    def test_process_raises_on_op_error(self):
+        """When an operator raises an exception during process(),
+        it should propagate as an exception rather than calling exit(1)."""
+        failing_op = MagicMock()
+        failing_op._name = 'test_failing_op'
+        failing_op._op_cfg = {}
+        failing_op.use_cuda.return_value = False
+        failing_op.run.side_effect = RuntimeError('op failed')
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.dataset.process([failing_op])
+        self.assertIn('op failed', str(ctx.exception))
+
+    def test_process_does_not_call_exit(self):
+        """Verify exit() is never called during error handling."""
+        failing_op = MagicMock()
+        failing_op._name = 'test_failing_op'
+        failing_op._op_cfg = {}
+        failing_op.use_cuda.return_value = False
+        failing_op.run.side_effect = ValueError('bad value')
+
+        with patch('builtins.exit') as mock_exit:
+            with self.assertRaises(ValueError):
+                self.dataset.process([failing_op])
+            mock_exit.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Two locations in dataset processing call `exit(1)` inside bare `except:` blocks instead of re-raising the caught exception. This terminates the Python process whenever an operator fails, which makes data-juicer unsafe to use as a library and silently disables existing fallback logic in the Ray path.

This PR replaces `exit(1)` with `raise` in both locations so exceptions propagate to callers as expected.

## Motivation

**`data_juicer/core/data/dj_dataset.py:323`** — `NestedDataset.process()` catches any exception raised by an operator, logs it, then calls `exit(1)`. Any application embedding data-juicer (notebooks, services, larger pipelines) is killed outright on a single op failure, with no chance to recover or report the error upstream.

**`data_juicer/core/data/ray_dataset.py:349`** — `RayDataset._run_single_op()` has the same pattern, but here it actively breaks existing logic. `RayDataset.process()` (lines 194–207) wraps `_run_single_op()` in a `try/except` that catches the failure and retries the operator without `runtime_env` as a fallback. Because `exit(1)` raises `SystemExit` and terminates the worker before the parent `except` can run, that fallback path is currently dead code.

The `finally` block in `dj_dataset.py` already runs correctly under `raise` (just as it did under `exit(1)`, which also unwinds via an exception). The only behavioral change is that exceptions reach the caller instead of killing the process.

## Changes

| File | Change |
|------|--------|
| `data_juicer/core/data/dj_dataset.py` | `exit(1)` → `raise` in `NestedDataset.process()` |
| `data_juicer/core/data/ray_dataset.py` | `exit(1)` → `raise` in `RayDataset._run_single_op()` |
| `tests/core/data/test_dataset_error_propagation.py` | New tests covering both behaviors |

## Verification

Added `tests/core/data/test_dataset_error_propagation.py` with two tests:

- `test_process_raises_on_op_error` — asserts that an operator raising `RuntimeError` causes `NestedDataset.process()` to propagate that same `RuntimeError` to the caller.
- `test_process_does_not_call_exit` — asserts that an operator failure does not raise `SystemExit` (i.e. the process is not terminated).

```
$ python3 -m pytest tests/core/data/test_dataset_error_propagation.py -v
tests/core/data/test_dataset_error_propagation.py::TestDjDatasetErrorPropagation::test_process_does_not_call_exit PASSED
tests/core/data/test_dataset_error_propagation.py::TestDjDatasetErrorPropagation::test_process_raises_on_op_error PASSED

2 passed
```

Both tests fail against the unpatched code (`SystemExit: 1` is observed instead of the expected exception) and pass with the fix applied, confirming the regression is covered.

## Risk

Low. The change is local to two `except` blocks and only affects the failure path. Callers that previously relied on the process exiting on op errors will now receive the original exception, which is the documented and expected behavior for library code; the Ray `runtime_env` fallback in `RayDataset.process()` becomes functional again as a side benefit.