### PR TITLE
feat(filter): support membership operators in general_field_filter

### DIFF
--- a/data_juicer/ops/filter/general_field_filter.py
+++ b/data_juicer/ops/filter/general_field_filter.py
@@ -60,6 +60,8 @@ class ExpressionTransformer(ast.NodeVisitor):
         ast.NotEq: lambda left_operand, right_operand: left_operand != right_operand,
         ast.GtE: lambda left_operand, right_operand: left_operand >= right_operand,
         ast.LtE: lambda left_operand, right_operand: left_operand <= right_operand,
+        ast.In: lambda left_operand, right_operand: left_operand in right_operand,
+        ast.NotIn: lambda left_operand, right_operand: left_operand not in right_operand,
     }
 
     def __init__(self, sample: Dict):
@@ -116,6 +118,15 @@ class ExpressionTransformer(ast.NodeVisitor):
 
     def visit_Constant(self, node: ast.Constant) -> Any:
         return node.value
+
+    def visit_List(self, node: ast.List) -> list:
+        return [self.visit(element) for element in node.elts]
+
+    def visit_Tuple(self, node: ast.Tuple) -> tuple:
+        return tuple(self.visit(element) for element in node.elts)
+
+    def visit_Set(self, node: ast.Set) -> set:
+        return {self.visit(element) for element in node.elts}
 
     def generic_visit(self, node: ast.AST) -> None:
         raise ValueError(f"Unsupported node type: {type(node).__name__}, details: {ast.dump(node)}")

--- a/data_juicer/ops/filter/general_field_filter.py
+++ b/data_juicer/ops/filter/general_field_filter.py
@@ -85,6 +85,10 @@ class ExpressionTransformer(ast.NodeVisitor):
             op = ops[i]
             right = comparators[i]
             if left is None or right is None:
+                if isinstance(op, ast.In):
+                    return False
+                if isinstance(op, ast.NotIn):
+                    return True
                 return False
             if not self._apply_op(op, left, right):
                 result = False

--- a/tests/ops/filter/test_general_field_filter.py
+++ b/tests/ops/filter/test_general_field_filter.py
@@ -85,7 +85,18 @@ class GeneralFieldFilterTest(DataJuicerTestCaseBase):
         op = GeneralFieldFilter(filter_condition="tag in allowed_tags and 'bad' not in text")
         self._run_general_field_filter(dataset, op, target_list)
 
-    def test_membership_missing_operand_is_false(self):
+    def test_membership_with_set_literal(self):
+        ds_list = [
+            {'text': 'sample1', 'lang': 'en'},
+            {'text': 'sample2', 'lang': 'fr'},
+            {'text': 'sample3', 'lang': 'zh'},
+        ]
+        target_list = [{'text': 'sample1'}, {'text': 'sample3'}]
+        dataset = Dataset.from_list(ds_list)
+        op = GeneralFieldFilter(filter_condition="lang in {'en', 'zh'}")
+        self._run_general_field_filter(dataset, op, target_list)
+
+    def test_membership_missing_operand(self):
         ds_list = [
             {'text': 'sample1', 'tag': 'news', 'allowed_tags': ['news']},
             {'text': 'sample2', 'tag': 'qa', 'allowed_tags': None},
@@ -94,6 +105,16 @@ class GeneralFieldFilterTest(DataJuicerTestCaseBase):
         target_list = [{'text': 'sample1'}]
         dataset = Dataset.from_list(ds_list)
         op = GeneralFieldFilter(filter_condition="tag in allowed_tags")
+        self._run_general_field_filter(dataset, op, target_list)
+
+    def test_notin_missing_operand(self):
+        ds_list = [
+            {'text': 'sample1', 'tag': 'news', 'allowed_tags': ['news']},
+            {'text': 'sample2', 'tag': None, 'allowed_tags': ['news']},
+        ]
+        target_list = [{'text': 'sample2'}]
+        dataset = Dataset.from_list(ds_list)
+        op = GeneralFieldFilter(filter_condition="tag not in allowed_tags")
         self._run_general_field_filter(dataset, op, target_list)
 
     def test_nested_field(self):

--- a/tests/ops/filter/test_general_field_filter.py
+++ b/tests/ops/filter/test_general_field_filter.py
@@ -62,6 +62,40 @@ class GeneralFieldFilterTest(DataJuicerTestCaseBase):
         op = GeneralFieldFilter(filter_condition="num <= 5")
         self._run_general_field_filter(dataset, op, target_list)
 
+    def test_membership_with_literal_containers(self):
+        ds_list = [
+            {'text': 'sample1', 'lang': 'en', 'domain': 'news'},
+            {'text': 'sample2', 'lang': 'fr', 'domain': 'news'},
+            {'text': 'sample3', 'lang': 'zh', 'domain': 'spam'},
+            {'text': 'sample4', 'lang': 'ja', 'domain': 'blog'},
+        ]
+        target_list = [{'text': 'sample1'}]
+        dataset = Dataset.from_list(ds_list)
+        op = GeneralFieldFilter(filter_condition="lang in ['en', 'zh'] and domain not in ('spam', 'ads')")
+        self._run_general_field_filter(dataset, op, target_list)
+
+    def test_membership_with_sample_field_and_string(self):
+        ds_list = [
+            {'text': 'clean sample', 'tag': 'news', 'allowed_tags': ['news', 'qa']},
+            {'text': 'bad sample', 'tag': 'qa', 'allowed_tags': ['news', 'qa']},
+            {'text': 'clean sample', 'tag': 'spam', 'allowed_tags': ['news', 'qa']},
+        ]
+        target_list = [{'text': 'clean sample'}]
+        dataset = Dataset.from_list(ds_list)
+        op = GeneralFieldFilter(filter_condition="tag in allowed_tags and 'bad' not in text")
+        self._run_general_field_filter(dataset, op, target_list)
+
+    def test_membership_missing_operand_is_false(self):
+        ds_list = [
+            {'text': 'sample1', 'tag': 'news', 'allowed_tags': ['news']},
+            {'text': 'sample2', 'tag': 'qa', 'allowed_tags': None},
+            {'text': 'sample3', 'tag': None, 'allowed_tags': ['news']},
+        ]
+        target_list = [{'text': 'sample1'}]
+        dataset = Dataset.from_list(ds_list)
+        op = GeneralFieldFilter(filter_condition="tag in allowed_tags")
+        self._run_general_field_filter(dataset, op, target_list)
+
     def test_nested_field(self):
         ds_list = [
             {'text': 'sample1', '__dj__meta__': {'a': 1}},


### PR DESCRIPTION
Allow general_field_filter users to write common membership expressions such as lang in ['en', 'zh'] or tag not in blacklist.

- Add ast.In and ast.NotIn to ExpressionTransformer._COMPARE_OPERATORS.
- Add visit_List, visit_Tuple, and visit_Set visitors for literal containers.
- Add tests for literal containers, sample-field membership, and missing-field behavior.
- Verified: uv run python -m unittest tests.ops.filter.test_general_field_filter (12/12 passed).