### PR TITLE
fix: stop injecting invalid `max_new_tokens` param into API chat completion requests

### DIFF
--- a/data_juicer/ops/filter/llm_analysis_filter.py
+++ b/data_juicer/ops/filter/llm_analysis_filter.py
@@ -182,6 +182,7 @@ json
         self.enable_vllm = enable_vllm
         self.is_hf_model = is_hf_model
 
+        sampling_params = dict(sampling_params) if sampling_params else {}
         if enable_vllm or is_hf_model:
             sampling_params = update_sampling_params(sampling_params, api_or_hf_model, self.enable_vllm)
 

--- a/data_juicer/ops/filter/llm_analysis_filter.py
+++ b/data_juicer/ops/filter/llm_analysis_filter.py
@@ -182,7 +182,8 @@ json
         self.enable_vllm = enable_vllm
         self.is_hf_model = is_hf_model
 
-        sampling_params = update_sampling_params(sampling_params, api_or_hf_model, self.enable_vllm)
+        if enable_vllm or is_hf_model:
+            sampling_params = update_sampling_params(sampling_params, api_or_hf_model, self.enable_vllm)
 
         if enable_vllm:
             if not is_ray_mode():

--- a/data_juicer/ops/filter/llm_condition_filter.py
+++ b/data_juicer/ops/filter/llm_condition_filter.py
@@ -73,7 +73,7 @@ class LLMConditionFilter(Filter):
         self.is_hf_model = is_hf_model
         self.enable_vllm = enable_vllm
         model_params = model_params or {}
-        sampling_params = sampling_params or {}
+        sampling_params = dict(sampling_params) if sampling_params else {}
         if enable_vllm or is_hf_model:
             sampling_params = update_sampling_params(sampling_params, api_or_hf_model, enable_vllm)
         self.sampling_params = sampling_params

--- a/data_juicer/ops/filter/llm_condition_filter.py
+++ b/data_juicer/ops/filter/llm_condition_filter.py
@@ -73,7 +73,9 @@ class LLMConditionFilter(Filter):
         self.is_hf_model = is_hf_model
         self.enable_vllm = enable_vllm
         model_params = model_params or {}
-        sampling_params = update_sampling_params(sampling_params or {}, api_or_hf_model, enable_vllm)
+        sampling_params = sampling_params or {}
+        if enable_vllm or is_hf_model:
+            sampling_params = update_sampling_params(sampling_params, api_or_hf_model, enable_vllm)
         self.sampling_params = sampling_params
 
         if enable_vllm:

--- a/data_juicer/ops/mapper/image_tagging_vlm_mapper.py
+++ b/data_juicer/ops/mapper/image_tagging_vlm_mapper.py
@@ -101,8 +101,9 @@ Verify text relevance before combining with visual elements. If text is missing 
         self.tag_field_name = tag_field_name
         self.try_num = try_num
 
+        sampling_params = dict(sampling_params) if sampling_params else {}
         if not self.is_api_model:
-            sampling_params = update_sampling_params(sampling_params, api_or_hf_model, not self.is_api_model)
+            sampling_params = update_sampling_params(sampling_params, api_or_hf_model, True)
 
         if self.is_api_model:
             self.sampling_params = sampling_params

--- a/data_juicer/ops/mapper/image_tagging_vlm_mapper.py
+++ b/data_juicer/ops/mapper/image_tagging_vlm_mapper.py
@@ -101,7 +101,8 @@ Verify text relevance before combining with visual elements. If text is missing 
         self.tag_field_name = tag_field_name
         self.try_num = try_num
 
-        sampling_params = update_sampling_params(sampling_params, api_or_hf_model, not self.is_api_model)
+        if not self.is_api_model:
+            sampling_params = update_sampling_params(sampling_params, api_or_hf_model, not self.is_api_model)
 
         if self.is_api_model:
             self.sampling_params = sampling_params

--- a/data_juicer/ops/mapper/llm_extract_mapper.py
+++ b/data_juicer/ops/mapper/llm_extract_mapper.py
@@ -82,7 +82,9 @@ class LLMExtractMapper(Mapper):
         self.is_hf_model = is_hf_model
         self.enable_vllm = enable_vllm
         model_params = model_params or {}
-        sampling_params = update_sampling_params(sampling_params or {}, api_or_hf_model, enable_vllm)
+        sampling_params = sampling_params or {}
+        if enable_vllm or is_hf_model:
+            sampling_params = update_sampling_params(sampling_params, api_or_hf_model, enable_vllm)
         self.sampling_params = sampling_params
 
         if enable_vllm:

--- a/data_juicer/ops/mapper/llm_extract_mapper.py
+++ b/data_juicer/ops/mapper/llm_extract_mapper.py
@@ -82,7 +82,7 @@ class LLMExtractMapper(Mapper):
         self.is_hf_model = is_hf_model
         self.enable_vllm = enable_vllm
         model_params = model_params or {}
-        sampling_params = sampling_params or {}
+        sampling_params = dict(sampling_params) if sampling_params else {}
         if enable_vllm or is_hf_model:
             sampling_params = update_sampling_params(sampling_params, api_or_hf_model, enable_vllm)
         self.sampling_params = sampling_params

--- a/data_juicer/ops/mapper/optimize_prompt_mapper.py
+++ b/data_juicer/ops/mapper/optimize_prompt_mapper.py
@@ -131,6 +131,7 @@ class OptimizePromptMapper(Mapper):
         model_params = model_params or {}
         sampling_params = sampling_params or {}
 
+        sampling_params = sampling_params.copy()
         if enable_vllm or is_hf_model:
             sampling_params = update_sampling_params(sampling_params, api_or_hf_model, self.enable_vllm)
 

--- a/data_juicer/ops/mapper/optimize_prompt_mapper.py
+++ b/data_juicer/ops/mapper/optimize_prompt_mapper.py
@@ -131,7 +131,8 @@ class OptimizePromptMapper(Mapper):
         model_params = model_params or {}
         sampling_params = sampling_params or {}
 
-        sampling_params = update_sampling_params(sampling_params, api_or_hf_model, self.enable_vllm)
+        if enable_vllm or is_hf_model:
+            sampling_params = update_sampling_params(sampling_params, api_or_hf_model, self.enable_vllm)
 
         if enable_vllm:
             if not is_ray_mode():

--- a/data_juicer/ops/mapper/optimize_qa_mapper.py
+++ b/data_juicer/ops/mapper/optimize_qa_mapper.py
@@ -101,7 +101,8 @@ class OptimizeQAMapper(Mapper):
         model_params = model_params or {}
         sampling_params = sampling_params or {}
 
-        sampling_params = update_sampling_params(sampling_params, api_or_hf_model, self.enable_vllm)
+        if enable_vllm or is_hf_model:
+            sampling_params = update_sampling_params(sampling_params, api_or_hf_model, self.enable_vllm)
 
         if enable_vllm:
             if not is_ray_mode():

--- a/data_juicer/ops/mapper/optimize_qa_mapper.py
+++ b/data_juicer/ops/mapper/optimize_qa_mapper.py
@@ -101,6 +101,7 @@ class OptimizeQAMapper(Mapper):
         model_params = model_params or {}
         sampling_params = sampling_params or {}
 
+        sampling_params = sampling_params.copy()
         if enable_vllm or is_hf_model:
             sampling_params = update_sampling_params(sampling_params, api_or_hf_model, self.enable_vllm)
 

--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -1453,6 +1453,13 @@ def update_sampling_params(
 ):
     """Update sampling_params with max_tokens/max_new_tokens from model or defaults.
 
+    For vLLM: ensures `max_tokens` is set (vLLM default 16 is too small).
+    For HF local: ensures `max_new_tokens` is set (transformers default 20 is too small).
+
+    This function should NOT be called for API models — API providers have
+    their own defaults, and injecting params like `max_new_tokens` would be
+    invalid for OpenAI-compatible endpoints.
+
     When fetch_generation_config_from_hf is False (e.g. API-only models like
     gemini-2.5-flash via DashScope), skip HuggingFace GenerationConfig fetch to
     avoid connection errors. Default None means: fetch when enable_vllm or when

--- a/docs/op_doc_enhance_workflow/utils/model.py
+++ b/docs/op_doc_enhance_workflow/utils/model.py
@@ -1,17 +1,15 @@
 from data_juicer.utils.model_utils import (
     get_model,
     prepare_model,
-    update_sampling_params,
 )
 
 API_MODEL = "qwen3-max"
 
 
 def chat(messages: list[dict]):
-    sampling_params = update_sampling_params({}, API_MODEL, False)
     model_key = prepare_model(
         model_type="api",
         model=API_MODEL,
     )
     _model = get_model(model_key, None, False)
-    return _model(messages, **sampling_params)
+    return _model(messages)


### PR DESCRIPTION
## Problem

`update_sampling_params` unconditionally injects `max_new_tokens` for all non-vLLM paths, including API model calls. This is a HuggingFace-only parameter that is not recognized by OpenAI-compatible Chat Completions endpoints (which use `max_tokens` or `max_completion_tokens`).

Affected operators: `llm_analysis_filter`, `llm_condition_filter`, `llm_extract_mapper`, `optimize_prompt_mapper`, `optimize_qa_mapper`, `image_tagging_vlm_mapper`.

Additionally, if a user explicitly passes `max_tokens`, the function still appends `max_new_tokens=512`, resulting in conflicting params in the request body.

## Fix

Skip `update_sampling_params` entirely for API model paths. 

- vLLM: still injects `max_tokens` 
- HF local: still injects `max_new_tokens`
- API: no injection — let the provider handle it