### PR TITLE
use custom gzip compression to tolerate FUSE-mounted OSS/S3

### DIFF
--- a/data_juicer/utils/logger_utils.py
+++ b/data_juicer/utils/logger_utils.py
@@ -153,14 +153,7 @@ def get_log_file_path():
             return handler._sink._file.name
 
 
-def setup_logger(
-    save_dir,
-    distributed_rank=0,
-    filename="log.txt",
-    mode="o",
-    level="INFO",
-    redirect="auto",
-):
+def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="o", level="INFO", redirect="auto"):
     """
     Setup logger for training and testing.
 
@@ -245,28 +238,15 @@ def setup_logger(
 
 
 def make_log_summarization(max_show_item=10):
-    error_pattern = (
-        r"^An error occurred in (.*?) when "
-        r"processing samples? \"(.*?)\" -- (.*?): (.*?) -- (.*?)$"
-    )
+    error_pattern = r"^An error occurred in (.*?) when " r"processing samples? \"(.*?)\" -- (.*?): (.*?) -- (.*?)$"
     log_file = get_log_file_path()
     if log_file is None:
         return
-    log_file = (
-        log_file.replace("_ERROR", "").replace("_WARNING", "").replace("_DEBUG", "")
-    )
+    log_file = log_file.replace("_ERROR", "").replace("_WARNING", "").replace("_DEBUG", "")
     error_log_file = add_suffix_to_filename(log_file, "_ERROR")
     warning_log_file = add_suffix_to_filename(log_file, "_WARNING")
-    error_pattern = (
-        r"^An error occurred in (.*?) when "
-        r"processing samples? \"(.*?)\" -- (.*?): (.*?) -- (.*?)$"
-    )
-    log_file = (
-        get_log_file_path()
-        .replace("_ERROR", "")
-        .replace("_WARNING", "")
-        .replace("_DEBUG", "")
-    )
+    error_pattern = r"^An error occurred in (.*?) when " r"processing samples? \"(.*?)\" -- (.*?): (.*?) -- (.*?)$"
+    log_file = get_log_file_path().replace("_ERROR", "").replace("_WARNING", "").replace("_DEBUG", "")
     error_log_file = add_suffix_to_filename(log_file, "_ERROR")
     warning_log_file = add_suffix_to_filename(log_file, "_WARNING")
 
@@ -310,10 +290,7 @@ def make_log_summarization(max_show_item=10):
             error_table.append([op_name, error_type, error_msg, num])
         table = tabulate(error_table, table_header, tablefmt="fancy_grid")
         summary += table
-    summary += (
-        f"\nError/Warning details can be found in the log file "
-        f"[{log_file}] and its related log files."
-    )
+    summary += f"\nError/Warning details can be found in the log file " f"[{log_file}] and its related log files."
     logger.opt(ansi=True).info(summary)
 
 

--- a/data_juicer/utils/logger_utils.py
+++ b/data_juicer/utils/logger_utils.py
@@ -15,8 +15,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import gzip
 import inspect
 import os
+import shutil
 import sys
 from io import StringIO
 
@@ -32,6 +34,28 @@ except Exception:
     get_ipython = None
 
 LOGGER_SETUP = False
+
+
+def gzip_compression(file_path):
+    """
+    Compress the rotated log file to ``<file_path>.gz`` and remove the source.
+
+    Used as the ``compression`` callback for loguru's file sink instead of the
+    built-in ``"gz"`` shortcut. The built-in shortcut will raise when the
+    source file cannot be removed, which happens on FUSE-mounted filesystems
+    backed by OSS / AWS S3 (e.g. K8s + Fluid): the unlink succeeds on the
+    object store but the FUSE layer returns ``OSError: [Errno 34] Numerical
+    result out of range``. Swallowing that specific failure keeps logging
+    working in those environments.
+    """
+    gz_path = file_path + ".gz"
+    with open(file_path, "rb") as f_in, gzip.open(gz_path, "wb") as f_out:
+        shutil.copyfileobj(f_in, f_out)
+
+    try:
+        os.remove(file_path)
+    except OSError:
+        pass
 
 
 def is_notebook():
@@ -171,7 +195,7 @@ def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="o", lev
             save_file,
             format=loguru_format,
             level=level,
-            compression="gz",
+            compression=gzip_compression,
             enqueue=True,
         )
 
@@ -181,7 +205,7 @@ def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="o", lev
         level="DEBUG",
         filter=lambda x: "DEBUG" == x["level"].name,
         format=loguru_format,
-        compression="gz",
+        compression=gzip_compression,
         enqueue=True,
         serialize=True,
     )
@@ -190,7 +214,7 @@ def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="o", lev
         level="ERROR",
         filter=lambda x: "ERROR" == x["level"].name,
         format=loguru_format,
-        compression="gz",
+        compression=gzip_compression,
         enqueue=True,
         serialize=True,
     )
@@ -199,7 +223,7 @@ def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="o", lev
         level="WARNING",
         filter=lambda x: "WARNING" == x["level"].name,
         format=loguru_format,
-        compression="gz",
+        compression=gzip_compression,
         enqueue=True,
         serialize=True,
     )

--- a/data_juicer/utils/logger_utils.py
+++ b/data_juicer/utils/logger_utils.py
@@ -15,6 +15,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import errno
 import gzip
 import inspect
 import os
@@ -54,8 +55,10 @@ def gzip_compression(file_path):
 
     try:
         os.remove(file_path)
-    except OSError:
-        pass
+    except OSError as e:
+        # Swallow only the specific errnos seen on some FUSE mounts
+        if e.errno not in (errno.ERANGE, errno.ENOSYS):
+            raise
 
 
 def is_notebook():
@@ -150,7 +153,14 @@ def get_log_file_path():
             return handler._sink._file.name
 
 
-def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="o", level="INFO", redirect="auto"):
+def setup_logger(
+    save_dir,
+    distributed_rank=0,
+    filename="log.txt",
+    mode="o",
+    level="INFO",
+    redirect="auto",
+):
     """
     Setup logger for training and testing.
 
@@ -235,15 +245,28 @@ def setup_logger(save_dir, distributed_rank=0, filename="log.txt", mode="o", lev
 
 
 def make_log_summarization(max_show_item=10):
-    error_pattern = r"^An error occurred in (.*?) when " r"processing samples? \"(.*?)\" -- (.*?): (.*?) -- (.*?)$"
+    error_pattern = (
+        r"^An error occurred in (.*?) when "
+        r"processing samples? \"(.*?)\" -- (.*?): (.*?) -- (.*?)$"
+    )
     log_file = get_log_file_path()
     if log_file is None:
         return
-    log_file = log_file.replace("_ERROR", "").replace("_WARNING", "").replace("_DEBUG", "")
+    log_file = (
+        log_file.replace("_ERROR", "").replace("_WARNING", "").replace("_DEBUG", "")
+    )
     error_log_file = add_suffix_to_filename(log_file, "_ERROR")
     warning_log_file = add_suffix_to_filename(log_file, "_WARNING")
-    error_pattern = r"^An error occurred in (.*?) when " r"processing samples? \"(.*?)\" -- (.*?): (.*?) -- (.*?)$"
-    log_file = get_log_file_path().replace("_ERROR", "").replace("_WARNING", "").replace("_DEBUG", "")
+    error_pattern = (
+        r"^An error occurred in (.*?) when "
+        r"processing samples? \"(.*?)\" -- (.*?): (.*?) -- (.*?)$"
+    )
+    log_file = (
+        get_log_file_path()
+        .replace("_ERROR", "")
+        .replace("_WARNING", "")
+        .replace("_DEBUG", "")
+    )
     error_log_file = add_suffix_to_filename(log_file, "_ERROR")
     warning_log_file = add_suffix_to_filename(log_file, "_WARNING")
 
@@ -287,7 +310,10 @@ def make_log_summarization(max_show_item=10):
             error_table.append([op_name, error_type, error_msg, num])
         table = tabulate(error_table, table_header, tablefmt="fancy_grid")
         summary += table
-    summary += f"\nError/Warning details can be found in the log file " f"[{log_file}] and its related log files."
+    summary += (
+        f"\nError/Warning details can be found in the log file "
+        f"[{log_file}] and its related log files."
+    )
     logger.opt(ansi=True).info(summary)
 
 


### PR DESCRIPTION
Loguru's built-in "gz" compression fails on K8s + Fluid OSS/S3 mounts because the post-compression unlink may returns OSError errno 34 even though the source file is removed. We replace it with a custom callback that swallows that specific failure so log compression works under FUSE.

e.g.:
<img width="2686" height="828" alt="image" src="https://github.com/user-attachments/assets/63142455-4318-41e1-8b2b-e19ce0d2585a" />
