### PR TITLE
[codex] fix initialize_ray without config

### DIFF
--- a/data_juicer/utils/ray_utils.py
+++ b/data_juicer/utils/ray_utils.py
@@ -36,9 +36,7 @@ def initialize_ray(cfg=None, force=False):
         if k.startswith(SPECIAL_TOKEN_ENV_PREFIX):
             env_vars.update({k: v})
 
-    custom_operator_paths = None
-    if cfg is not None and cfg.get("custom_operator_paths", None):
-        custom_operator_paths = cfg.custom_operator_paths
+    custom_operator_paths = (cfg.get("custom_operator_paths") or None) if cfg else None
 
     ray.init(
         ray_address,

--- a/data_juicer/utils/ray_utils.py
+++ b/data_juicer/utils/ray_utils.py
@@ -36,11 +36,16 @@ def initialize_ray(cfg=None, force=False):
         if k.startswith(SPECIAL_TOKEN_ENV_PREFIX):
             env_vars.update({k: v})
 
+    custom_operator_paths = None
+    if cfg is not None and cfg.get("custom_operator_paths", None):
+        custom_operator_paths = cfg.custom_operator_paths
+
     ray.init(
         ray_address,
         ignore_reinit_error=True,
         runtime_env=dict(
-            py_modules=cfg.custom_operator_paths if cfg.get("custom_operator_paths", None) else None, env_vars=env_vars
+            py_modules=custom_operator_paths,
+            env_vars=env_vars,
         ),
     )
 

--- a/tests/utils/test_ray_utils.py
+++ b/tests/utils/test_ray_utils.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from data_juicer.utils import ray_utils
+from data_juicer.utils.constant import RAY_JOB_ENV_VAR
+from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
+
+
+class RayUtilsTest(DataJuicerTestCaseBase):
+
+    def test_initialize_ray_without_cfg_uses_default_address(self):
+        mock_ray = MagicMock()
+        mock_ray.is_initialized.return_value = False
+
+        with patch.object(ray_utils, "ray", mock_ray):
+            ray_utils.initialize_ray(cfg=None)
+
+        mock_ray.init.assert_called_once()
+        args, kwargs = mock_ray.init.call_args
+        self.assertEqual(args, ("auto",))
+        self.assertTrue(kwargs["ignore_reinit_error"])
+        self.assertIsNone(kwargs["runtime_env"]["py_modules"])
+        self.assertIn(RAY_JOB_ENV_VAR, kwargs["runtime_env"]["env_vars"])
+
+    def test_initialize_ray_passes_custom_operator_paths(self):
+        class Config:
+            ray_address = "ray://127.0.0.1:10001"
+            custom_operator_paths = ["custom_ops"]
+
+            def get(self, key, default=None):
+                return getattr(self, key, default)
+
+        mock_ray = MagicMock()
+        mock_ray.is_initialized.return_value = False
+
+        with patch.object(ray_utils, "ray", mock_ray):
+            ray_utils.initialize_ray(cfg=Config())
+
+        mock_ray.init.assert_called_once()
+        args, kwargs = mock_ray.init.call_args
+        self.assertEqual(args, ("ray://127.0.0.1:10001",))
+        self.assertEqual(kwargs["runtime_env"]["py_modules"], ["custom_ops"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid reading cfg.get when initialize_ray is called with cfg=None
- keep custom_operator_paths behavior unchanged when a config is provided
- add focused unit coverage for no-config initialization and custom operator paths

## Root Cause
initialize_ray already defaulted the Ray address to auto when cfg was None, but runtime_env construction still dereferenced cfg.get, raising AttributeError before ray.init could run.

## Tests
- python3 -m unittest tests.utils.test_ray_utils
- python3 -m py_compile data_juicer/utils/ray_utils.py tests/utils/test_ray_utils.py
- git diff --check