### PR TITLE
fix(mapper): drop visible split_pattern delimiters in text_chunk_mapper

### DIFF
--- a/data_juicer/ops/mapper/text_chunk_mapper.py
+++ b/data_juicer/ops/mapper/text_chunk_mapper.py
@@ -109,7 +109,7 @@ class TextChunkMapper(Mapper):
 
     def get_text_chunks(self, text, rank=None):
         if self.split_pattern is not None and self.max_len is None:
-            chunks = re.split(f"({self.split_pattern})", text)
+            chunks = re.split(self.split_pattern, text)
             chunks = [t for t in chunks if t.strip()]
         elif self.split_pattern is None and self.max_len is not None:
             tokens = text

--- a/data_juicer/ops/mapper/text_chunk_mapper.py
+++ b/data_juicer/ops/mapper/text_chunk_mapper.py
@@ -110,7 +110,7 @@ class TextChunkMapper(Mapper):
     def get_text_chunks(self, text, rank=None):
         if self.split_pattern is not None and self.max_len is None:
             chunks = re.split(self.split_pattern, text)
-            chunks = [t for t in chunks if t.strip()]
+            chunks = [t for t in chunks if t is not None and t.strip()]
         elif self.split_pattern is None and self.max_len is not None:
             tokens = text
             total_len = len(text)

--- a/tests/ops/mapper/test_text_chunk_mapper.py
+++ b/tests/ops/mapper/test_text_chunk_mapper.py
@@ -48,6 +48,26 @@ class TextChunkMapperTest(DataJuicerTestCaseBase):
         ]
         op = TextChunkMapper(split_pattern='\n')
         self._run_helper(op, ds_list, tgt_list)
+
+    def test_split_pattern_drops_visible_delimiters(self):
+        ds_list = [
+            {
+                'text': 'a_@@@_b_@@@_c'
+            },
+        ]
+        tgt_list = [
+            {
+                'text': 'a'
+            },
+            {
+                'text': 'b'
+            },
+            {
+                'text': 'c'
+            },
+        ]
+        op = TextChunkMapper(split_pattern='_@@@_')
+        self._run_helper(op, ds_list, tgt_list)
     
     def test_max_len_text_chunk(self):
         ds_list = [


### PR DESCRIPTION
Make text_chunk_mapper.split_pattern behave like a separator for visible delimiters such as _@@@_.

- Remove the capturing group around split_pattern in the split-pattern-only path so delimiters are no longer emitted as standalone chunks.
- Add a focused regression test proving visible delimiters are excluded.
- Verified: relevant non-tokenizer tests pass; tokenizer/API tests require OPENAI_API_KEY and are unaffected by this change.