### PR TITLE
fix(analysis): convert boolean columns to int before histogram binning

### DIFF
--- a/data_juicer/analysis/column_wise_analysis.py
+++ b/data_juicer/analysis/column_wise_analysis.py
@@ -149,8 +149,15 @@ class ColumnWiseAnalysis:
                 subfig.set_facecolor("0.85")
 
             # numeric or string via nan. Apply different plot method for them.
+            # Boolean columns (numpy, pandas nullable, or pyarrow-backed) have
+            # a non-NaN `top` in overall_result but must be treated as numeric
+            # for histogram/boxplot — numpy.histogram does not support boolean
+            # subtraction, and wordcloud requires string keys.
+            is_bool = pd.api.types.is_bool_dtype(data)
             sampled_top = self.overall_result[column_name].get("top")
-            if pd.isna(sampled_top):
+            if pd.isna(sampled_top) or is_bool:
+                if is_bool:
+                    data = data.astype(int)
                 # numeric or numeric list -- draw histogram and box plot for
                 # this stat
                 percentiles = self.overall_result[column_name] if show_percentiles else None


### PR DESCRIPTION
  ## Summary                                                                                                                                                                   
  - `dj-analyze` crashes with `TypeError: numpy boolean subtract, the `-` operator, is not supported` when a stat column contains boolean values (e.g. `subplot_detected` from 
  `image_subplot_filter`)                                                                                                                                                      
  - `ColumnWiseAnalysis` routes boolean columns into the string branch (since `pd.isna(False)` is `False`), then calls `ax.hist()` on a boolean array                          
  - `numpy.histogram` computes `last_edge - first_edge` internally which is not supported on boolean arrays                                                                    
  - Fix: cast boolean columns to `int` (`True->1`, `False->0`) after `explode().infer_objects()`, before plotting                                                              
                                                                                                                                                                               
  ## Reproduction                                                                                                                                                              
  Run `dj-analyze` with `image_subplot_filter` in the process list.  