### PR TITLE
Release/v1.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ for s in res_ds:
 <details open>
 <summary>[2026-07-17] Release v1.5.4: <b>HumanVBench Video OPs; Batch-local Stage Fusion; Robustness Fixes</b></summary>
 
-* 🧑‍🤝‍🧑 *HumanVBench Human-centric Video OPs* — Added 9 human-centric video understanding operators (human track extraction, active-speaker detection, audio ASR, speech emotion & age/gender detection, face demographic & attribute/emotion captioning, face-ratio filtering) for building HumanVBench-style pipelines (source install required for now; see the demo README for setup).
+* 🧑‍🤝‍🧑 *New OPs* — Added 9 human-centric video understanding operators (human track extraction, active-speaker detection, audio ASR, speech emotion & age/gender detection, face demographic & attribute/emotion captioning, face-ratio filtering) for building HumanVBench (CVPR'26)-style pipelines.
 * ⚡ *Batch-local Stage Fusion* — New `FusedSequentialBatchOp` fuses consecutive OPs within a batch to cut inter-op overhead and speed up sequential processing.
 * 🔧 *Robustness & Install Fixes* — Fixed Ray deduplicator shared-state handling, resolved a relative-path issue in the Ray checkpoint writer, made `clean_html_mapper` robust to null text values, handled boolean stat columns in `ColumnWiseAnalysis`, and unblocked ARM64 (aarch64) installation via precise `decord`/`torchcodec` platform markers.
 * 🧪 *Test Coverage & Cleanup* — Expanded tests for utility functions and model handling, plus assorted code cleanup.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ for s in res_ds:
 ## 📰 News
 
 <details open>
+<summary>[2026-07-17] Release v1.5.4: <b>HumanVBench Video OPs; Batch-local Stage Fusion; Robustness Fixes</b></summary>
+
+* 🧑‍🤝‍🧑 *HumanVBench Human-centric Video OPs* — Added 9 human-centric video understanding operators (human track extraction, active-speaker detection, audio ASR, speech emotion & age/gender detection, face demographic & attribute/emotion captioning, face-ratio filtering) for building HumanVBench-style pipelines (source install required for now; see the demo README for setup).
+* ⚡ *Batch-local Stage Fusion* — New `FusedSequentialBatchOp` fuses consecutive OPs within a batch to cut inter-op overhead and speed up sequential processing.
+* 🔧 *Robustness & Install Fixes* — Fixed Ray deduplicator shared-state handling, resolved a relative-path issue in the Ray checkpoint writer, made `clean_html_mapper` robust to null text values, handled boolean stat columns in `ColumnWiseAnalysis`, and unblocked ARM64 (aarch64) installation via precise `decord`/`torchcodec` platform markers.
+* 🧪 *Test Coverage & Cleanup* — Expanded tests for utility functions and model handling, plus assorted code cleanup.
+</details>
+
+<details open>
 <summary>[2026-06-26] Release v1.5.3: <b>VLA Ops Enhancements; Ray Repartition Pipeline; Scalability & Robustness</b></summary>
 
 * 🤖 *VLA Ops Enhancements* — Expanded embodied-AI processing with 10+ new/renamed VLA operators (camera calibration via DeepCalib/DroidCalib/MoGe, atomic action segmentation, hand action computation & motion smoothing, clip reassembly, trajectory overlay, LeRobot export) and a complete VLA pipeline demo.
@@ -96,7 +105,7 @@ for s in res_ds:
 * 🐳 *Stability & Robustness Fixes* — JSONStreamDatasource schema unification, OP env version resolution, FUSE-safe rmtree for PartitionedRayExecutor, deprecated model name updates, and num_proc handling fixes.
 </details>
 
-<details open>
+<details>
 <summary>[2026-05-29] Release v1.5.2: <b>Semantic LLM OPs, Cross-doc Line Dedup & Leaner Dependencies</b></summary>
 
 * 🧹 *New Deduplicator* — Added `DocumentLineDeduplicator` for cross-document line-level dedup, removing boilerplate lines (templates, copyright notices, navigation bars) by global document frequency.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -87,7 +87,7 @@ for s in res_ds:
 <details open>
 <summary>[2026-07-17] Release v1.5.4: <b>HumanVBench 视频算子；批内阶段算子融合；健壮性修复</b></summary>
 
-* 🧑‍🤝‍🧑 HumanVBench 以人为中心的视频算子 — 新增 9 个以人为中心的视频理解算子（人物轨迹提取、活跃说话人检测、音频 ASR、语音情绪与年龄/性别检测、人脸人口统计与属性/情绪描述、人脸占比过滤），用于构建 HumanVBench 风格的处理流水线（目前需源码安装，安装方式详见 demo README）。
+* 🧑‍🤝‍🧑 新算子 — 新增 9 个以人为中心的视频理解算子（人物轨迹提取、活跃说话人检测、音频 ASR、语音情绪与年龄/性别检测、人脸人口统计与属性/情绪描述、人脸占比过滤），用于构建 HumanVBench (CVPR'26) 风格的处理流水线。
 * ⚡ 批内阶段算子融合 — 新增 `FusedSequentialBatchOp`，在一个 batch 内融合连续算子，减少算子间开销，加速顺序处理。
 * 🔧 健壮性与安装修复 — 修复 Ray 去重算子的共享状态处理；修复 Ray checkpoint writer 的相对路径问题；使 `clean_html_mapper` 对 null 文本值更健壮；`ColumnWiseAnalysis` 支持处理布尔型统计列；并通过为 `decord`/`torchcodec` 添加精确的平台标记解锁 ARM64 (aarch64) 平台的安装。
 * 🧪 测试覆盖与清理 — 扩展工具函数与模型处理相关的测试，并进行若干代码清理。

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -85,6 +85,15 @@ for s in res_ds:
 
 ## 📰 动态
 <details open>
+<summary>[2026-07-17] Release v1.5.4: <b>HumanVBench 视频算子；批内阶段算子融合；健壮性修复</b></summary>
+
+* 🧑‍🤝‍🧑 HumanVBench 以人为中心的视频算子 — 新增 9 个以人为中心的视频理解算子（人物轨迹提取、活跃说话人检测、音频 ASR、语音情绪与年龄/性别检测、人脸人口统计与属性/情绪描述、人脸占比过滤），用于构建 HumanVBench 风格的处理流水线（目前需源码安装，安装方式详见 demo README）。
+* ⚡ 批内阶段算子融合 — 新增 `FusedSequentialBatchOp`，在一个 batch 内融合连续算子，减少算子间开销，加速顺序处理。
+* 🔧 健壮性与安装修复 — 修复 Ray 去重算子的共享状态处理；修复 Ray checkpoint writer 的相对路径问题；使 `clean_html_mapper` 对 null 文本值更健壮；`ColumnWiseAnalysis` 支持处理布尔型统计列；并通过为 `decord`/`torchcodec` 添加精确的平台标记解锁 ARM64 (aarch64) 平台的安装。
+* 🧪 测试覆盖与清理 — 扩展工具函数与模型处理相关的测试，并进行若干代码清理。
+</details>
+
+<details open>
 <summary>[2026-06-26] Release v1.5.3: <b>VLA 算子升级；Ray 重分区管道；可扩展性与健壮性</b></summary>
 
 * 🤖 VLA 算子升级 — 新增/重命名 10+ 个 VLA 算子（DeepCalib/DroidCalib/MoGe 相机标定、原子动作分割、手部动作计算与运动平滑、片段重组、轨迹叠加、LeRobot 导出），并提供完整的 VLA pipeline 示例。
@@ -94,7 +103,7 @@ for s in res_ds:
 * 🐳 稳定性与健壮性修复 — JSONStreamDatasource 跨批次 schema 统一、OP 环境版本解析、PartitionedRayExecutor FUSE 安全 rmtree、废弃模型名更新、num_proc 处理修复等。
 </details>
 
-<details open>
+<details>
 <summary>[2026-05-29] Release v1.5.2: <b>语义化 LLM 算子；跨文档行级去重；更轻量的依赖</b></summary>
 
 - 🧹 新增去重算子：DocumentLineDeduplicator 支持跨文档的行级去重，依据全局文档频率识别并移除模板文本、版权声明、导航栏等样板行。

--- a/data_juicer/__init__.py
+++ b/data_juicer/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 
 import sys
 

--- a/data_juicer/ops/mapper/video_human_tracks_extraction_mapper.py
+++ b/data_juicer/ops/mapper/video_human_tracks_extraction_mapper.py
@@ -4,7 +4,6 @@ import pickle
 
 import numpy as np
 import tqdm
-from scipy import signal
 
 from data_juicer.utils.ASD_mapper_utils import (
     detect_and_mark_anomalies,
@@ -24,6 +23,7 @@ from ..base_op import OPERATORS, Mapper
 from ..op_fusion import LOADED_VIDEOS
 
 torch = LazyLoader("torch")
+signal = LazyLoader("scipy.signal", "scipy")
 
 OP_NAME = "video_human_tracks_extraction_mapper"
 

--- a/data_juicer/utils/ASD_mapper_utils.py
+++ b/data_juicer/utils/ASD_mapper_utils.py
@@ -6,8 +6,6 @@ import subprocess
 
 import numpy as np
 import tqdm
-from scipy.interpolate import interp1d
-from scipy.io import wavfile
 
 from data_juicer.utils.lazy_loader import LazyLoader
 
@@ -15,6 +13,8 @@ cv2 = LazyLoader("cv2", "opencv-contrib-python")
 mp = LazyLoader("moviepy")
 python_speech_features = LazyLoader("python_speech_features")
 torch = LazyLoader("torch")
+scipy_interpolate = LazyLoader("scipy.interpolate", "scipy")
+wavfile = LazyLoader("scipy.io.wavfile", "scipy")
 DeepFace = None  # lazy loaded below
 open_video = None  # lazy loaded below
 
@@ -140,7 +140,7 @@ def track_shot(sceneFaces, numFailedDet=8, minTrack=10):
             frameI = np.arange(frameNum[0], frameNum[-1] + 1)
             bboxesI = []
             for ij in range(0, 4):
-                interpfn = interp1d(frameNum, bboxes[:, ij])
+                interpfn = scipy_interpolate.interp1d(frameNum, bboxes[:, ij])
                 bboxesI.append(interpfn(frameI))
             bboxesI = np.stack(bboxesI, axis=1)
             if max(np.mean(bboxesI[:, 2] - bboxesI[:, 0]), np.mean(bboxesI[:, 3] - bboxesI[:, 1])) > 1:

--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -491,6 +491,13 @@ def prepare_api_model(
             pass
 
         try:
+            return transformers.AutoTokenizer.from_pretrained(
+                pretrained_model_name_or_path=check_model_home(model), **processor_config
+            )
+        except Exception:
+            pass
+
+        try:
             processor = transformers.AutoProcessor.from_pretrained(
                 pretrained_model_name_or_path=check_model_home(model), **processor_config
             )

--- a/demos/video_humanvbench_simple/README.md
+++ b/demos/video_humanvbench_simple/README.md
@@ -29,6 +29,16 @@ This is the operator contribution page for the paper: **HumanVBench: Probing Hum
 | `video_captioning_face_attribute_emotion_mapper` | mapper | Face attribute/emotion captioning via VideoLLaMA3. |
 | `video_active_speaker_detect_mapper` | mapper | Active speaker detection via Light-ASD. |
 
+## Installation
+
+> **Note:** These OPs need third-party patches/models under `thirdparty/humanvbench_models/`, so a **source install** is required for now.
+
+```shell
+git clone https://github.com/datajuicer/data-juicer.git
+cd data-juicer
+pip install -e .
+```
+
 ## Quick Start
 
 Since HumanVBench operators involve modifications to external repositories, these adjusted repositories are stored in `thirdparty/humanvbench_models`.

--- a/demos/video_humanvbench_simple/README_ZH.md
+++ b/demos/video_humanvbench_simple/README_ZH.md
@@ -29,6 +29,16 @@
 | `video_captioning_face_attribute_emotion_mapper` | mapper | 通过 VideoLLaMA3 生成面部属性/情感描述。 |
 | `video_active_speaker_detect_mapper` | mapper | 通过 Light-ASD 检测活跃说话者。 |
 
+## 安装
+
+> **注意：** 这些算子需要 `thirdparty/humanvbench_models/` 下的第三方补丁/模型，目前需**源码安装**。
+
+```shell
+git clone https://github.com/datajuicer/data-juicer.git
+cd data-juicer
+pip install -e .
+```
+
 ## 快速开始
 
 由于 HumanVBench 算子涉及外部仓库的修改，这些经过调整的仓库存储在 `thirdparty/humanvbench_models`。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ vision = [
     "qwen-vl-utils==0.0.14",  # for Qwen-VL
     "ptlflow==0.4.1",  # optical flow models collection
     "timm==1.0.22",  # avoid importing issue in the latest v1.0.23
-    "protobuf<=3.20.3",  # timm->wandb pb2 code breaks on protobuf>=4 (Descriptors cannot be created directly)
     # --- HumanVBench (CVPR 2026) face/video ops ---
     # These ops additionally need ffmpeg/ffprobe binaries on PATH (VideoLLaMA3
     # video loading) and a flash-attn build matching the local torch/CUDA; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ vision = [
     "tf-keras==2.21.0",  # required by deepface on TensorFlow>=2.16
     "imageio>=2.37",  # required by VideoLLaMA3 remote code
     "imageio-ffmpeg>=0.6",  # ffmpeg backend for imageio
+    "scipy",  # signal/interpolation/wavfile for face-track ASD ops
 ]
 
 # Natural Language Processing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ dev = [
     "myst_parser",
     "linkify-it-py",
     "recommonmark",
-    "wandb<=0.19.0",
+    "wandb>=0.19.11,<0.22",  # >=0.19.11 lifts protobuf cap to <7, compatible with tensorflow 2.21 (protobuf>=6.31); old <=0.19.0 pin (added in #512 to dodge a 0.19.x bug) forced protobuf<6 and clashed with TF
     "fire",
     "click",
     "toml",  # for yapf configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ vision = [
     "qwen-vl-utils==0.0.14",  # for Qwen-VL
     "ptlflow==0.4.1",  # optical flow models collection
     "timm==1.0.22",  # avoid importing issue in the latest v1.0.23
+    "protobuf<=3.20.3",  # timm->wandb pb2 code breaks on protobuf>=4 (Descriptors cannot be created directly)
     # --- HumanVBench (CVPR 2026) face/video ops ---
     # These ops additionally need ffmpeg/ffprobe binaries on PATH (VideoLLaMA3
     # video loading) and a flash-attn build matching the local torch/CUDA; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,6 @@ audio = [
     "ffmpeg-python",
     "audiomentations",
     "funasr==1.3.14",  # SenseVoice-based ASR / speech-emotion ops (HumanVBench)
-    "modelscope>=1.38.1",  # resolve SenseVoiceSmall snapshot for funasr (HumanVBench)
 ]
 
 # Distributed Computing

--- a/tests/ops/mapper/test_text_tagging_by_prompt_mapper.py
+++ b/tests/ops/mapper/test_text_tagging_by_prompt_mapper.py
@@ -5,13 +5,13 @@ from data_juicer.utils.resource_utils import is_cuda_available
 from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
 
 def check_string_in_list(string_list, output):
-    if not string_list: 
+    if not string_list:
         assert False, "输入的列表不能是空的"
-    
+
     for string in string_list:
         if string in output:
             return
-        
+
     assert False, f"没有字符串在输出中"
 
 


### PR DESCRIPTION
Release v1.5.4.

- Bump version to `1.5.4`
- Update the News section in `README.md` / `README_ZH.md` with v1.5.4 release notes

Rebased on the latest `main` (includes #938, #979, #1013). Verified imports and `dj-process --help` succeed with all new OPs.

Full release notes will be published on the GitHub Releases page.

**Full Changelog:** v1.5.3...v1.5.4
