### PR TITLE
fix: avoid requiring OpenCV for core package startup

### DIFF
--- a/data_juicer/ops/common/hawor_func.py
+++ b/data_juicer/ops/common/hawor_func.py
@@ -8,7 +8,6 @@ import sys
 from inspect import isfunction
 from typing import Callable, Dict, List, Optional, Tuple
 
-import cv2
 import numpy as np
 from tqdm import tqdm
 
@@ -16,6 +15,7 @@ from data_juicer.ops.common import hawor_constants as constants
 from data_juicer.ops.common.hawor_func_vit import vit
 from data_juicer.utils.lazy_loader import LazyLoader
 
+cv2 = LazyLoader("cv2", "opencv-contrib-python")
 torch = LazyLoader("torch")
 F = LazyLoader("torch.nn.functional")
 smplx = LazyLoader("smplx")

--- a/data_juicer/ops/mapper/export_to_lerobot_mapper.py
+++ b/data_juicer/ops/mapper/export_to_lerobot_mapper.py
@@ -4,7 +4,6 @@ import shutil
 import subprocess
 import uuid
 
-import cv2
 import numpy as np
 from loguru import logger
 
@@ -15,6 +14,7 @@ from ..base_op import OPERATORS, Mapper
 
 OP_NAME = "export_to_lerobot_mapper"
 
+cv2 = LazyLoader("cv2", "opencv-contrib-python")
 pa = LazyLoader("pyarrow", "pyarrow")
 pd = LazyLoader("pandas", "pandas")
 
@@ -471,8 +471,6 @@ class ExportToLeRobotMapper(Mapper):
         }
 
         try:
-            import cv2
-
             cap = cv2.VideoCapture(video_path)
             if cap.isOpened():
                 defaults["width"] = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))

--- a/data_juicer/ops/mapper/video_clip_reassembly_mapper.py
+++ b/data_juicer/ops/mapper/video_clip_reassembly_mapper.py
@@ -1,15 +1,17 @@
 import hashlib
 
-import cv2
 import numpy as np
 from loguru import logger
 
 from data_juicer.utils.constant import CameraCalibrationKeys, Fields, MetaKeys
 from data_juicer.utils.file_utils import load_numpy
+from data_juicer.utils.lazy_loader import LazyLoader
 
 from ..base_op import OPERATORS, Mapper
 
 OP_NAME = "video_clip_reassembly_mapper"
+
+cv2 = LazyLoader("cv2", "opencv-contrib-python")
 
 
 @OPERATORS.register_module(OP_NAME)

--- a/data_juicer/ops/mapper/video_trajectory_overlay_mapper.py
+++ b/data_juicer/ops/mapper/video_trajectory_overlay_mapper.py
@@ -1,14 +1,16 @@
 import os
 
-import cv2
 import numpy as np
 from loguru import logger
 
 from data_juicer.utils.constant import Fields, MetaKeys
+from data_juicer.utils.lazy_loader import LazyLoader
 
 from ..base_op import OPERATORS, Mapper
 
 OP_NAME = "video_trajectory_overlay_mapper"
+
+cv2 = LazyLoader("cv2", "opencv-contrib-python")
 
 
 @OPERATORS.register_module(OP_NAME)


### PR DESCRIPTION
## Summary

This PR avoids requiring OpenCV during core package startup by lazy-loading `cv2` in optional video/robotics modules.

Before this fix, installing the core wheel and running `dj-process --help` could fail because importing the operator registry reached modules with top-level `cv2` imports, while OpenCV is only part of optional vision dependencies.

## Changed Files

- `data_juicer/ops/common/hawor_func.py`
- `data_juicer/ops/mapper/export_to_lerobot_mapper.py`
- `data_juicer/ops/mapper/video_clip_reassembly_mapper.py`
- `data_juicer/ops/mapper/video_trajectory_overlay_mapper.py`

## Validation

Locally reproduced the PyPI publish smoke test without uploading:

```bash
uv run --no-project --with hatch hatch build -c
uv run --no-project --with twine twine check dist/*
uv run --no-project --python 3.10 --with ./dist/py_data_juicer-1.5.3-py3-none-any.whl python -c "import data_juicer; print(data_juicer.__version__)"
uv run --no-project --python 3.10 --with ./dist/py_data_juicer-1.5.3-py3-none-any.whl dj-process --help