### PR TITLE
fix(core): add FUSE-safe rmtree fallback to PartitionedRayExecutor

### DIFF
--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -55,10 +55,7 @@ class TempDirManager:
             try:
                 shutil.rmtree(self.tmp_dir)
             except OSError as e:
-                logger.warning(
-                    f"Remove tmp dir with shutil.rmtree() failed: {e}, "
-                    "will try os.rmdir()"
-                )
+                logger.warning(f"Remove tmp dir with shutil.rmtree() failed: {e}, " "will try os.rmdir()")
                 os.rmdir(self.tmp_dir)
 
 
@@ -492,10 +489,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
             try:
                 shutil.rmtree(tmp_base_dir)
             except OSError as e:
-                logger.warning(
-                    f"Remove tmp dir with shutil.rmtree() failed: {e}, "
-                    "will try os.rmdir()"
-                )
+                logger.warning(f"Remove tmp dir with shutil.rmtree() failed: {e}, " "will try os.rmdir()")
                 os.rmdir(tmp_base_dir)
             logger.info("Temporary files cleaned up successfully")
         else:
@@ -1022,9 +1016,6 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
             try:
                 shutil.rmtree(self.ckpt_manager.ckpt_dir)
             except OSError as e:
-                logger.warning(
-                    f"Remove ckpt dir with shutil.rmtree() failed: {e}, "
-                    "will try os.rmdir()"
-                )
+                logger.warning(f"Remove ckpt dir with shutil.rmtree() failed: {e}, " "will try os.rmdir()")
                 os.rmdir(self.ckpt_manager.ckpt_dir)
             os.makedirs(self.ckpt_manager.ckpt_dir, exist_ok=True)

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -49,7 +49,17 @@ class TempDirManager:
     def __exit__(self, exc_type, exc_val, exc_tb):
         if os.path.exists(self.tmp_dir):
             logger.info(f"Removing tmp dir {self.tmp_dir} ...")
-            shutil.rmtree(self.tmp_dir)
+            # in some cases, such as we mount OSS bucket with fuse device
+            # using Fluid, cleaning up temporary directories via
+            # shutil.rmtree() fails, but os.rmdir() succeeds.
+            try:
+                shutil.rmtree(self.tmp_dir)
+            except OSError as e:
+                logger.warning(
+                    f"Remove tmp dir with shutil.rmtree() failed: {e}, "
+                    "will try os.rmdir()"
+                )
+                os.rmdir(self.tmp_dir)
 
 
 # Note: Using Ray Data's built-in map_batches for parallel processing instead of custom remote functions
@@ -479,8 +489,15 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         tmp_base_dir = os.path.join(self.work_dir, ".tmp")
         if os.path.exists(tmp_base_dir):
             logger.info(f"Cleaning up temporary files in {tmp_base_dir}")
-            shutil.rmtree(tmp_base_dir)
-            logger.info("✅ Temporary files cleaned up successfully")
+            try:
+                shutil.rmtree(tmp_base_dir)
+            except OSError as e:
+                logger.warning(
+                    f"Remove tmp dir with shutil.rmtree() failed: {e}, "
+                    "will try os.rmdir()"
+                )
+                os.rmdir(tmp_base_dir)
+            logger.info("Temporary files cleaned up successfully")
         else:
             logger.info("No temporary files found to clean up")
 
@@ -1002,5 +1019,12 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         """Clear checkpoints when partition validation fails."""
         if os.path.exists(self.ckpt_manager.ckpt_dir):
             logger.warning(f"Clearing invalid checkpoints in {self.ckpt_manager.ckpt_dir}")
-            shutil.rmtree(self.ckpt_manager.ckpt_dir)
+            try:
+                shutil.rmtree(self.ckpt_manager.ckpt_dir)
+            except OSError as e:
+                logger.warning(
+                    f"Remove ckpt dir with shutil.rmtree() failed: {e}, "
+                    "will try os.rmdir()"
+                )
+                os.rmdir(self.ckpt_manager.ckpt_dir)
             os.makedirs(self.ckpt_manager.ckpt_dir, exist_ok=True)


### PR DESCRIPTION
PR #943 fixed shutil.rmtree() failures on FUSE-mounted OSS buckets (Fluid) in RayExecutor, but missed the same pattern in ray_executor_partitioned.py. When shutil.rmtree() fails with OSError (e.g. errno 34 on FUSE devices), fall back to os.rmdir() which succeeds in this scenario.

Applies the fix to all 3 shutil.rmtree sites:
- TempDirManager.__exit__
- cleanup_temp_files()
- _clear_invalid_checkpoints()