### PR TITLE
fix(op_env): resolve LATEST strategy returning unpinned version for unbounded ranges

### DIFF
--- a/data_juicer/ops/op_env.py
+++ b/data_juicer/ops/op_env.py
@@ -523,28 +523,43 @@ class OPEnvManager:
             # use union to combine them to find the latest version
             combined = p1 | p2
             if isinstance(combined, UnionSpecifier):
-                max_str = []
-                for r in combined.ranges:
-                    if r.max:
+                has_unbounded = any(r.max is None for r in combined.ranges)
+                if has_unbounded:
+                    # Some ranges extend to +inf. Use the highest lower bound
+                    # from unbounded ranges as the LATEST constraint.
+                    max_min = None
+                    include_max_min = False
+                    for r in combined.ranges:
+                        if r.max is None and r.min is not None:
+                            if max_min is None or r.min > max_min:
+                                max_min = r.min
+                                include_max_min = r.include_min
+                    if max_min is not None:
+                        latest_version = (
+                            SpecifierSet(f">={max_min}") if include_max_min else SpecifierSet(f">{max_min}")
+                        )
+                    # else: fully unbounded (no min), fall through to warning
+                else:
+                    # All ranges have upper bounds, find the maximum upper bound
+                    max_str = []
+                    for r in combined.ranges:
                         if r.include_max:
                             max_str.append(f"<={r.max}")
                         else:
                             max_str.append(f"<{r.max}")
-                    else:
-                        max_str = []
-                        break
-                if len(max_str) > 0:
-                    max_spec = parse_version_specifier("||".join(max_str))
-                    include_latest = max_spec.include_max
-                    latest_version = max_spec.max
+                    if len(max_str) > 0:
+                        max_spec = parse_version_specifier("||".join(max_str))
+                        include_latest = max_spec.include_max
+                        latest_version = max_spec.max
             else:
                 include_latest = combined.include_max
                 latest_version = combined.max
-            if latest_version:
+            # Convert raw version to SpecifierSet (skip if already set above)
+            if latest_version is not None and not isinstance(latest_version, SpecifierSet):
                 latest_version = (
                     SpecifierSet(f"=={latest_version}") if include_latest else SpecifierSet(f"<{latest_version}")
                 )
-            elif latest_version is None:
+            if latest_version is None:
                 logger.warning(
                     f"Dependency conflict for {first_req.name or second_req.name}, "
                     f"fallback to unpinned version under LATEST strategy: "

--- a/tests/ops/test_op_env.py
+++ b/tests/ops/test_op_env.py
@@ -10,6 +10,7 @@ class RequirementTest(DataJuicerTestCaseBase):
     def setUp(self):
         super().setUp()
         from data_juicer.ops.op_env import Requirement
+
         self.Requirement = Requirement
 
     def test_basic_requirement(self):
@@ -46,15 +47,16 @@ class OPEnvSpecTest(DataJuicerTestCaseBase):
     def setUp(self):
         super().setUp()
         from data_juicer.ops.op_env import OPEnvSpec
+
         self.OPEnvSpec = OPEnvSpec
 
-        self.work_dir = 'tmp/test_op_env_spec/'
+        self.work_dir = "tmp/test_op_env_spec/"
         os.makedirs(self.work_dir, exist_ok=True)
 
     def tearDown(self) -> None:
         super().tearDown()
         if os.path.exists(self.work_dir):
-            os.system(f'rm -rf {self.work_dir}')
+            os.system(f"rm -rf {self.work_dir}")
 
     def test_init_with_pip_packages_list(self):
         spec = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0", "pandas>=1.3.0"])
@@ -66,7 +68,7 @@ class OPEnvSpecTest(DataJuicerTestCaseBase):
         req_file = Path(self.work_dir) / "requirements.txt"
         with open(req_file, "w") as f:
             f.write("numpy>=1.20.0\npandas>=1.3.0\n")
-        
+
         spec = self.OPEnvSpec(pip_pkgs=str(req_file))
         self.assertEqual(len(spec.pip_pkgs), 2)
         self.assertIn("numpy>=1.20.0", spec.pip_pkgs)
@@ -94,13 +96,11 @@ class OPEnvSpecTest(DataJuicerTestCaseBase):
 
     def test_parsed_requirements(self):
         from data_juicer.ops.op_env import Requirement
+
         req1 = Requirement(name="numpy", version=">=1.20.0")
         req2 = Requirement(name="pandas", version=">=1.3.0")
         spec = self.OPEnvSpec(parsed_requirements={"numpy": req1, "pandas": req2})
-        self.assertEqual(spec.parsed_requirements, {
-            "numpy": req1,
-            "pandas": req2
-        })
+        self.assertEqual(spec.parsed_requirements, {"numpy": req1, "pandas": req2})
         self.assertEqual(spec.pip_pkgs, ["numpy>=1.20.0", "pandas>=1.3.0"])
 
     def test_hash(self):
@@ -114,25 +114,28 @@ class OPEnvSpecTest(DataJuicerTestCaseBase):
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0"])
         self.assertEqual(spec1.get_requirement_name_list(), ["numpy"])
         from data_juicer.ops.op_env import Requirement
+
         req1 = Requirement(name="numpy", version=">=1.20.0")
         req2 = Requirement(name="pandas", version=">=1.3.0")
         spec2 = self.OPEnvSpec(parsed_requirements={"numpy": req1, "pandas": req2})
         self.assertEqual(spec2.get_requirement_name_list(), ["numpy", "pandas"])
+
 
 class ParseSingleRequirementTest(DataJuicerTestCaseBase):
 
     def setUp(self):
         super().setUp()
         from data_juicer.ops.op_env import parse_single_requirement
+
         self.parse_single_requirement = parse_single_requirement
 
-        self.work_dir = 'tmp/test_parse_single_requirement/'
+        self.work_dir = "tmp/test_parse_single_requirement/"
         os.makedirs(self.work_dir, exist_ok=True)
 
     def tearDown(self) -> None:
         super().tearDown()
         if os.path.exists(self.work_dir):
-            os.system(f'rm -rf {self.work_dir}')
+            os.system(f"rm -rf {self.work_dir}")
 
     def test_parse_basic_requirement(self):
         req = self.parse_single_requirement("numpy>=1.20.0")
@@ -166,6 +169,7 @@ class ParseRequirementsListTest(DataJuicerTestCaseBase):
     def setUp(self):
         super().setUp()
         from data_juicer.ops.op_env import parse_requirements_list
+
         self.parse_requirements_list = parse_requirements_list
 
     def test_parse_requirements_list(self):
@@ -181,15 +185,16 @@ class OpRequirementsToOpEnvSpecTest(DataJuicerTestCaseBase):
     def setUp(self):
         super().setUp()
         from data_juicer.ops.op_env import op_requirements_to_op_env_spec
+
         self.op_requirements_to_op_env_spec = op_requirements_to_op_env_spec
 
-        self.work_dir = 'tmp/test_op_requirements_to_op_env_spec/'
+        self.work_dir = "tmp/test_op_requirements_to_op_env_spec/"
         os.makedirs(self.work_dir, exist_ok=True)
 
     def tearDown(self) -> None:
         super().tearDown()
         if os.path.exists(self.work_dir):
-            os.system(f'rm -rf {self.work_dir}')
+            os.system(f"rm -rf {self.work_dir}")
 
     def test_empty_requirements(self):
         spec = self.op_requirements_to_op_env_spec("test_op")
@@ -230,17 +235,18 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
     def setUp(self):
         super().setUp()
         from data_juicer.ops.op_env import OPEnvManager, OPEnvSpec, ConflictResolveStrategy
+
         self.OPEnvManager = OPEnvManager
         self.OPEnvSpec = OPEnvSpec
         self.ConflictResolveStrategy = ConflictResolveStrategy
 
-        self.work_dir = 'tmp/test_op_env_manager/'
+        self.work_dir = "tmp/test_op_env_manager/"
         os.makedirs(self.work_dir, exist_ok=True)
 
     def tearDown(self) -> None:
         super().tearDown()
         if os.path.exists(self.work_dir):
-            os.system(f'rm -rf {self.work_dir}')
+            os.system(f"rm -rf {self.work_dir}")
 
     def test_init_with_default_values(self):
         manager = self.OPEnvManager()
@@ -248,8 +254,9 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         self.assertEqual(manager.conflict_resolve_strategy, self.ConflictResolveStrategy.SPLIT)
 
     def test_init_with_custom_values(self):
-        manager = self.OPEnvManager(min_common_dep_num_to_combine=2,
-                                    conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST)
+        manager = self.OPEnvManager(
+            min_common_dep_num_to_combine=2, conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
+        )
         self.assertEqual(manager.min_common_dep_num_to_combine, 2)
         self.assertEqual(manager.conflict_resolve_strategy, self.ConflictResolveStrategy.LATEST)
 
@@ -261,10 +268,10 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         manager = self.OPEnvManager()
         spec = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0"])
         op_name = "test_op"
-        
+
         manager.record_op_env_spec(op_name, spec)
         retrieved_spec = manager.get_op_env_spec(op_name)
-        
+
         self.assertEqual(retrieved_spec, spec)
         states = manager.print_the_current_states()
         self.assertEqual(len(states), 1)
@@ -278,7 +285,7 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         manager = self.OPEnvManager(min_common_dep_num_to_combine=2)
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0"])
         spec2 = self.OPEnvSpec(pip_pkgs=["pandas>=1.3.0"])
-        
+
         result = manager.can_combine_op_env_specs(spec1, spec2)
         self.assertFalse(result)
 
@@ -286,7 +293,7 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         manager = self.OPEnvManager(min_common_dep_num_to_combine=1)
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0", "pandas>=1.3.0"])
         spec2 = self.OPEnvSpec(pip_pkgs=["numpy>=1.21.0", "scipy>=1.7.0"])
-        
+
         result = manager.can_combine_op_env_specs(spec1, spec2)
         self.assertTrue(result)
 
@@ -294,17 +301,17 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         manager = self.OPEnvManager(min_common_dep_num_to_combine=1)
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0"], working_dir="/path1")
         spec2 = self.OPEnvSpec(pip_pkgs=["numpy>=1.21.0"], working_dir="/path2")
-        
+
         result = manager.can_combine_op_env_specs(spec1, spec2)
         self.assertFalse(result)
 
     def test_merge_op_env_specs_same_spec(self):
         manager = self.OPEnvManager()
         spec = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0"])
-        
+
         manager.record_op_env_spec("op1", spec)
         manager.record_op_env_spec("op2", spec)
-        
+
         self.assertEqual(manager.op2hash["op1"], manager.op2hash["op2"])
         self.assertEqual(len(manager.hash2specs), 1)
         states = manager.print_the_current_states()
@@ -314,12 +321,12 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         manager = self.OPEnvManager(min_common_dep_num_to_combine=1)
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0"], env_vars={"A": "1"})
         spec2 = self.OPEnvSpec(pip_pkgs=["numpy>=1.21.0"], env_vars={"B": "2"})
-        
+
         manager.record_op_env_spec("op1", spec1)
         manager.record_op_env_spec("op2", spec2)
-        
+
         # Since we allow combining (common deps exist), there should be a combined spec
-        self.assertEqual(len(manager.hash2ops), 1)   # Only one combined hash
+        self.assertEqual(len(manager.hash2ops), 1)  # Only one combined hash
         combined_spec = next(iter(manager.hash2specs.values()))
         # Check that both ops reference the same combined spec
         self.assertEqual(len(manager.hash2ops[manager.op2hash["op1"]]), 2)  # Both ops use the same hash
@@ -330,10 +337,10 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         manager = self.OPEnvManager(min_common_dep_num_to_combine=-1)  # No combination
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0"])
         spec2 = self.OPEnvSpec(pip_pkgs=["pandas>=1.3.0"])
-        
+
         manager.record_op_env_spec("op1", spec1)
         manager.record_op_env_spec("op2", spec2)
-        
+
         # Since combination is disabled, there should be 2 separate specs
         self.assertEqual(len(manager.hash2specs), 2)
         self.assertEqual(len(manager.hash2ops), 2)
@@ -398,15 +405,14 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
 
     def test_conflict_resolution_split_strategy(self):
         manager = self.OPEnvManager(
-            min_common_dep_num_to_combine=1,
-            conflict_resolve_strategy=self.ConflictResolveStrategy.SPLIT
+            min_common_dep_num_to_combine=1, conflict_resolve_strategy=self.ConflictResolveStrategy.SPLIT
         )
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0"])  # This would cause conflict
         spec2 = self.OPEnvSpec(pip_pkgs=["numpy<1.19.0"])  # This conflicts with above
-        
+
         manager.record_op_env_spec("op1", spec1)
         manager.record_op_env_spec("op2", spec2)
-        
+
         # With SPLIT strategy, specs should remain separate due to conflict
         self.assertNotEqual(manager.op2hash["op1"], manager.op2hash["op2"])
         states = manager.print_the_current_states()
@@ -414,15 +420,14 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
 
     def test_conflict_resolution_latest_strategy(self):
         manager = self.OPEnvManager(
-            min_common_dep_num_to_combine=1,
-            conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
+            min_common_dep_num_to_combine=1, conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
         )
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy==1.25.0"])
         spec2 = self.OPEnvSpec(pip_pkgs=["numpy>=1.19.0,<1.22.0"])
-        
+
         manager.record_op_env_spec("op1", spec1)
         manager.record_op_env_spec("op2", spec2)
-        
+
         # With LATEST strategy, the latest version in the spec should be used.
         # In this case the latest version is 1.25.0.
         # The exact behavior depends on the implementation of conflict resolution
@@ -435,8 +440,7 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
 
     def test_conflict_resolution_latest_strategy_not_include_max(self):
         manager = self.OPEnvManager(
-            min_common_dep_num_to_combine=1,
-            conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
+            min_common_dep_num_to_combine=1, conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
         )
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy<1.25.0,>1.23.0"])
         spec2 = self.OPEnvSpec(pip_pkgs=["numpy>=1.19.0,<1.22.0"])
@@ -457,8 +461,7 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
 
     def test_conflict_resolution_latest_strategy_without_max(self):
         manager = self.OPEnvManager(
-            min_common_dep_num_to_combine=1,
-            conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
+            min_common_dep_num_to_combine=1, conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
         )
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy>1.23.0"])
         spec2 = self.OPEnvSpec(pip_pkgs=["numpy>=1.19.0,<1.22.0"])
@@ -466,21 +469,18 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         manager.record_op_env_spec("op1", spec1)
         manager.record_op_env_spec("op2", spec2)
 
-        # With LATEST strategy, the latest version in the spec should be used.
-        # In this case the latest version is the one less than but closest to 1.25.0,
-        # which can be described as <.
-        # The exact behavior depends on the implementation of conflict resolution
+        # With LATEST strategy, when the union contains an unbounded range
+        # (>1.23.0 has no upper limit), the highest lower bound from
+        # unbounded ranges is used as the constraint.
         combined_spec = manager.hash2specs[manager.op2hash["op1"]]
-        # We expect at least one combined spec to exist
         self.assertGreaterEqual(len(manager.hash2specs), 1)
-        self.assertEqual(combined_spec.pip_pkgs, ["numpy"])
+        self.assertEqual(combined_spec.pip_pkgs, ["numpy>1.23.0"])
         states = manager.print_the_current_states()
         self.assertEqual(len(states), 1)
 
     def test_conflict_resolution_latest_strategy_allow_union(self):
         manager = self.OPEnvManager(
-            min_common_dep_num_to_combine=1,
-            conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
+            min_common_dep_num_to_combine=1, conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
         )
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy>=1.22.0,<2.0"])
         spec2 = self.OPEnvSpec(pip_pkgs=["numpy>=1.19.0,<1.22.0"])
@@ -498,6 +498,61 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         states = manager.print_the_current_states()
         self.assertEqual(len(states), 1)
 
+    def test_conflict_resolution_latest_incompatible_uses_highest_min(self):
+        """Fully incompatible ranges: >=2.0 vs <1.5.
+        The unbounded range >=2.0 has the highest lower bound, so LATEST
+        should select >=2.0 instead of falling back to unpinned."""
+        manager = self.OPEnvManager(
+            min_common_dep_num_to_combine=1, conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
+        )
+        spec1 = self.OPEnvSpec(pip_pkgs=["numpy>=2.0"])
+        spec2 = self.OPEnvSpec(pip_pkgs=["numpy<1.5"])
+
+        manager.record_op_env_spec("op1", spec1)
+        manager.record_op_env_spec("op2", spec2)
+
+        combined_spec = manager.hash2specs[manager.op2hash["op1"]]
+        self.assertEqual(combined_spec.pip_pkgs, ["numpy>=2.0"])
+        states = manager.print_the_current_states()
+        self.assertEqual(len(states), 1)
+
+    def test_conflict_resolution_latest_multiple_unbounded_picks_max_min(self):
+        """Multiple unbounded ranges: >1.23.0 and >=2.0.
+        LATEST should pick the highest lower bound: >=2.0."""
+        manager = self.OPEnvManager(
+            min_common_dep_num_to_combine=1, conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
+        )
+        # >1.23.0 | >=2.0 both unbounded; combined with <1.0 to trigger conflict
+        spec1 = self.OPEnvSpec(pip_pkgs=["numpy>=2.0"])
+        spec2 = self.OPEnvSpec(pip_pkgs=["numpy>1.23.0,<1.25.0"])
+
+        manager.record_op_env_spec("op1", spec1)
+        manager.record_op_env_spec("op2", spec2)
+
+        # Union is >=2.0 | (>1.23.0,<1.25.0). Only >=2.0 is unbounded.
+        # Highest min from unbounded ranges is 2.0 (inclusive).
+        combined_spec = manager.hash2specs[manager.op2hash["op1"]]
+        self.assertEqual(combined_spec.pip_pkgs, ["numpy>=2.0"])
+        states = manager.print_the_current_states()
+        self.assertEqual(len(states), 1)
+
+    def test_conflict_resolution_latest_unbounded_include_min_false(self):
+        """Unbounded range with exclusive lower bound: >1.23.0 vs <1.0.
+        LATEST should use >1.23.0 (exclusive)."""
+        manager = self.OPEnvManager(
+            min_common_dep_num_to_combine=1, conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
+        )
+        spec1 = self.OPEnvSpec(pip_pkgs=["numpy>1.23.0"])
+        spec2 = self.OPEnvSpec(pip_pkgs=["numpy<1.0"])
+
+        manager.record_op_env_spec("op1", spec1)
+        manager.record_op_env_spec("op2", spec2)
+
+        combined_spec = manager.hash2specs[manager.op2hash["op1"]]
+        self.assertEqual(combined_spec.pip_pkgs, ["numpy>1.23.0"])
+        states = manager.print_the_current_states()
+        self.assertEqual(len(states), 1)
+
     def test_conflict_resolution_with_arbitrary_equal(self):
         spec1 = self.OPEnvSpec(pip_pkgs=["numpy===2.0"])
         spec2 = self.OPEnvSpec(pip_pkgs=["numpy>=1.19.0,<1.22.0"])
@@ -505,8 +560,7 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
 
         # the first one is arbitrary
         manager = self.OPEnvManager(
-            min_common_dep_num_to_combine=1,
-            conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
+            min_common_dep_num_to_combine=1, conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
         )
         manager.record_op_env_spec("op1", spec1)
         manager.record_op_env_spec("op2", spec2)
@@ -521,8 +575,7 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
 
         # the second one is arbitrary
         manager = self.OPEnvManager(
-            min_common_dep_num_to_combine=1,
-            conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
+            min_common_dep_num_to_combine=1, conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
         )
         manager.record_op_env_spec("op2", spec2)
         manager.record_op_env_spec("op3", spec3)
@@ -537,8 +590,7 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
 
         # both are arbitrary, should be split
         manager = self.OPEnvManager(
-            min_common_dep_num_to_combine=1,
-            conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
+            min_common_dep_num_to_combine=1, conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST
         )
         manager.record_op_env_spec("op1", spec1)
         manager.record_op_env_spec("op3", spec3)
@@ -557,9 +609,9 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         manager = self.OPEnvManager()
         spec = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0"])
         op_name = "test_op"
-        
+
         manager.record_op_env_spec(op_name, spec)
-        
+
         self.assertIn(op_name, manager.op2hash)
         self.assertIn(manager.op2hash[op_name], manager.hash2specs)
         self.assertIn(op_name, manager.hash2ops[manager.op2hash[op_name]])
@@ -568,10 +620,10 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         manager = self.OPEnvManager()
         spec = self.OPEnvSpec(pip_pkgs=["numpy>=1.20.0"])
         op1, op2 = "test_op1", "test_op2"
-        
+
         manager.record_op_env_spec(op1, spec)
         manager.record_op_env_spec(op2, spec)
-        
+
         # Both ops should have the same hash
         self.assertEqual(manager.op2hash[op1], manager.op2hash[op2])
         # Both ops should be listed under the same hash
@@ -580,43 +632,46 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
 
     def test_resolve_with_strategy(self):
         from data_juicer.ops.op_env import Requirement, ConflictResolveStrategy
+
         manager = self.OPEnvManager(conflict_resolve_strategy=self.ConflictResolveStrategy.SPLIT)
-        
+
         # Test basic conflict resolution with SPLIT strategy
         req1 = Requirement(name="numpy", version=">=1.20.0")
         req2 = Requirement(name="numpy", version="<1.19.0")
-        
+
         result = manager._resolve_with_strategy(req1, req2)
         self.assertIsNone(result, "SPLIT strategy should return None for conflicting versions")
-        
+
         # Test no conflict case
         req3 = Requirement(name="numpy", version=">=1.20.0")
         req4 = Requirement(name="numpy", version=">=1.19.0")
-        
+
         result = manager._resolve_with_strategy(req3, req4)
         self.assertIsNotNone(result, "Should return merged requirement when no conflict exists")
         self.assertEqual(result.name, "numpy")
-        
+
         # Test OVERWRITE strategy
         manager_overwrite = self.OPEnvManager(conflict_resolve_strategy=self.ConflictResolveStrategy.OVERWRITE)
         result = manager_overwrite._resolve_with_strategy(req1, req2)
         self.assertEqual(result, req2, "OVERWRITE strategy should return the second requirement")
-        
+
         # Test LATEST strategy
         manager_latest = self.OPEnvManager(conflict_resolve_strategy=self.ConflictResolveStrategy.LATEST)
         req5 = Requirement(name="numpy", version=">=1.20.0")
         req6 = Requirement(name="numpy", version=">=1.19.0,<1.22.0")
-        
+
         result = manager_latest._resolve_with_strategy(req5, req6)
         # With these specific versions, it should find a compatible range
         self.assertIsNotNone(result, "LATEST strategy should resolve compatible ranges")
-        
+
         # Test with extras and markers
         req7 = Requirement(name="scipy", version=">=1.7.0", extras=["io"], markers="python_version>='3.6'")
         req8 = Requirement(name="scipy", version=">=1.8.0", extras=["optimize"])
-        
+
         result = manager_overwrite._resolve_with_strategy(req7, req8)
-        self.assertEqual(sorted(result.extras), ["io", "optimize"], "Extras should come from second requirement with OVERWRITE")
+        self.assertEqual(
+            sorted(result.extras), ["io", "optimize"], "Extras should come from second requirement with OVERWRITE"
+        )
         self.assertEqual(result.markers, "python_version>='3.6'", "Markers should be combined")
 
         # Test with extras and markers
@@ -624,9 +679,10 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
         req8 = Requirement(name="scipy", version=">=1.8.0", markers="python_version<'3.8'")
 
         result = manager_overwrite._resolve_with_strategy(req7, req8)
-        self.assertEqual(sorted(result.extras), ["io"],
-                         "Extras should come from second requirement with OVERWRITE")
-        self.assertEqual(result.markers, 'python_version >= "3.6" and python_version < "3.8"', "Markers should be combined")
+        self.assertEqual(sorted(result.extras), ["io"], "Extras should come from second requirement with OVERWRITE")
+        self.assertEqual(
+            result.markers, 'python_version >= "3.6" and python_version < "3.8"', "Markers should be combined"
+        )
 
         # Test with no version infos
         req1 = Requirement(name="numpy")
@@ -650,23 +706,27 @@ class OPEnvManagerTest(DataJuicerTestCaseBase):
 
 
 class AnalyzeLazyLoadedRequirementsTest(DataJuicerTestCaseBase):
-    
+
     def setUp(self):
         super().setUp()
-        from data_juicer.ops.op_env import analyze_lazy_loaded_requirements, analyze_lazy_loaded_requirements_for_code_file
+        from data_juicer.ops.op_env import (
+            analyze_lazy_loaded_requirements,
+            analyze_lazy_loaded_requirements_for_code_file,
+        )
+
         self.analyze_lazy_loaded_requirements = analyze_lazy_loaded_requirements
         self.analyze_lazy_loaded_requirements_for_code_file = analyze_lazy_loaded_requirements_for_code_file
 
-        self.work_dir = 'tmp/test_analyze_lazy_loaded_requirements/'
+        self.work_dir = "tmp/test_analyze_lazy_loaded_requirements/"
         os.makedirs(self.work_dir, exist_ok=True)
 
     def tearDown(self) -> None:
         super().tearDown()
         if os.path.exists(self.work_dir):
-            os.system(f'rm -rf {self.work_dir}')
+            os.system(f"rm -rf {self.work_dir}")
 
     def test_analyze_lazy_loaded_requirements_with_LazyLoader_calls(self):
-        code_content = '''
+        code_content = """
 from data_juicer.utils.lazy_loader import LazyLoader
 
 # Define some lazy-loaded packages
@@ -676,17 +736,13 @@ torch = LazyLoader('torch', package_name='torch',
 
 # Another usage
 numpy = LazyLoader('numpy', 'numpy')
-'''
-        expected_reqs = [
-            'transformers',
-            'torch @ https://github.com/pytorch/pytorch.git',
-            'numpy'
-        ]
+"""
+        expected_reqs = ["transformers", "torch @ https://github.com/pytorch/pytorch.git", "numpy"]
         result = self.analyze_lazy_loaded_requirements(code_content)
         self.assertEqual(sorted(result), sorted(expected_reqs))
 
     def test_analyze_lazy_loaded_requirements_with_check_packages_calls(self):
-        code_content = '''
+        code_content = """
 from data_juicer.utils.lazy_loader import LazyLoader
 
 # Using check_packages
@@ -695,13 +751,13 @@ LazyLoader.check_packages(package_specs=['torch>=1.8.0'])
 
 # Mixed usage
 LazyLoader.check_packages(['scipy'])
-'''
-        expected_reqs = ['numpy>=1.20.0', 'pandas>=1.3.0', 'torch>=1.8.0', 'scipy']
+"""
+        expected_reqs = ["numpy>=1.20.0", "pandas>=1.3.0", "torch>=1.8.0", "scipy"]
         result = self.analyze_lazy_loaded_requirements(code_content)
         self.assertEqual(sorted(result), sorted(expected_reqs))
 
     def test_analyze_lazy_loaded_requirements_mixed_usage(self):
-        code_content = '''
+        code_content = """
 from data_juicer.utils.lazy_loader import LazyLoader
 
 # Mixed usage of LazyLoader and check_packages
@@ -710,52 +766,52 @@ LazyLoader.check_packages(['numpy>=1.20.0'])
 torch = LazyLoader('torch',
                    package_url='https://github.com/pytorch/pytorch.git')
 LazyLoader.check_packages(package_specs=['pandas>=1.3.0'])
-'''
+"""
         expected_reqs = [
-            'transformers',
-            'numpy>=1.20.0',
-            'torch @ https://github.com/pytorch/pytorch.git',
-            'pandas>=1.3.0'
+            "transformers",
+            "numpy>=1.20.0",
+            "torch @ https://github.com/pytorch/pytorch.git",
+            "pandas>=1.3.0",
         ]
         result = self.analyze_lazy_loaded_requirements(code_content)
         self.assertEqual(sorted(result), sorted(expected_reqs))
 
     def test_analyze_lazy_loaded_requirements_for_code_file(self):
         # Create a temporary Python file
-        code_file = os.path.join(self.work_dir, 'temp_test_code.py')
-        with open(code_file, 'w') as f:
-            f.write('''
+        code_file = os.path.join(self.work_dir, "temp_test_code.py")
+        with open(code_file, "w") as f:
+            f.write("""
 from data_juicer.utils.lazy_loader import LazyLoader
 
 # Test code for file analysis
 transformers = LazyLoader('transformers', package_name='transformers')
 LazyLoader.check_packages(['numpy>=1.20.0'])
-''')
-        
-        expected_reqs = ['transformers', 'numpy>=1.20.0']
+""")
+
+        expected_reqs = ["transformers", "numpy>=1.20.0"]
         result = self.analyze_lazy_loaded_requirements_for_code_file(code_file)
         self.assertEqual(sorted(result), sorted(expected_reqs))
 
     def test_analyze_lazy_loaded_requirements_empty_code(self):
-        code_content = '''
+        code_content = """
 # Just some comments
 a = 1
 b = 2
-'''
+"""
         result = self.analyze_lazy_loaded_requirements(code_content)
         self.assertEqual(result, [])
 
     def test_analyze_lazy_loaded_requirements_no_LazyLoader_calls(self):
-        code_content = '''
+        code_content = """
 import numpy as np
 import pandas as pd
 
 def func():
     return "no LazyLoader calls here"
-'''
+"""
         result = self.analyze_lazy_loaded_requirements(code_content)
         self.assertEqual(result, [])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes a bug in `OPEnvManager._resolve_with_strategy()` where the LATEST conflict
resolution strategy incorrectly falls back to an unpinned (unconstrained) version
when the union of two conflicting version specifiers contains ranges without an
upper bound.

## Problem

When resolving conflicts like `numpy>=2.0` vs `numpy<1.5`, the union produces
`<1.5||>=2.0` (a UnionSpecifier with one unbounded range). The original code
breaks out of the loop when encountering any range with `max=None`, discarding
all version information and returning a Requirement with no version constraint.

This allows pip to install any version, potentially breaking both OPs.

## Fix

When a UnionSpecifier contains unbounded ranges (`max=None`), instead of falling
back to unpinned, we now use the highest lower bound (`min`) from those unbounded
ranges as the version constraint:

- `>=2.0 | <1.5` → `>=2.0` (highest min from unbounded ranges)
- `>1.23.0 | <1.22.0` → `>1.23.0`

Only when no lower bound exists at all (fully open range) does the fallback to
unpinned + warning remain.

## Tests

- Updated `test_conflict_resolution_latest_strategy_without_max` to reflect corrected behavior
- Added `test_conflict_resolution_latest_incompatible_uses_highest_min`
- Added `test_conflict_resolution_latest_multiple_unbounded_picks_max_min`
- Added `test_conflict_resolution_latest_unbounded_include_min_false`

All 60 tests in `test_op_env.py` pass.