### PR TITLE
fix: unblock ARM64 install by marking decord/torchcodec with platform markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ vision = [
     "scenedetect[opencv]",  # Scene detection
     "ultralytics",  # YOLO models
     "rembg",  # Background removal
-    "decord", # video/audio handling
+    "decord; (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'win32' and platform_machine == 'AMD64')", # video/audio handling (no aarch64/macOS py3.10+ wheel)
     "qwen-vl-utils==0.0.14",  # for Qwen-VL
     "ptlflow==0.4.1",  # optical flow models collection
     "timm==1.0.22",  # avoid importing issue in the latest v1.0.23
@@ -104,7 +104,7 @@ audio = [
     "resampy",
     "samplerate==0.1.0",
     "torchaudio",  # Audio processing with PyTorch
-    "torchcodec==0.7",
+    "torchcodec==0.7; (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'win32' and platform_machine == 'AMD64')", # only platforms with 0.7 wheels
     "soundfile",  # audio handling
     "ffmpeg-python",
     "audiomentations",

--- a/uv.lock
+++ b/uv.lock
@@ -1910,7 +1910,7 @@ name = "decord"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/79/936af42edf90a7bd4e41a6cac89c913d4b47fa48a26b042d5129a9242ee3/decord-0.6.0-py3-none-manylinux2010_x86_64.whl", hash = "sha256:51997f20be8958e23b7c4061ba45d0efcd86bffd5fe81c695d0befee0d442976", size = 13602299, upload-time = "2021-06-14T21:30:55.486Z" },
@@ -6282,7 +6282,7 @@ all = [
     { name = "coverage" },
     { name = "cudf-cu12", marker = "sys_platform == 'linux'" },
     { name = "dashscope" },
-    { name = "decord" },
+    { name = "decord", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
     { name = "diffusers" },
     { name = "docstring-parser" },
     { name = "easyocr" },
@@ -6343,7 +6343,7 @@ all = [
     { name = "toml" },
     { name = "torch" },
     { name = "torchaudio" },
-    { name = "torchcodec" },
+    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
     { name = "transformers" },
     { name = "ultralytics" },
     { name = "uvloop" },
@@ -6359,7 +6359,7 @@ audio = [
     { name = "samplerate" },
     { name = "soundfile" },
     { name = "torchaudio" },
-    { name = "torchcodec" },
+    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 dev = [
     { name = "black" },
@@ -6431,7 +6431,7 @@ tools = [
 ]
 vision = [
     { name = "av" },
-    { name = "decord" },
+    { name = "decord", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
     { name = "diffusers" },
     { name = "imagededup" },
     { name = "opencv-contrib-python" },
@@ -6470,8 +6470,8 @@ requires-dist = [
     { name = "dashscope", marker = "extra == 'ai-services'" },
     { name = "dashscope", marker = "extra == 'all'" },
     { name = "datasets", specifier = ">=4.7.0" },
-    { name = "decord", marker = "extra == 'all'" },
-    { name = "decord", marker = "extra == 'vision'" },
+    { name = "decord", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'all') or (platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'all')" },
+    { name = "decord", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'vision') or (platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'vision')" },
     { name = "dep-logic" },
     { name = "diffusers", marker = "extra == 'all'", specifier = ">=0.33.0" },
     { name = "diffusers", marker = "extra == 'vision'", specifier = ">=0.33.0" },
@@ -6613,8 +6613,8 @@ requires-dist = [
     { name = "torch", marker = "extra == 'generic'", specifier = "==2.8.0" },
     { name = "torchaudio", marker = "extra == 'all'" },
     { name = "torchaudio", marker = "extra == 'audio'" },
-    { name = "torchcodec", marker = "extra == 'all'", specifier = "==0.7" },
-    { name = "torchcodec", marker = "extra == 'audio'", specifier = "==0.7" },
+    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'all') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'all') or (platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'all')", specifier = "==0.7" },
+    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'audio') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'audio') or (platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'audio')", specifier = "==0.7" },
     { name = "tqdm" },
     { name = "transformers", marker = "extra == 'all'", specifier = "==4.57.1" },
     { name = "transformers", marker = "extra == 'generic'", specifier = "==4.57.1" },


### PR DESCRIPTION
## Background

Related issue: #982

Data-Juicer currently cannot install `[vision]`, `[audio]`, or `[all]` on Linux ARM64 (e.g. `ubuntu-24.04-arm`), and also has gaps on macOS x86_64, because two dependencies lack wheels for those platforms:

- `decord`: only `manylinux2010_x86_64` / `win_amd64` wheels; the macOS x86_64 wheels only cover cp36–cp38 (Data-Juicer requires `>=3.10`)
- `torchcodec==0.7`: only `manylinux_2_28_x86_64` / `macosx_11_0_arm64` / `win_amd64` wheels; no Linux aarch64 or macOS x86_64 wheel

This blocks users on ARM64 Linux and macOS x86_64 from installing any extra that transitively includes them.

## Change

Restrict both packages to platforms that actually ship pre-built wheels, instead of only excluding `aarch64`:

```toml
"decord; (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'win32' and platform_machine == 'AMD64')"
"torchcodec==0.7; (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'win32' and platform_machine == 'AMD64')"
```

Platform coverage after the change:

| package | Linux x86_64 | Linux aarch64 | macOS x86_64 | macOS arm64 | Windows x86_64 |
|---|---|---|---|---|---|
| `decord` | ✅ | ❌ | ❌ | ❌ | ✅ |
| `torchcodec==0.7` | ✅ | ❌ | ❌ | ✅ | ✅ |

- `decord` is an optional video backend in `video_utils.py` (`ffmpeg`/`av` are available as fallbacks).
- `torchcodec` is only used by two audio filters via `LazyLoader`.
- x86_64 Linux/Windows behavior is unchanged; macOS arm64 `torchcodec` is preserved (0.7 has a wheel).

## ARM64 CI verification

Tested on GitHub Actions `ubuntu-24.04-arm` (native `aarch64`):

| extra | before | after |
|---|---|---|
| core | ✅ | ✅ |
| `[nlp]` | ✅ | ✅ |
| `[distributed]` | ✅ | ✅ |
| `[generic]` | ✅ | ✅ |
| `[audio]` | ❌ torchcodec | ✅ |
| `[vision]` | ❌ decord | ✅ |
| `[all]` | ❌ | ✅ |

Notably, `[generic]` already installs fine on ARM64 (`vllm==0.11.0`, `cudf-cu12==25.10.0` have aarch64 wheels). The only blockers were `decord` and `torchcodec==0.7`.

## Notes

- `torchcodec` cannot be upgraded independently because 0.8+ requires `torch>=2.9`; Data-Juicer currently pins `torch==2.8.0`.
- On platforms without wheels, `decord`/`torchcodec` dependent operators are unavailable, but installation and other operators work.
