### PR TITLE
feat: add FusedSharedContextOp for batch-local context reuse

### DIFF
--- a/data_juicer/ops/__init__.py
+++ b/data_juicer/ops/__init__.py
@@ -29,6 +29,7 @@ with timing_context('Importing operator modules'):
         Pipeline,
         Selector,
     )
+    from .fused_shared_context_op import FusedSharedContextOp  # noqa: F401
     from .load import load_ops
     from .op_env import (
         OPEnvManager,
@@ -51,6 +52,7 @@ __all__ = [
     'OPERATORS',
     'TAGGING_OPS',
     'Pipeline',
+    'FusedSharedContextOp',
     'OPEnvSpec',
     'op_requirements_to_op_env_spec',
     'OPEnvManager',

--- a/data_juicer/ops/fused_shared_context_op.py
+++ b/data_juicer/ops/fused_shared_context_op.py
@@ -1,12 +1,4 @@
-"""
-FusedSharedContextOp - run batch-local ops with a shared temporary context.
-
-This op is an explicit fused operator for cases where several mapper/filter
-ops can reuse intermediate data such as words, lines, decoded images, decoded
-audio, decoded video, or sampled frames. It keeps the normal sequential
-pipeline semantics while making ``Fields.context`` available to every sub-op
-within the same batch stage.
-"""
+"""Run mapper/filter sub-ops with a batch-local shared context."""
 
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -29,9 +21,17 @@ OP_NAME = "fused_shared_context_op"
 class FusedSharedContextOp(Mapper):
     """Run mapper/filter sub-ops sequentially with shared batch context.
 
-    ``FusedSharedContextOp`` is intentionally manual: callers explicitly list
-    the sub-ops to run. It does not attempt to discover fusible ops or parallel
-    execution opportunities.
+    The context is owned by this fused stage. It is created once per input
+    row, kept aligned when filters drop rows, and removed from every batch
+    before the stage returns. Context values that own PyAV containers are
+    closed exactly once, including values belonging to rows dropped by an
+    inner filter or batches replaced by an inner mapper.
+
+    This operator is intentionally configured manually. Sub-ops that reuse a
+    context key must agree on what that key represents. In particular, a
+    mapper must not invalidate an already-cached value (for example, cached
+    lines after changing the source text) unless it also updates or removes
+    that context value.
     """
 
     _batched_op = True
@@ -46,10 +46,14 @@ class FusedSharedContextOp(Mapper):
     ):
         """
         Args:
-            batch_size: outer batch size for the fused stage.
-            fused_op_list: list of standard Data-Juicer op config dicts.
-            fused_ops: pre-built op instances, mainly for tests.
+            batch_size: Outer batch size for the fused stage.
+            fused_op_list: Standard Data-Juicer op config dictionaries.
+            fused_ops: Pre-built op instances, primarily for tests and
+                programmatic construction.
         """
+        if isinstance(batch_size, bool) or not isinstance(batch_size, int) or batch_size <= 0:
+            raise ValueError("FusedSharedContextOp: batch_size must be a positive integer.")
+
         kwargs["batch_size"] = batch_size
         super().__init__(*args, **kwargs)
 
@@ -58,6 +62,7 @@ class FusedSharedContextOp(Mapper):
 
         self.fused_op_list = list(fused_op_list or [])
         self.fused_ops = list(fused_ops) if fused_ops is not None else load_ops(self.fused_op_list)
+        self._validate_sub_ops()
 
         if any(op.accelerator == "cuda" for op in self.fused_ops):
             self.accelerator = "cuda"
@@ -71,54 +76,114 @@ class FusedSharedContextOp(Mapper):
         if not self.fused_ops:
             return samples
 
+        self._validate_batch(samples, "input batch")
+        if Fields.context in samples:
+            raise ValueError(
+                "FusedSharedContextOp owns Fields.context and does not accept "
+                "an input batch that already contains it."
+            )
         if self._batch_size(samples) == 0:
             return samples
 
+        tracked_batches = []
+        tracked_batch_ids = set()
+        tracked_contexts = []
+        tracked_context_ids = set()
+
         samples[Fields.context] = [{} for _ in range(self._batch_size(samples))]
+        self._track_context_ownership(
+            samples,
+            tracked_batches,
+            tracked_batch_ids,
+            tracked_contexts,
+            tracked_context_ids,
+        )
+
         try:
             for op in self.fused_ops:
+                previous_contexts = samples[Fields.context]
                 if isinstance(op, Mapper):
                     samples = self._run_mapper(op, samples, rank=rank)
-                elif isinstance(op, Filter):
-                    samples = self._run_filter(op, samples, rank=rank)
+                    samples = self._prepare_sub_op_result(previous_contexts, samples, op)
+                    self._track_context_ownership(
+                        samples,
+                        tracked_batches,
+                        tracked_batch_ids,
+                        tracked_contexts,
+                        tracked_context_ids,
+                    )
                 else:
-                    raise NotImplementedError(
-                        f"FusedSharedContextOp does not support OP [{op._name}] "
-                        f"of type [{type(op).__name__}]. Only Mapper and Filter "
-                        f"sub-ops are supported."
+                    samples = self._compute_filter(op, samples, rank=rank)
+                    samples = self._prepare_sub_op_result(previous_contexts, samples, op)
+                    self._track_context_ownership(
+                        samples,
+                        tracked_batches,
+                        tracked_batch_ids,
+                        tracked_contexts,
+                        tracked_context_ids,
+                    )
+                    keep_mask = self._filter_keep_mask(op, samples)
+                    samples = self._filter_batch(samples, keep_mask, op)
+                    self._track_context_ownership(
+                        samples,
+                        tracked_batches,
+                        tracked_batch_ids,
+                        tracked_contexts,
+                        tracked_context_ids,
                     )
 
                 if self._batch_size(samples) == 0:
                     break
             return samples
         finally:
-            if Fields.context in samples:
-                self._cleanup_contexts(samples[Fields.context])
-                samples.pop(Fields.context, None)
+            for batch in list(tracked_batches):
+                self._track_context_ownership(
+                    batch,
+                    tracked_batches,
+                    tracked_batch_ids,
+                    tracked_contexts,
+                    tracked_context_ids,
+                )
+            self._cleanup_contexts(tracked_contexts)
+            for batch in tracked_batches:
+                batch.pop(Fields.context, None)
 
     def _run_mapper(self, op, samples, rank=None):
         samples = self._ensure_meta_if_needed(samples, op)
         call_kwargs = self._build_call_kwargs(op.process, op, rank=rank, context=True)
         if op.is_batched_op():
-            result = op.process(samples, **call_kwargs)
-        else:
-            result = op.process_batched(samples, **call_kwargs)
-        return self._validate_batch_result(result, op)
+            return op.process(samples, **call_kwargs)
+        return op.process_batched(samples, **call_kwargs)
 
-    def _run_filter(self, op, samples, rank=None):
+    def _compute_filter(self, op, samples, rank=None):
+        samples = self._ensure_meta_if_needed(samples, op)
         samples = self._ensure_stats_if_needed(samples, op)
         call_kwargs = self._build_call_kwargs(op.compute_stats, op, rank=rank, context=True)
         if op.is_batched_op():
-            result = op.compute_stats(samples, **call_kwargs)
-        else:
-            result = op.compute_stats_batched(samples, **call_kwargs)
-        result = self._validate_batch_result(result, op)
+            return op.compute_stats(samples, **call_kwargs)
 
+        rows = []
+        for idx in range(self._batch_size(samples)):
+            sample = {key: values[idx] for key, values in samples.items()}
+            result = op.compute_stats_single(sample, **call_kwargs)
+            if result is None or not isinstance(result, dict):
+                result_type = type(result).__name__
+                raise ValueError(
+                    f"Filter sub-op [{op._name}] returned unsupported sample type "
+                    f"[{result_type}] inside FusedSharedContextOp."
+                )
+            rows.append(result)
+        return self._rows_to_batch(rows, op)
+
+    def _filter_keep_mask(self, op, samples):
         if op.is_batched_op():
-            keep_mask = list(op.process(result))
-        else:
-            keep_mask = list(op.process_batched(result))
-        return self._filter_batch(result, keep_mask, op)
+            return list(op.process(samples))
+
+        keep_mask = []
+        for idx in range(self._batch_size(samples)):
+            sample = {key: values[idx] for key, values in samples.items()}
+            keep_mask.append(op.process_single(sample))
+        return keep_mask
 
     def _build_call_kwargs(self, method, op, rank=None, context=False):
         kwargs = {}
@@ -128,14 +193,30 @@ class FusedSharedContextOp(Mapper):
             kwargs["rank"] = rank
         return kwargs
 
-    def _validate_batch_result(self, result, op):
-        if result is None:
-            raise ValueError(f"Sub-op [{op._name}] returned None inside FusedSharedContextOp.")
-        if not isinstance(result, dict):
+    def _prepare_sub_op_result(self, previous_contexts, result, op):
+        self._validate_batch(result, f"sub-op [{op._name}] result")
+        result_size = self._batch_size(result)
+
+        if Fields.context not in result:
+            if result_size == len(previous_contexts):
+                result[Fields.context] = previous_contexts
+            elif result_size == 0:
+                result[Fields.context] = []
+            else:
+                raise ValueError(
+                    f"Sub-op [{op._name}] changed the batch size from "
+                    f"[{len(previous_contexts)}] to [{result_size}] without "
+                    f"returning an aligned Fields.context column."
+                )
+
+        contexts = result[Fields.context]
+        if len(contexts) != result_size:
             raise ValueError(
-                f"Sub-op [{op._name}] returned unsupported batch type "
-                f"[{type(result).__name__}] inside FusedSharedContextOp."
+                f"Fields.context length [{len(contexts)}] does not match batch "
+                f"size [{result_size}] after sub-op [{op._name}]."
             )
+        if any(not isinstance(context, dict) for context in contexts):
+            raise ValueError(f"Sub-op [{op._name}] returned a non-dict Fields.context entry.")
         return result
 
     def _filter_batch(self, samples, keep_mask, op):
@@ -147,48 +228,48 @@ class FusedSharedContextOp(Mapper):
                 f"FusedSharedContextOp."
             )
 
-        dropped_contexts = []
-        if Fields.context in samples:
-            dropped_contexts = [ctx for ctx, keep in zip(samples[Fields.context], keep_mask) if not keep]
-        self._cleanup_contexts(dropped_contexts)
-
         kept_indices = [idx for idx, keep in enumerate(keep_mask) if keep]
         return {key: [values[idx] for idx in kept_indices] for key, values in samples.items()}
+
+    def _rows_to_batch(self, rows, op):
+        if not rows:
+            return {}
+        keys = list(rows[0].keys())
+        key_set = set(keys)
+        for row in rows[1:]:
+            if set(row.keys()) != key_set:
+                raise ValueError(
+                    f"Filter sub-op [{op._name}] returned inconsistent fields "
+                    f"across samples inside FusedSharedContextOp."
+                )
+        return {key: [row[key] for row in rows] for key in keys}
 
     def _ensure_meta_if_needed(self, samples, op):
         if not self._needs_meta(samples, op):
             return samples
-        num_samples = self._batch_size(samples)
-        if Fields.meta not in samples or samples[Fields.meta] is None or len(samples[Fields.meta]) == 0:
-            samples[Fields.meta] = [{} for _ in range(num_samples)]
-        elif len(samples[Fields.meta]) != num_samples:
-            raise ValueError(
-                f"Fields.meta length [{len(samples[Fields.meta])}] does not "
-                f"match batch size [{num_samples}] before sub-op [{op._name}] "
-                f"inside FusedSharedContextOp."
-            )
-        else:
-            for idx in range(num_samples):
-                if samples[Fields.meta][idx] is None:
-                    samples[Fields.meta][idx] = {}
-        return samples
+        return self._ensure_dict_column(samples, Fields.meta, op)
 
     def _ensure_stats_if_needed(self, samples, op):
         if not self._needs_stats(samples, op):
             return samples
+        return self._ensure_dict_column(samples, Fields.stats, op)
+
+    def _ensure_dict_column(self, samples, field, op):
         num_samples = self._batch_size(samples)
-        if Fields.stats not in samples or samples[Fields.stats] is None or len(samples[Fields.stats]) == 0:
-            samples[Fields.stats] = [{} for _ in range(num_samples)]
-        elif len(samples[Fields.stats]) != num_samples:
+        if field not in samples or samples[field] is None or len(samples[field]) == 0:
+            samples[field] = [{} for _ in range(num_samples)]
+        elif len(samples[field]) != num_samples:
             raise ValueError(
-                f"Fields.stats length [{len(samples[Fields.stats])}] does not "
-                f"match batch size [{num_samples}] before sub-op [{op._name}] "
-                f"inside FusedSharedContextOp."
+                f"{field} length [{len(samples[field])}] does not match batch "
+                f"size [{num_samples}] before sub-op [{op._name}] inside "
+                f"FusedSharedContextOp."
             )
         else:
             for idx in range(num_samples):
-                if samples[Fields.stats][idx] is None:
-                    samples[Fields.stats][idx] = {}
+                if samples[field][idx] is None:
+                    samples[field][idx] = {}
+                elif not isinstance(samples[field][idx], dict):
+                    raise ValueError(f"{field} entry [{idx}] must be a dict before sub-op [{op._name}].")
         return samples
 
     def _needs_meta(self, samples, op):
@@ -199,7 +280,7 @@ class FusedSharedContextOp(Mapper):
         if op._name in TAGGING_OPS.modules:
             return True
         output_columns = getattr(op, "_output_columns", []) or []
-        return any(str(col).startswith(Fields.meta) for col in output_columns)
+        return any(str(column).startswith(Fields.meta) for column in output_columns)
 
     def _needs_stats(self, samples, op):
         if Fields.stats in samples:
@@ -207,7 +288,37 @@ class FusedSharedContextOp(Mapper):
         if isinstance(op, Filter) and op._name not in NON_STATS_FILTERS.modules:
             return True
         output_columns = getattr(op, "_output_columns", []) or []
-        return any(str(col).startswith(Fields.stats) for col in output_columns)
+        return any(str(column).startswith(Fields.stats) for column in output_columns)
+
+    def _validate_sub_ops(self):
+        unsupported = [op for op in self.fused_ops if not isinstance(op, (Mapper, Filter))]
+        if unsupported:
+            names = ", ".join(f"{op._name} ({type(op).__name__})" for op in unsupported)
+            raise NotImplementedError(
+                f"FusedSharedContextOp supports only Mapper and Filter sub-ops; unsupported: {names}."
+            )
+
+    def _validate_batch(self, samples, description):
+        if not isinstance(samples, dict):
+            raise ValueError(
+                f"{description} has unsupported batch type [{type(samples).__name__}] inside FusedSharedContextOp."
+            )
+        if not samples:
+            return
+
+        expected_size = None
+        for key, values in samples.items():
+            try:
+                column_size = len(values)
+            except TypeError as error:
+                raise ValueError(f"Column [{key}] in {description} is not a sized batch column.") from error
+            if expected_size is None:
+                expected_size = column_size
+            elif column_size != expected_size:
+                raise ValueError(
+                    f"Column [{key}] length [{column_size}] does not match batch "
+                    f"size [{expected_size}] in {description}."
+                )
 
     def _batch_size(self, samples):
         if not samples:
@@ -215,26 +326,53 @@ class FusedSharedContextOp(Mapper):
         first_key = next(iter(samples.keys()))
         return len(samples[first_key])
 
-    def _cleanup_contexts(self, contexts: Iterable[Dict[str, Any]]):
-        for context in contexts:
-            if isinstance(context, dict):
-                for value in context.values():
-                    self._cleanup_context_value(value)
+    def _track_context_ownership(
+        self,
+        batch,
+        tracked_batches,
+        tracked_batch_ids,
+        tracked_contexts,
+        tracked_context_ids,
+    ):
+        batch_id = id(batch)
+        if batch_id not in tracked_batch_ids:
+            tracked_batch_ids.add(batch_id)
+            tracked_batches.append(batch)
 
-    def _cleanup_context_value(self, value):
+        for context in batch.get(Fields.context, []):
+            context_id = id(context)
+            if context_id not in tracked_context_ids:
+                tracked_context_ids.add(context_id)
+                tracked_contexts.append(context)
+
+    def _cleanup_contexts(self, contexts: Iterable[Dict[str, Any]]):
+        seen_value_ids = set()
+        for context in contexts:
+            for value in context.values():
+                self._cleanup_context_value(value, seen_value_ids)
+
+    def _cleanup_context_value(self, value, seen_value_ids):
+        value_id = id(value)
+        if value_id in seen_value_ids:
+            return
+        seen_value_ids.add(value_id)
+
         if isinstance(value, dict):
             for item in value.values():
-                self._cleanup_context_value(item)
+                self._cleanup_context_value(item, seen_value_ids)
             return
-        if isinstance(value, (list, tuple)):
+        if isinstance(value, (list, tuple, set)):
             for item in value:
-                self._cleanup_context_value(item)
+                self._cleanup_context_value(item, seen_value_ids)
             return
         if self._looks_like_av_container(value):
-            try:
-                video_streams = getattr(getattr(value, "streams", None), "video", None)
-                if video_streams:
+            video_streams = getattr(getattr(value, "streams", None), "video", None)
+            if video_streams:
+                try:
                     video_streams[0].close()
+                except Exception:
+                    pass
+            try:
                 value.close()
             except Exception:
                 pass
@@ -245,6 +383,7 @@ class FusedSharedContextOp(Mapper):
 
     def run(self, dataset, *, exporter=None, tracer=None):
         from data_juicer.core.data import NestedDataset
+        from data_juicer.utils.model_utils import free_models
 
         if not isinstance(dataset, NestedDataset):
             dataset = NestedDataset(dataset)
@@ -254,10 +393,13 @@ class FusedSharedContextOp(Mapper):
         for op in self.fused_ops:
             dataset = OP.run(op, dataset)
 
-        return dataset.map(
-            self.process_batched,
-            num_proc=self.runtime_np(),
-            with_rank=self.use_cuda(),
-            batch_size=self.batch_size,
-            desc=self._name + "_process",
-        )
+        try:
+            return dataset.map(
+                self.process_batched,
+                num_proc=self.runtime_np(),
+                with_rank=self.use_cuda(),
+                batch_size=self.batch_size,
+                desc=self._name + "_process",
+            )
+        finally:
+            free_models()

--- a/data_juicer/ops/fused_shared_context_op.py
+++ b/data_juicer/ops/fused_shared_context_op.py
@@ -1,0 +1,263 @@
+"""
+FusedSharedContextOp - run batch-local ops with a shared temporary context.
+
+This op is an explicit fused operator for cases where several mapper/filter
+ops can reuse intermediate data such as words, lines, decoded images, decoded
+audio, decoded video, or sampled frames. It keeps the normal sequential
+pipeline semantics while making ``Fields.context`` available to every sub-op
+within the same batch stage.
+"""
+
+from typing import Any, Dict, Iterable, List, Optional
+
+from data_juicer.ops.base_op import (
+    NON_STATS_FILTERS,
+    OP,
+    OPERATORS,
+    TAGGING_OPS,
+    Filter,
+    Mapper,
+)
+from data_juicer.ops.load import load_ops
+from data_juicer.utils.common_utils import check_op_method_param
+from data_juicer.utils.constant import Fields
+
+OP_NAME = "fused_shared_context_op"
+
+
+@OPERATORS.register_module(OP_NAME)
+class FusedSharedContextOp(Mapper):
+    """Run mapper/filter sub-ops sequentially with shared batch context.
+
+    ``FusedSharedContextOp`` is intentionally manual: callers explicitly list
+    the sub-ops to run. It does not attempt to discover fusible ops or parallel
+    execution opportunities.
+    """
+
+    _batched_op = True
+
+    def __init__(
+        self,
+        batch_size: int = 1,
+        fused_op_list: Optional[List[Dict[str, Dict[str, Any]]]] = None,
+        fused_ops: Optional[List[Any]] = None,
+        *args,
+        **kwargs,
+    ):
+        """
+        Args:
+            batch_size: outer batch size for the fused stage.
+            fused_op_list: list of standard Data-Juicer op config dicts.
+            fused_ops: pre-built op instances, mainly for tests.
+        """
+        kwargs["batch_size"] = batch_size
+        super().__init__(*args, **kwargs)
+
+        if fused_op_list is not None and fused_ops is not None:
+            raise ValueError("FusedSharedContextOp: provide either fused_op_list or fused_ops, not both.")
+
+        self.fused_op_list = list(fused_op_list or [])
+        self.fused_ops = list(fused_ops) if fused_ops is not None else load_ops(self.fused_op_list)
+
+        if any(op.accelerator == "cuda" for op in self.fused_ops):
+            self.accelerator = "cuda"
+
+        runtime_nps = [op.runtime_np() for op in self.fused_ops]
+        runtime_nps = [runtime_np for runtime_np in runtime_nps if runtime_np is not None]
+        if runtime_nps:
+            self.num_proc = min(runtime_nps)
+
+    def process_batched(self, samples, rank=None):
+        if not self.fused_ops:
+            return samples
+
+        if self._batch_size(samples) == 0:
+            return samples
+
+        samples[Fields.context] = [{} for _ in range(self._batch_size(samples))]
+        try:
+            for op in self.fused_ops:
+                if isinstance(op, Mapper):
+                    samples = self._run_mapper(op, samples, rank=rank)
+                elif isinstance(op, Filter):
+                    samples = self._run_filter(op, samples, rank=rank)
+                else:
+                    raise NotImplementedError(
+                        f"FusedSharedContextOp does not support OP [{op._name}] "
+                        f"of type [{type(op).__name__}]. Only Mapper and Filter "
+                        f"sub-ops are supported."
+                    )
+
+                if self._batch_size(samples) == 0:
+                    break
+            return samples
+        finally:
+            if Fields.context in samples:
+                self._cleanup_contexts(samples[Fields.context])
+                samples.pop(Fields.context, None)
+
+    def _run_mapper(self, op, samples, rank=None):
+        samples = self._ensure_meta_if_needed(samples, op)
+        call_kwargs = self._build_call_kwargs(op.process, op, rank=rank, context=True)
+        if op.is_batched_op():
+            result = op.process(samples, **call_kwargs)
+        else:
+            result = op.process_batched(samples, **call_kwargs)
+        return self._validate_batch_result(result, op)
+
+    def _run_filter(self, op, samples, rank=None):
+        samples = self._ensure_stats_if_needed(samples, op)
+        call_kwargs = self._build_call_kwargs(op.compute_stats, op, rank=rank, context=True)
+        if op.is_batched_op():
+            result = op.compute_stats(samples, **call_kwargs)
+        else:
+            result = op.compute_stats_batched(samples, **call_kwargs)
+        result = self._validate_batch_result(result, op)
+
+        if op.is_batched_op():
+            keep_mask = list(op.process(result))
+        else:
+            keep_mask = list(op.process_batched(result))
+        return self._filter_batch(result, keep_mask, op)
+
+    def _build_call_kwargs(self, method, op, rank=None, context=False):
+        kwargs = {}
+        if context and check_op_method_param(method, "context"):
+            kwargs["context"] = True
+        if op.accelerator == "cuda" and check_op_method_param(method, "rank"):
+            kwargs["rank"] = rank
+        return kwargs
+
+    def _validate_batch_result(self, result, op):
+        if result is None:
+            raise ValueError(f"Sub-op [{op._name}] returned None inside FusedSharedContextOp.")
+        if not isinstance(result, dict):
+            raise ValueError(
+                f"Sub-op [{op._name}] returned unsupported batch type "
+                f"[{type(result).__name__}] inside FusedSharedContextOp."
+            )
+        return result
+
+    def _filter_batch(self, samples, keep_mask, op):
+        num_samples = self._batch_size(samples)
+        if len(keep_mask) != num_samples:
+            raise ValueError(
+                f"Filter sub-op [{op._name}] returned keep mask length "
+                f"[{len(keep_mask)}], expected [{num_samples}] inside "
+                f"FusedSharedContextOp."
+            )
+
+        dropped_contexts = []
+        if Fields.context in samples:
+            dropped_contexts = [ctx for ctx, keep in zip(samples[Fields.context], keep_mask) if not keep]
+        self._cleanup_contexts(dropped_contexts)
+
+        kept_indices = [idx for idx, keep in enumerate(keep_mask) if keep]
+        return {key: [values[idx] for idx in kept_indices] for key, values in samples.items()}
+
+    def _ensure_meta_if_needed(self, samples, op):
+        if not self._needs_meta(samples, op):
+            return samples
+        num_samples = self._batch_size(samples)
+        if Fields.meta not in samples or samples[Fields.meta] is None or len(samples[Fields.meta]) == 0:
+            samples[Fields.meta] = [{} for _ in range(num_samples)]
+        elif len(samples[Fields.meta]) != num_samples:
+            raise ValueError(
+                f"Fields.meta length [{len(samples[Fields.meta])}] does not "
+                f"match batch size [{num_samples}] before sub-op [{op._name}] "
+                f"inside FusedSharedContextOp."
+            )
+        else:
+            for idx in range(num_samples):
+                if samples[Fields.meta][idx] is None:
+                    samples[Fields.meta][idx] = {}
+        return samples
+
+    def _ensure_stats_if_needed(self, samples, op):
+        if not self._needs_stats(samples, op):
+            return samples
+        num_samples = self._batch_size(samples)
+        if Fields.stats not in samples or samples[Fields.stats] is None or len(samples[Fields.stats]) == 0:
+            samples[Fields.stats] = [{} for _ in range(num_samples)]
+        elif len(samples[Fields.stats]) != num_samples:
+            raise ValueError(
+                f"Fields.stats length [{len(samples[Fields.stats])}] does not "
+                f"match batch size [{num_samples}] before sub-op [{op._name}] "
+                f"inside FusedSharedContextOp."
+            )
+        else:
+            for idx in range(num_samples):
+                if samples[Fields.stats][idx] is None:
+                    samples[Fields.stats][idx] = {}
+        return samples
+
+    def _needs_meta(self, samples, op):
+        if Fields.meta in samples:
+            return True
+        if getattr(op, "_requires_meta", False):
+            return True
+        if op._name in TAGGING_OPS.modules:
+            return True
+        output_columns = getattr(op, "_output_columns", []) or []
+        return any(str(col).startswith(Fields.meta) for col in output_columns)
+
+    def _needs_stats(self, samples, op):
+        if Fields.stats in samples:
+            return True
+        if isinstance(op, Filter) and op._name not in NON_STATS_FILTERS.modules:
+            return True
+        output_columns = getattr(op, "_output_columns", []) or []
+        return any(str(col).startswith(Fields.stats) for col in output_columns)
+
+    def _batch_size(self, samples):
+        if not samples:
+            return 0
+        first_key = next(iter(samples.keys()))
+        return len(samples[first_key])
+
+    def _cleanup_contexts(self, contexts: Iterable[Dict[str, Any]]):
+        for context in contexts:
+            if isinstance(context, dict):
+                for value in context.values():
+                    self._cleanup_context_value(value)
+
+    def _cleanup_context_value(self, value):
+        if isinstance(value, dict):
+            for item in value.values():
+                self._cleanup_context_value(item)
+            return
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                self._cleanup_context_value(item)
+            return
+        if self._looks_like_av_container(value):
+            try:
+                video_streams = getattr(getattr(value, "streams", None), "video", None)
+                if video_streams:
+                    video_streams[0].close()
+                value.close()
+            except Exception:
+                pass
+
+    def _looks_like_av_container(self, value):
+        cls = value.__class__
+        return cls.__name__ == "InputContainer" and cls.__module__.startswith("av.")
+
+    def run(self, dataset, *, exporter=None, tracer=None):
+        from data_juicer.core.data import NestedDataset
+
+        if not isinstance(dataset, NestedDataset):
+            dataset = NestedDataset(dataset)
+        if not self.fused_ops:
+            return dataset
+
+        for op in self.fused_ops:
+            dataset = OP.run(op, dataset)
+
+        return dataset.map(
+            self.process_batched,
+            num_proc=self.runtime_np(),
+            with_rank=self.use_cuda(),
+            batch_size=self.batch_size,
+            desc=self._name + "_process",
+        )

--- a/docs/operators/mapper/fused_shared_context_op.md
+++ b/docs/operators/mapper/fused_shared_context_op.md
@@ -1,0 +1,65 @@
+# fused_shared_context_op
+
+Runs mapper and filter operators sequentially in one batch stage while sharing a temporary per-sample context.
+
+The shared context lets compatible operators reuse expensive intermediate values, such as split lines, extracted words, decoded images/audio/video, and sampled video frames. The context is batch-local: it is never returned as an output column, and owned PyAV containers are closed when their row is filtered, when processing fails, or when the batch completes.
+
+在同一个批处理阶段中顺序执行 Mapper 和 Filter，并共享按样本保存的临时上下文。
+
+共享上下文可让兼容算子复用分行结果、分词结果、已解码的图像/音频/视频及采样视频帧等开销较大的中间值。上下文只在当前批次内有效，不会作为结果列返回；其中持有的 PyAV 容器会在样本被过滤、处理失败或批次完成时关闭。
+
+Type 算子类型: **mapper**
+
+Tags 标签: cpu, cuda, text, image, audio, video
+
+## 🔧 Parameter Configuration 参数配置
+
+| name 参数名 | type 类型 | default 默认值 | desc 说明 |
+|--------|------|--------|------|
+| `batch_size` | `int` | `1` | Outer batch size of the fused stage. Must be positive. |
+| `fused_op_list` | `Optional[List[Dict]]` | `None` | Ordered list of standard Data-Juicer operator configs. |
+
+## Usage 使用方式
+
+```yaml
+process:
+  - fused_shared_context_op:
+      batch_size: 128
+      fused_op_list:
+        - average_line_length_filter:
+            min_len: 10
+        - maximum_line_length_filter:
+            max_len: 10000
+```
+
+Both filters above use the same cached line split. Filters may drop rows, and later sub-ops receive the filtered batch.
+
+上述两个 Filter 会复用同一次文本分行结果。Filter 可以删除样本，后续子算子会收到过滤后的批次。
+
+## Safety contract 安全约束
+
+- Only Mapper and Filter sub-ops are supported.
+- Every returned top-level batch column must have the same row count.
+- The input must not already contain the reserved `Fields.context` column.
+- Context keys are shared only within one batch; there is no cross-batch cache.
+- Sub-ops that share a context key must use the same source semantics and compatible parameters.
+- Do not put a source-mutating Mapper between a context producer and consumer unless that Mapper also updates or removes the affected cached value. For example, cached lines are stale after changing the source text.
+- GPU/resource scheduling belongs to the outer fused operator. Set its resource options to cover all inner operators used by the stage.
+
+- 仅支持 Mapper 和 Filter 子算子。
+- 返回批次的所有顶层列必须具有相同的样本数。
+- 输入数据不得预先包含保留列 `Fields.context`。
+- 上下文仅在单个批次内共享，不支持跨批次缓存。
+- 共享同一上下文键的子算子必须采用一致的数据源语义及兼容参数。
+- 除非 Mapper 同时更新或删除受影响的缓存值，否则不要把修改数据源的 Mapper 放在上下文生产者与消费者之间。例如，修改原文本后，先前缓存的分行结果将失效。
+- GPU 和资源调度由外层融合算子负责；外层资源参数应覆盖阶段内所有子算子的需要。
+
+`fused_shared_context_op` differs from `general_fused_op` by making context ownership, alignment, and cleanup an explicit contract. It remains a manually configured optimization and does not perform automatic fusion planning.
+
+`fused_shared_context_op` 与 `general_fused_op` 的区别是：它显式约定了上下文的所有权、行对齐及资源清理行为。它仍是手工配置的优化，不会自动规划算子融合。
+
+## 🔗 related links 相关链接
+
+- [source code 源代码](../../../data_juicer/ops/fused_shared_context_op.py)
+- [unit test 单元测试](../../../tests/ops/test_fused_shared_context_op.py)
+- [Return operator list 返回算子列表](../../Operators.md)

--- a/tests/ops/test_fused_shared_context_op.py
+++ b/tests/ops/test_fused_shared_context_op.py
@@ -1,10 +1,18 @@
 import unittest
 
-from data_juicer.ops.base_op import OPERATORS, Filter, Mapper
+from data_juicer.ops.base_op import (
+    NON_STATS_FILTERS,
+    OPERATORS,
+    TAGGING_OPS,
+    Filter,
+    Mapper,
+)
+from data_juicer.ops.filter.average_line_length_filter import AverageLineLengthFilter
+from data_juicer.ops.filter.maximum_line_length_filter import MaximumLineLengthFilter
+from data_juicer.ops.filter.suffix_filter import SuffixFilter
 from data_juicer.ops.fused_shared_context_op import FusedSharedContextOp
 from data_juicer.ops.load import load_ops
-from data_juicer.utils.constant import Fields, InterVars
-from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
+from data_juicer.utils.constant import Fields, InterVars, StatsKeys
 
 
 class _SharedLinesContextFilter(Filter):
@@ -66,6 +74,93 @@ class _ContextAwareMapper(Mapper):
         return samples
 
 
+class _CountingText(str):
+    splitlines_count = 0
+
+    @classmethod
+    def reset_count(cls):
+        cls.splitlines_count = 0
+
+    def splitlines(self, *args, **kwargs):
+        type(self).splitlines_count += 1
+        return super().splitlines(*args, **kwargs)
+
+
+class _TaggingNonStatsFilter(Filter):
+    def compute_stats_single(self, sample, context=False):
+        sample[Fields.meta]["tagged"] = context
+        return sample
+
+    def process_single(self, sample):
+        return sample[Fields.meta]["tagged"]
+
+
+class _RegisteredTaggingNonStatsFilter(_TaggingNonStatsFilter):
+    pass
+
+
+class _ContainerContextMapper(Mapper):
+    _batched_op = True
+
+    def __init__(self, containers, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.containers = containers
+
+    def process_batched(self, samples, context=False):
+        if context:
+            for sample_context, container in zip(samples[Fields.context], self.containers):
+                sample_context[InterVars.loaded_videos] = {"nested": [container]}
+        return samples
+
+
+class _ReturnWithoutContextMapper(Mapper):
+    _batched_op = True
+
+    def process_batched(self, samples, context=False):
+        return {"text": [f"{text}|copied" for text in samples["text"]]}
+
+
+class _RaisingMapper(Mapper):
+    _batched_op = True
+
+    def process_batched(self, samples, context=False):
+        raise RuntimeError("expected test error")
+
+
+class _FakeVideoStream:
+    def __init__(self):
+        self.close_count = 0
+
+    def close(self):
+        self.close_count += 1
+
+
+class _FakeStreams:
+    def __init__(self, video_stream):
+        self.video = [video_stream]
+
+
+def _fake_container_init(self):
+    self.video_stream = _FakeVideoStream()
+    self.streams = _FakeStreams(self.video_stream)
+    self.close_count = 0
+
+
+def _fake_container_close(self):
+    self.close_count += 1
+
+
+FakeInputContainer = type(
+    "InputContainer",
+    (),
+    {
+        "__module__": "av.container.core",
+        "__init__": _fake_container_init,
+        "close": _fake_container_close,
+    },
+)
+
+
 class _RegisteredSharedLinesContextFilter(_SharedLinesContextFilter):
     pass
 
@@ -84,9 +179,50 @@ OPERATORS.register_module(
     _RegisteredContextAwareMapper,
     force=True,
 )
+OPERATORS.register_module(
+    "test_tagging_non_stats_filter",
+    _RegisteredTaggingNonStatsFilter,
+    force=True,
+)
+TAGGING_OPS.register_module(
+    "test_tagging_non_stats_filter",
+    _RegisteredTaggingNonStatsFilter,
+    force=True,
+)
+NON_STATS_FILTERS.register_module(
+    "test_tagging_non_stats_filter",
+    _RegisteredTaggingNonStatsFilter,
+    force=True,
+)
 
 
-class TestFusedSharedContextOp(DataJuicerTestCaseBase):
+class TestFusedSharedContextOp(unittest.TestCase):
+
+    def test_real_line_filters_reuse_context(self):
+        _CountingText.reset_count()
+        fused = FusedSharedContextOp(
+            fused_ops=[
+                AverageLineLengthFilter(min_len=0),
+                MaximumLineLengthFilter(min_len=0),
+            ],
+            accelerator="cpu",
+        )
+
+        result = fused.process_batched(
+            {
+                "text": [
+                    _CountingText("one\ntwo"),
+                    _CountingText("one\ntwo\nthree"),
+                ]
+            }
+        )
+
+        self.assertEqual(_CountingText.splitlines_count, 2)
+        self.assertEqual(
+            [stat[StatsKeys.max_line_length] for stat in result[Fields.stats]],
+            [3, 5],
+        )
+        self.assertNotIn(Fields.context, result)
 
     def test_shared_context_computed_once_across_filters(self):
         _SharedLinesContextFilter.reset_count()
@@ -124,6 +260,110 @@ class TestFusedSharedContextOp(DataJuicerTestCaseBase):
         self.assertEqual([meta["context_available"] for meta in result[Fields.meta]], [True, True])
         self.assertEqual(mapper.context_flags, [True])
         self.assertNotIn(Fields.context, result)
+
+    def test_non_batched_non_stats_filter(self):
+        fused = FusedSharedContextOp(
+            fused_ops=[SuffixFilter(suffixes=[".txt"])],
+            accelerator="cpu",
+        )
+
+        result = fused.process_batched(
+            {
+                "text": ["keep", "drop"],
+                Fields.suffix: [".txt", ".json"],
+            }
+        )
+
+        self.assertEqual(result["text"], ["keep"])
+        self.assertEqual(result[Fields.suffix], [".txt"])
+        self.assertNotIn(Fields.stats, result)
+        self.assertNotIn(Fields.context, result)
+
+    def test_tagging_filter_initializes_meta(self):
+        tagging_filter = _RegisteredTaggingNonStatsFilter()
+        fused = FusedSharedContextOp(
+            fused_ops=[tagging_filter],
+            accelerator="cpu",
+        )
+
+        result = fused.process_batched({"text": ["a", "b"]})
+
+        self.assertEqual(result[Fields.meta], [{"tagged": True}, {"tagged": True}])
+        self.assertNotIn(Fields.stats, result)
+
+    def test_mapper_result_without_context_keeps_owned_context(self):
+        mapper = _ContextAwareMapper()
+        fused = FusedSharedContextOp(
+            fused_ops=[
+                _SharedLinesContextFilter(stat_key="line_count"),
+                _ReturnWithoutContextMapper(),
+                mapper,
+            ],
+            accelerator="cpu",
+        )
+
+        result = fused.process_batched({"text": ["one\ntwo"]})
+
+        self.assertEqual(result["text"], ["one\ntwo|copied|mapped"])
+        self.assertEqual(result[Fields.meta][0]["context_available"], True)
+        self.assertNotIn(Fields.context, result)
+
+    def test_context_resources_closed_once_after_row_drop(self):
+        shared_container = FakeInputContainer()
+        fused = FusedSharedContextOp(
+            fused_ops=[
+                _ContainerContextMapper([shared_container, shared_container]),
+                _SharedLinesContextFilter(stat_key="line_count", min_value=2),
+            ],
+            accelerator="cpu",
+        )
+
+        result = fused.process_batched({"text": ["one", "one\ntwo"]})
+
+        self.assertEqual(result["text"], ["one\ntwo"])
+        self.assertEqual(shared_container.video_stream.close_count, 1)
+        self.assertEqual(shared_container.close_count, 1)
+
+    def test_context_resources_closed_on_error(self):
+        containers = [FakeInputContainer(), FakeInputContainer()]
+        fused = FusedSharedContextOp(
+            fused_ops=[
+                _ContainerContextMapper(containers),
+                _RaisingMapper(),
+            ],
+            accelerator="cpu",
+        )
+        samples = {"text": ["a", "b"]}
+
+        with self.assertRaisesRegex(RuntimeError, "expected test error"):
+            fused.process_batched(samples)
+
+        self.assertNotIn(Fields.context, samples)
+        for container in containers:
+            self.assertEqual(container.video_stream.close_count, 1)
+            self.assertEqual(container.close_count, 1)
+
+    def test_rejects_misaligned_batch_columns(self):
+        fused = FusedSharedContextOp(
+            fused_ops=[_ContextAwareMapper()],
+            accelerator="cpu",
+        )
+
+        with self.assertRaisesRegex(ValueError, "does not match batch size"):
+            fused.process_batched({"text": ["a", "b"], "other": [1]})
+
+    def test_rejects_preexisting_context_column(self):
+        fused = FusedSharedContextOp(
+            fused_ops=[_ContextAwareMapper()],
+            accelerator="cpu",
+        )
+
+        with self.assertRaisesRegex(ValueError, "owns Fields.context"):
+            fused.process_batched({"text": ["a"], Fields.context: [{}]})
+
+    def test_batch_size_must_be_positive(self):
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            FusedSharedContextOp(batch_size=0, fused_ops=[], accelerator="cpu")
 
     def test_load_ops_constructs_fused_shared_context_op(self):
         ops = load_ops(

--- a/tests/ops/test_fused_shared_context_op.py
+++ b/tests/ops/test_fused_shared_context_op.py
@@ -1,0 +1,162 @@
+import unittest
+
+from data_juicer.ops.base_op import OPERATORS, Filter, Mapper
+from data_juicer.ops.fused_shared_context_op import FusedSharedContextOp
+from data_juicer.ops.load import load_ops
+from data_juicer.utils.constant import Fields, InterVars
+from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
+
+
+class _SharedLinesContextFilter(Filter):
+    _batched_op = True
+    compute_count = 0
+
+    def __init__(
+        self,
+        stat_key="line_count",
+        min_value=0,
+        context_key=InterVars.lines,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.stat_key = stat_key
+        self.min_value = min_value
+        self.context_key = context_key
+        self.auto_op_parallelism = False
+        self.num_proc = 1
+
+    @classmethod
+    def reset_count(cls):
+        cls.compute_count = 0
+
+    def compute_stats_batched(self, samples, context=False):
+        for idx, stat in enumerate(samples[Fields.stats]):
+            if context and self.context_key in samples[Fields.context][idx]:
+                lines = samples[Fields.context][idx][self.context_key]
+            else:
+                type(self).compute_count += 1
+                lines = samples["text"][idx].splitlines()
+                if context:
+                    samples[Fields.context][idx][self.context_key] = lines
+            stat[self.stat_key] = len(lines)
+        return samples
+
+    def process_batched(self, samples):
+        return [stat[self.stat_key] >= self.min_value for stat in samples[Fields.stats]]
+
+
+class _ContextAwareMapper(Mapper):
+    _batched_op = True
+    _requires_meta = True
+
+    def __init__(self, context_key=InterVars.lines, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.context_key = context_key
+        self.context_flags = []
+        self.auto_op_parallelism = False
+        self.num_proc = 1
+
+    def process_batched(self, samples, context=False):
+        self.context_flags.append(context)
+        for idx, meta in enumerate(samples[Fields.meta]):
+            meta["context_enabled"] = context
+            meta["context_available"] = self.context_key in samples[Fields.context][idx]
+        samples["text"] = [f"{text}|mapped" for text in samples["text"]]
+        return samples
+
+
+class _RegisteredSharedLinesContextFilter(_SharedLinesContextFilter):
+    pass
+
+
+class _RegisteredContextAwareMapper(_ContextAwareMapper):
+    pass
+
+
+OPERATORS.register_module(
+    "test_shared_lines_context_filter",
+    _RegisteredSharedLinesContextFilter,
+    force=True,
+)
+OPERATORS.register_module(
+    "test_context_aware_mapper",
+    _RegisteredContextAwareMapper,
+    force=True,
+)
+
+
+class TestFusedSharedContextOp(DataJuicerTestCaseBase):
+
+    def test_shared_context_computed_once_across_filters(self):
+        _SharedLinesContextFilter.reset_count()
+        fused = FusedSharedContextOp(
+            fused_ops=[
+                _SharedLinesContextFilter(stat_key="lines_a"),
+                _SharedLinesContextFilter(stat_key="lines_b"),
+            ],
+            accelerator="cpu",
+        )
+
+        result = fused.process_batched({"text": ["one\ntwo", "one\ntwo\nthree"]})
+
+        self.assertEqual(_SharedLinesContextFilter.compute_count, 2)
+        self.assertEqual([stat["lines_a"] for stat in result[Fields.stats]], [2, 3])
+        self.assertEqual([stat["lines_b"] for stat in result[Fields.stats]], [2, 3])
+        self.assertNotIn(Fields.context, result)
+
+    def test_filter_drop_rows_and_downstream_mapper(self):
+        _SharedLinesContextFilter.reset_count()
+        mapper = _ContextAwareMapper()
+        fused = FusedSharedContextOp(
+            fused_ops=[
+                _SharedLinesContextFilter(stat_key="line_count", min_value=2),
+                mapper,
+            ],
+            accelerator="cpu",
+        )
+
+        result = fused.process_batched({"text": ["one", "one\ntwo", "one\ntwo\nthree"]})
+
+        self.assertEqual(result["text"], ["one\ntwo|mapped", "one\ntwo\nthree|mapped"])
+        self.assertEqual([stat["line_count"] for stat in result[Fields.stats]], [2, 3])
+        self.assertEqual([meta["context_enabled"] for meta in result[Fields.meta]], [True, True])
+        self.assertEqual([meta["context_available"] for meta in result[Fields.meta]], [True, True])
+        self.assertEqual(mapper.context_flags, [True])
+        self.assertNotIn(Fields.context, result)
+
+    def test_load_ops_constructs_fused_shared_context_op(self):
+        ops = load_ops(
+            [
+                {
+                    "fused_shared_context_op": {
+                        "batch_size": 2,
+                        "fused_op_list": [
+                            {"test_shared_lines_context_filter": {"stat_key": "lines_a"}},
+                            {"test_context_aware_mapper": {}},
+                        ],
+                    }
+                }
+            ]
+        )
+
+        self.assertEqual(len(ops), 1)
+        self.assertIsInstance(ops[0], FusedSharedContextOp)
+
+        result = ops[0].process_batched({"text": ["abc"]})
+        self.assertEqual(result["text"], ["abc|mapped"])
+        self.assertEqual(result[Fields.stats][0]["lines_a"], 1)
+        self.assertTrue(result[Fields.meta][0]["context_available"])
+
+    def test_empty_fused_op_returns_samples_unchanged(self):
+        fused = FusedSharedContextOp(fused_ops=[], accelerator="cpu")
+        samples = {"text": ["abc"]}
+
+        result = fused.process_batched(samples)
+
+        self.assertIs(result, samples)
+        self.assertNotIn(Fields.context, result)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Add `FusedSharedContextOp`, a manually configured batch-local fused operator that runs Mapper/Filter sub-ops sequentially while sharing a temporary per-sample `Fields.context`.

The main use case is avoiding repeated intermediate work—line splitting, word extraction, image/audio/video decoding, and sampled-frame generation—when compatible sub-ops in the same batch can reuse it.

This PR is independent from #1004. It does not add an automatic fusion planner or parallel execution.

## Why a separate operator

`GeneralFusedOP` already provides general sequential execution. This operator makes shared-context ownership an explicit contract:

- create one context dict per input row
- pass `context=True` only to sub-ops that support it
- keep context aligned when filters drop rows
- preserve the owned context when a mapper returns a replacement batch without the internal column
- clean every owned context on success and failure
- close nested/shared PyAV containers exactly once
- remove `Fields.context` from all returned and intermediate batches

## Supported behavior

- standard `fused_op_list` config through `load_ops`
- pre-built `fused_ops` for programmatic use/tests
- batched and non-batched Mapper/Filter sub-ops
- stats-producing and `NON_STATS_FILTERS`
- tagging filters that require `Fields.meta`
- sequential mapper results and filter row dropping
- CPU/CUDA rank forwarding where supported
- aligned batch/result validation and early unsupported-op validation

## Safety contract

This remains an explicit/manual optimization:

- only Mapper and Filter sub-ops are supported
- every top-level batch column must stay row-aligned
- input may not already contain the reserved `Fields.context` column
- shared context is batch-local; there is no cross-batch cache
- sub-ops sharing a context key must agree on its source semantics and parameters
- a source-mutating mapper must update/remove any cached value it invalidates
- outer fused-op resource settings must cover all inner sub-ops

User documentation and a YAML example are included in `docs/operators/mapper/fused_shared_context_op.md`.

## Validation

```bash
pytest -q \
  tests/ops/test_fused_shared_context_op.py \
  tests/ops/test_load.py \
  tests/ops/filter/test_average_line_length_filter.py \
  tests/ops/filter/test_maximum_line_length_filter.py \
  tests/ops/filter/test_suffix_filter.py \
  tests/ops/test_op_fusion_mapper_bug.py
# 31 passed

python -m compileall -q \
  data_juicer/ops/fused_shared_context_op.py \
  data_juicer/ops/__init__.py \
  tests/ops/test_fused_shared_context_op.py

python -m isort --check-only \
  data_juicer/ops/fused_shared_context_op.py \
  tests/ops/test_fused_shared_context_op.py

python -m black --check \
  data_juicer/ops/fused_shared_context_op.py \
  tests/ops/test_fused_shared_context_op.py

python -m flake8 data_juicer/ops/fused_shared_context_op.py
git diff --check
```

The focused tests include real line filters, non-batched/non-stats filters, tagging/meta initialization, returned replacement batches, row dropping, exception cleanup, nested/shared container cleanup, invalid batch alignment, and `load_ops` construction.
