### PR TITLE
fix(checkpoint): resolve relative path issue in Ray checkpoint writer

### DIFF
--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -155,7 +155,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         super().__init__(cfg)
 
         self.executor_type = "ray_partitioned"
-        self.work_dir = self.cfg.work_dir
+        self.work_dir = os.path.abspath(self.cfg.work_dir)
         self.job_id = self.cfg.get("job_id", None)
 
         # Initialize temporary directory for Ray operations
@@ -177,7 +177,9 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
         # Checkpoint configuration and manager initialization
         checkpoint_cfg = getattr(self.cfg, "checkpoint", None)
-        checkpoint_dir = getattr(self.cfg, "checkpoint_dir", os.path.join(self.work_dir, "checkpoints"))
+        checkpoint_dir = os.path.abspath(
+            getattr(self.cfg, "checkpoint_dir", os.path.join(self.work_dir, "checkpoints"))
+        )
 
         if checkpoint_cfg:
             # Use ConfigAccessor to handle both dict and object configurations

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -155,7 +155,9 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         super().__init__(cfg)
 
         self.executor_type = "ray_partitioned"
-        self.work_dir = os.path.abspath(self.cfg.work_dir)
+        self.work_dir = self.cfg.work_dir
+        if self.work_dir and "://" not in self.work_dir:
+            self.work_dir = os.path.abspath(self.work_dir)
         self.job_id = self.cfg.get("job_id", None)
 
         # Initialize temporary directory for Ray operations
@@ -177,9 +179,9 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
         # Checkpoint configuration and manager initialization
         checkpoint_cfg = getattr(self.cfg, "checkpoint", None)
-        checkpoint_dir = os.path.abspath(
-            getattr(self.cfg, "checkpoint_dir", os.path.join(self.work_dir, "checkpoints"))
-        )
+        checkpoint_dir = getattr(self.cfg, "checkpoint_dir", os.path.join(self.work_dir, "checkpoints"))
+        if checkpoint_dir and "://" not in checkpoint_dir:
+            checkpoint_dir = os.path.abspath(checkpoint_dir)
 
         if checkpoint_cfg:
             # Use ConfigAccessor to handle both dict and object configurations

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -31,6 +31,7 @@ from data_juicer.ops import load_ops
 from data_juicer.ops.op_fusion import fuse_operators
 from data_juicer.utils.ckpt_utils import CheckpointStrategy, RayCheckpointManager
 from data_juicer.utils.config_utils import ConfigAccessor
+from data_juicer.utils.file_utils import is_remote_path
 from data_juicer.utils.lazy_loader import LazyLoader
 
 ray = LazyLoader("ray")
@@ -155,9 +156,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         super().__init__(cfg)
 
         self.executor_type = "ray_partitioned"
-        self.work_dir = self.cfg.work_dir
-        if self.work_dir and "://" not in self.work_dir:
-            self.work_dir = os.path.abspath(self.work_dir)
+        self.work_dir = self._resolve_local_path(self.cfg.work_dir)
         self.job_id = self.cfg.get("job_id", None)
 
         # Initialize temporary directory for Ray operations
@@ -179,9 +178,9 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
         # Checkpoint configuration and manager initialization
         checkpoint_cfg = getattr(self.cfg, "checkpoint", None)
-        checkpoint_dir = getattr(self.cfg, "checkpoint_dir", os.path.join(self.work_dir, "checkpoints"))
-        if checkpoint_dir and "://" not in checkpoint_dir:
-            checkpoint_dir = os.path.abspath(checkpoint_dir)
+        checkpoint_dir = self._resolve_local_path(
+            getattr(self.cfg, "checkpoint_dir", os.path.join(self.work_dir, "checkpoints"))
+        )
 
         if checkpoint_cfg:
             # Use ConfigAccessor to handle both dict and object configurations
@@ -252,6 +251,22 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
             encryption_key_path=getattr(self.cfg, "encryption_key_path", None),
             **export_extra_args,
         )
+
+    @staticmethod
+    def _resolve_local_path(path):
+        """Convert a local, non-empty path to an absolute path.
+
+        Ray's writers (e.g. write_parquet) run on workers whose working
+        directory may differ from the main process, so relative paths like
+        './tmp/...' cannot be resolved correctly and lead to empty checkpoint
+        directories. Absolute conversion is applied only to local, non-empty
+        paths: remote URIs (e.g. s3://, gs://, hdfs://) are left untouched to
+        avoid corrupting their scheme, and empty/None values pass through
+        unchanged to avoid raising TypeError.
+        """
+        if path and not is_remote_path(path):
+            return os.path.abspath(path)
+        return path
 
     def _configure_partitioning(self):
         """Configure partitioning based on manual or auto mode."""

--- a/tests/core/executor/test_ray_executor_partitioned.py
+++ b/tests/core/executor/test_ray_executor_partitioned.py
@@ -367,6 +367,67 @@ class PartitionedRayExecutorTest(DataJuicerTestCaseBase):
             self.assertEqual(result, "failed")
 
 
+    # ==================== Path Resolution Tests ====================
+    # These cover the ray-mode path handling in PartitionedRayExecutor:
+    # Ray workers may run with a different working directory than the main
+    # process, so relative work_dir / checkpoint_dir must be resolved to
+    # absolute paths, while remote URIs and empty values must be preserved.
+
+    @TEST_TAG('ray')
+    def test_resolve_relative_path_to_absolute(self):
+        """Relative local paths should be converted to absolute paths."""
+        rel_path = os.path.join('.', 'tmp', 'ckpt')
+        resolved = PartitionedRayExecutor._resolve_local_path(rel_path)
+        self.assertTrue(os.path.isabs(resolved))
+        self.assertEqual(resolved, os.path.abspath(rel_path))
+
+    @TEST_TAG('ray')
+    def test_resolve_absolute_path_preserved(self):
+        """Normalized absolute local paths should pass through unchanged."""
+        abs_path = os.path.abspath(os.path.join(self.tmp_dir, 'checkpoints'))
+        resolved = PartitionedRayExecutor._resolve_local_path(abs_path)
+        self.assertEqual(resolved, abs_path)
+        # Applying resolution again must not change an already-absolute path
+        self.assertEqual(PartitionedRayExecutor._resolve_local_path(resolved), abs_path)
+
+    @TEST_TAG('ray')
+    def test_resolve_remote_uri_not_corrupted(self):
+        """Remote URIs must not be mangled by absolute-path conversion."""
+        for uri in ['s3://bucket/ckpt', 'gs://bucket/ckpt', 'hdfs://ns/ckpt']:
+            resolved = PartitionedRayExecutor._resolve_local_path(uri)
+            self.assertEqual(resolved, uri)
+
+    @TEST_TAG('ray')
+    def test_resolve_empty_path_no_error(self):
+        """Empty/None paths should pass through without raising TypeError."""
+        self.assertIsNone(PartitionedRayExecutor._resolve_local_path(None))
+        self.assertEqual(PartitionedRayExecutor._resolve_local_path(''), '')
+
+    @TEST_TAG('ray')
+    def test_executor_resolves_relative_work_dir_and_checkpoint_dir(self):
+        """End-to-end: relative work_dir/checkpoint_dir become absolute on the
+        executor and its checkpoint manager."""
+        cfg = init_configs([
+            '--config', os.path.join(self.root_path, 'demos/process_on_ray/configs/demo-new-config.yaml'),
+            '--partition.mode', 'manual',
+            '--partition.num_of_partitions', '2',
+            '--checkpoint.enabled', 'true'
+        ])
+        abs_work_dir = os.path.join(self.tmp_dir, 'test_relative_work_dir')
+        os.makedirs(abs_work_dir, exist_ok=True)
+        cfg.export_path = os.path.join(abs_work_dir, 'res.jsonl')
+        # Provide a relative work_dir to mimic './tmp/...' usage
+        cfg.work_dir = os.path.relpath(abs_work_dir, os.getcwd())
+
+        executor = PartitionedRayExecutor(cfg)
+
+        # work_dir on the executor must be absolute and point to the same place
+        self.assertTrue(os.path.isabs(executor.work_dir))
+        self.assertEqual(os.path.realpath(executor.work_dir), os.path.realpath(abs_work_dir))
+        # checkpoint dir handed to the manager must be absolute too, so that
+        # Ray workers write to the correct location
+        self.assertTrue(os.path.isabs(executor.ckpt_manager.ckpt_dir))
+
     # ==================== Edge Case Tests ====================
 
     @TEST_TAG('ray')


### PR DESCRIPTION
Ray's write_parquet is executed by Ray workers whose working directory may differ from the main process. When checkpoint_dir or work_dir is a relative path (e.g., './tmp/...'), Ray workers cannot resolve it correctly, resulting in empty checkpoint directories.

Fix: convert work_dir and checkpoint_dir to absolute paths during PartitionedRayExecutor initialization.