### PR TITLE
Replace bs4 stub with beautifulsoup4 in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "httpx",
     "emoji==2.2.0", # emoji handling
     "tabulate",
-    "bs4",
+    "beautifulsoup4",
     "requests",
     "wget",
     "streamlit",


### PR DESCRIPTION
## Summary

Swap `"bs4"` for `"beautifulsoup4"` in `pyproject.toml`'s `dependencies`.

## Why

The [`bs4` package on PyPI](https://pypi.org/project/bs4/) is a dummy stub maintained by Beautiful Soup's author to prevent name-squatting. Its only purpose is to depend on `beautifulsoup4` (the real library) so that users who accidentally type `pip install bs4` get something working. The PyPI page itself says: *"This is a dummy package managed by the developer of Beautiful Soup to prevent name squatting."*

Listing `bs4` as a direct dependency:

- Adds an extra hop in dependency resolution (`bs4` → `beautifulsoup4`).
- Pulls in a package that contains no real code of its own.

## What stays the same

`beautifulsoup4` registers the `bs4` import name, so the two existing usages in this repo continue to work unchanged:

- `data_juicer/download/downloader.py:12` — `from bs4 import BeautifulSoup`
- `data_juicer/ops/mapper/extract_tables_from_html_mapper.py:1` — `import bs4`

No code changes needed elsewhere.

## Test plan

- [ ] CI passes (no expected functional change).
- [ ] `pip install py-data-juicer` after this lands installs `beautifulsoup4` directly without going through the `bs4` shim, and `import bs4` still resolves.