### PR TITLE
feat: support HDFS protocol for dataset loading and exporting

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -949,15 +949,16 @@ def init_setup_from_cfg(cfg: Namespace, load_configs_only=False):
     :param cfg: an updated cfg
     """
 
-    # Handle S3 paths differently from local paths
-    if cfg.export_path.startswith("s3://"):
-        # For S3 paths, keep as-is (don't use os.path.abspath)
+    # Handle remote paths (S3/HDFS) differently from local paths
+    _is_remote = cfg.export_path.startswith("s3://") or cfg.export_path.startswith("hdfs://")
+    if _is_remote:
+        # For remote paths, keep as-is (don't use os.path.abspath)
         # If work_dir is not provided, use a default local directory for logs/checkpoints
         if cfg.work_dir is None:
-            # Use a default local work directory for S3 exports
+            # Use a default local work directory for remote exports
             # This is where logs, checkpoints, and other local artifacts will be stored
             cfg.work_dir = os.path.abspath("./outputs")
-            logger.info(f"Using default work_dir [{cfg.work_dir}] for S3 export_path [{cfg.export_path}]")
+            logger.info(f"Using default work_dir [{cfg.work_dir}] for remote export_path [{cfg.export_path}]")
     else:
         # For local paths, convert to absolute path
         cfg.export_path = os.path.abspath(cfg.export_path)
@@ -970,11 +971,12 @@ def init_setup_from_cfg(cfg: Namespace, load_configs_only=False):
 
     timestamp = time.strftime("%Y%m%d%H%M%S", time.localtime(time.time()))
     if not load_configs_only:
-        # For S3 paths, use a simplified export path for log filename
-        if cfg.export_path.startswith("s3://"):
-            # Extract bucket and key from S3 path for log filename
-            s3_path_parts = cfg.export_path.replace("s3://", "").split("/", 1)
-            export_rel_path = s3_path_parts[1] if len(s3_path_parts) > 1 else s3_path_parts[0]
+        # For remote paths, use a simplified export path for log filename
+        if _is_remote:
+            # Extract path after scheme prefix for log filename
+            scheme = "s3://" if cfg.export_path.startswith("s3://") else "hdfs://"
+            remote_parts = cfg.export_path.replace(scheme, "").split("/", 1)
+            export_rel_path = remote_parts[1] if len(remote_parts) > 1 else remote_parts[0]
         else:
             export_rel_path = os.path.relpath(cfg.export_path, start=cfg.work_dir)
 

--- a/data_juicer/core/data/load_strategy.py
+++ b/data_juicer/core/data/load_strategy.py
@@ -13,6 +13,11 @@ from data_juicer.core.data.config_validator import ConfigValidator
 from data_juicer.download.downloader import validate_snapshot_format
 from data_juicer.format.formatter import unify_format
 from data_juicer.format.load import load_formatter
+from data_juicer.utils.hdfs_utils import (
+    create_pyarrow_hdfs_filesystem,
+    strip_hdfs_scheme,
+    validate_hdfs_path,
+)
 from data_juicer.utils.s3_utils import create_pyarrow_s3_filesystem, validate_s3_path
 
 # based on executor type and data source type, use different
@@ -545,6 +550,115 @@ class DefaultS3DataLoadStrategy(DefaultDataLoadStrategy):
             )
 
 
+@DataLoadStrategyRegistry.register("default", "remote", "hdfs")
+class DefaultHdfsDataLoadStrategy(DefaultDataLoadStrategy):
+    """
+    data load strategy for HDFS datasets for LocalExecutor (default executor).
+
+    Creates a PyArrow HadoopFileSystem with user-supplied config (host, port,
+    user, kerb_ticket, extra_conf), wraps it via fsspec ArrowFSWrapper, and
+    passes it as ``filesystem`` in storage_options — consistent with how the
+    Exporter handles HDFS export paths.
+    """
+
+    CONFIG_VALIDATION_RULES = {
+        "required_fields": ["path"],
+        "optional_fields": [
+            "format",
+            "hdfs_host",
+            "hdfs_port",
+            "hdfs_user",
+            "hdfs_kerb_ticket",
+            "hdfs_extra_conf",
+        ],
+        "field_types": {"path": str},
+        "custom_validators": {
+            "path": lambda x: x.startswith("hdfs://"),
+        },
+    }
+
+    def load_data(self, **kwargs):
+        import datasets
+        from fsspec.implementations.arrow import ArrowFSWrapper
+
+        from data_juicer.format.formatter import unify_format
+        from data_juicer.utils.hdfs_utils import (
+            create_pyarrow_hdfs_filesystem,
+            validate_hdfs_path,
+        )
+
+        path = self.ds_config["path"]
+        validate_hdfs_path(path)
+
+        load_data_np = kwargs.get("num_proc", 1)
+
+        # Get config values with defaults
+        text_keys = getattr(self.cfg, "text_keys", ["text"])
+
+        logger.info(f"Loading dataset from HDFS: {path}")
+
+        # Determine file format from extension or config
+        file_extension_map = {
+            ".json": "json",
+            ".jsonl": "json",
+            ".txt": "text",
+            ".csv": "csv",
+            ".tsv": "csv",
+            ".parquet": "parquet",
+        }
+        data_format = self.ds_config.get("format", None)
+        valid_formats = set(file_extension_map.values())
+        if data_format is None or data_format not in valid_formats:
+            # try to interpret it as an extension/suffix, else auto-detect from path
+            suffix = None
+            if data_format is not None:
+                suffix = os.path.splitext(data_format)[1] or ("." + data_format)
+            if suffix in file_extension_map:
+                data_format = file_extension_map[suffix]
+            else:
+                file_extension = os.path.splitext(path)[1].lower()
+                data_format = file_extension_map.get(file_extension, "json")
+        logger.info(f"Detected format: {data_format} for HDFS path: {path}")
+
+        # Build storage_options using ArrowFSWrapper, consistent with
+        # Exporter's HDFS handling (exporter.py L139-158).
+        # create_pyarrow_hdfs_filesystem constructs a configured
+        # pyarrow.fs.HadoopFileSystem; ArrowFSWrapper adapts it for fsspec.
+        hdfs_pyarrow_fs = create_pyarrow_hdfs_filesystem(self.ds_config)
+        wrapped_fs = ArrowFSWrapper(hdfs_pyarrow_fs)
+        storage_options = {"filesystem": wrapped_fs}
+
+        logger.info(f"Using HDFS ArrowFSWrapper for path: {path}")
+
+        try:
+            ds = datasets.load_dataset(
+                data_format,
+                data_files=path,
+                storage_options=storage_options,
+                **kwargs,
+            )
+            # Handle DatasetDict (multiple splits) vs Dataset (single)
+            if isinstance(ds, datasets.DatasetDict):
+                from data_juicer.core.data import NestedDataset
+
+                ds = NestedDataset(datasets.concatenate_datasets([d for d in ds.values()]))
+            else:
+                from data_juicer.core.data import NestedDataset
+
+                ds = NestedDataset(ds)
+
+            # Unify format
+            ds = unify_format(ds, text_keys=text_keys, num_proc=load_data_np, global_cfg=self.cfg)
+            return ds
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load {data_format} data from HDFS path {path}. "
+                f"Ensure your Hadoop environment (HADOOP_HOME, JAVA_HOME, CLASSPATH, "
+                f"ARROW_LIBHDFS_DIR) is configured on the machine running the local executor. "
+                f"Error: {str(e)}"
+            )
+
+
 @DataLoadStrategyRegistry.register("ray", "remote", "s3")
 class RayS3DataLoadStrategy(RayDataLoadStrategy):
     """
@@ -667,5 +781,143 @@ class RayS3DataLoadStrategy(RayDataLoadStrategy):
             raise RuntimeError(
                 f"Failed to load {data_format} data from S3 path {path}. "
                 f"Ensure your AWS credentials are configured. "
+                f"Error: {str(e)}"
+            )
+
+
+@DataLoadStrategyRegistry.register("ray", "remote", "hdfs")
+class RayHdfsDataLoadStrategy(RayDataLoadStrategy):
+    """
+    data load strategy for HDFS datasets for RayExecutor.
+    Uses PyArrow's HadoopFileSystem to read from HDFS.
+
+    Requires a working Hadoop/JVM environment on every Ray node
+    (HADOOP_HOME, JAVA_HOME, CLASSPATH, ARROW_LIBHDFS_DIR).
+    """
+
+    CONFIG_VALIDATION_RULES = {
+        "required_fields": ["path"],
+        "optional_fields": [
+            "format",
+            "hdfs_host",
+            "hdfs_port",
+            "hdfs_user",
+            "hdfs_kerb_ticket",
+            "hdfs_extra_conf",
+        ],
+        "field_types": {"path": str},
+        "custom_validators": {
+            "path": lambda x: x.startswith("hdfs://"),
+        },
+    }
+
+    def load_data(self, **kwargs):
+        from data_juicer.core.data.ray_dataset import RayDataset
+
+        override_num_blocks = kwargs.pop("override_num_blocks", None)
+
+        path = self.ds_config["path"]
+        validate_hdfs_path(path)
+
+        # Create HDFS filesystem using utility function
+        hdfs_fs = create_pyarrow_hdfs_filesystem(self.ds_config)
+
+        logger.info(f"Loading dataset from HDFS: {path}")
+
+        # Determine file format from extension or config
+        file_extension_map = {
+            ".json": "json",
+            ".jsonl": "json",
+            ".txt": "text",
+            ".csv": "csv",
+            ".tsv": "csv",
+            ".parquet": "parquet",
+            ".npy": "numpy",
+            ".tfrecords": "tfrecords",
+            ".lance": "lance",
+        }
+
+        auto_detect = False
+        data_format = self.ds_config.get("format", None)
+        if data_format is None:
+            auto_detect = True
+        else:
+            # First check if it's already a valid format name
+            valid_formats = set(file_extension_map.values())
+            if data_format in valid_formats:
+                pass  # It's a valid format name, use it as is
+            else:
+                # Try to interpret as an extension or filename
+                suffix = os.path.splitext(data_format)[1]
+                if suffix in file_extension_map:
+                    data_format = file_extension_map[suffix]
+                elif "." + data_format in file_extension_map:
+                    data_format = file_extension_map["." + data_format]
+                else:
+                    auto_detect = True
+
+        if auto_detect:
+            # Extract extension from path
+            file_extension = os.path.splitext(path)[1]
+            if file_extension in file_extension_map:
+                data_format = file_extension_map[file_extension]
+                logger.info(f"Auto-detected data format: {data_format} from extension: {file_extension}")
+            else:
+                data_format = "json"
+                logger.warning(
+                    f"Could not determine data format from path '{path}' "
+                    f"(extension: '{file_extension or '(none)'}'), "
+                    f"defaulting to 'json'. "
+                    f"Consider explicitly specifying 'format' field in dataset config."
+                )
+        else:
+            logger.info(f"Using specified data format: {data_format}")
+
+        # PyArrow's HadoopFileSystem expects paths WITHOUT the hdfs:// scheme,
+        # since the host/port is provided when constructing the filesystem.
+        # Strip the scheme+authority, keeping the absolute path.
+        fs_path = strip_hdfs_scheme(path)
+
+        try:
+            import ray.data
+
+            if data_format in {"json", "jsonl", "json.gz", "jsonl.gz", "json.zst", "jsonl.zst"}:
+                from data_juicer.core.data.ray_dataset import read_json_stream
+
+                read_options = kwargs.get("read_options")
+                # PyArrow's open_json/read_json require a pyarrow.json.ReadOptions
+                # object, but read_options is passed in as a dict (its default value
+                # is an empty dict {}). Convert it here so HDFS JSON reading works.
+                if isinstance(read_options, dict):
+                    import pyarrow.json as paj
+
+                    read_options = paj.ReadOptions(**read_options)
+                dataset = read_json_stream(
+                    fs_path, filesystem=hdfs_fs, read_options=read_options, override_num_blocks=override_num_blocks
+                )
+            elif data_format == "parquet":
+                dataset = ray.data.read_parquet(fs_path, filesystem=hdfs_fs, override_num_blocks=override_num_blocks)
+            elif data_format == "csv":
+                dataset = ray.data.read_csv(fs_path, filesystem=hdfs_fs, override_num_blocks=override_num_blocks)
+            elif data_format == "text":
+                dataset = ray.data.read_text(fs_path, filesystem=hdfs_fs, override_num_blocks=override_num_blocks)
+            elif data_format == "numpy":
+                dataset = ray.data.read_numpy(fs_path, filesystem=hdfs_fs, override_num_blocks=override_num_blocks)
+            elif data_format == "tfrecords":
+                dataset = ray.data.read_tfrecords(fs_path, filesystem=hdfs_fs, override_num_blocks=override_num_blocks)
+            elif data_format == "lance":
+                from data_juicer.utils.lazy_loader import LazyLoader
+
+                LazyLoader.check_packages(["pylance"])
+                dataset = ray.data.read_lance(fs_path, filesystem=hdfs_fs, override_num_blocks=override_num_blocks)
+            else:
+                raise ValueError(f"Unsupported data format for HDFS: {data_format}")
+
+            return RayDataset(dataset, dataset_path=path, cfg=self.cfg)
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load {data_format} data from HDFS path {path}. "
+                f"Ensure your Hadoop environment (HADOOP_HOME, JAVA_HOME, CLASSPATH, "
+                f"ARROW_LIBHDFS_DIR) is configured on all Ray nodes. "
                 f"Error: {str(e)}"
             )

--- a/data_juicer/core/exporter.py
+++ b/data_juicer/core/exporter.py
@@ -47,8 +47,8 @@ class Exporter:
         :param encrypt_before_export: whether to encrypt each exported file
             in-place immediately after writing. Requires a valid Fernet key
             accessible via ``encryption_key_path`` or the environment
-            variable ``DJ_ENCRYPTION_KEY``. S3 paths are skipped (use S3
-            SSE instead). Default: False.
+            variable ``DJ_ENCRYPTION_KEY``. Remote paths (s3://, hdfs://)
+            are skipped. Default: False.
         :param encryption_key_path: path to a file containing the Fernet key.
             Falls back to the ``DJ_ENCRYPTION_KEY`` environment variable when
             ``None``. Only used when ``encrypt_before_export`` is True.
@@ -74,11 +74,11 @@ class Exporter:
         self.encrypt_before_export = encrypt_before_export
         self._fernet = None
         if encrypt_before_export:
-            if export_path.startswith("s3://"):
+            if export_path.startswith("s3://") or export_path.startswith("hdfs://"):
                 logger.warning(
-                    "encrypt_before_export is True but export_path is an S3 "
-                    "path. Local-file encryption is skipped for S3 exports. "
-                    "Use S3 server-side encryption (SSE) to protect data at rest."
+                    "encrypt_before_export is True but export_path is a remote "
+                    f"path ({export_path}). Local-file encryption is skipped. "
+                    "Use server-side encryption to protect data at rest."
                 )
                 self.encrypt_before_export = False
             else:
@@ -135,6 +135,24 @@ class Exporter:
 
             self.storage_options = storage_options
             logger.info(f"Detected S3 export path: {export_path}. S3 storage_options configured.")
+
+        # Check if export_path is HDFS. Wrap PyArrow HadoopFileSystem via
+        # fsspec ArrowFSWrapper so that dataset.to_json/parquet(path)
+        # routes through fsspec → Arrow, unifying HDFS with the same
+        # storage_options path that S3 already uses.
+        if export_path.startswith("hdfs://"):
+            from fsspec.implementations.arrow import ArrowFSWrapper
+
+            from data_juicer.utils.hdfs_utils import create_pyarrow_hdfs_filesystem
+
+            hdfs_config = {"path": export_path}
+            for field in ("hdfs_host", "hdfs_port", "hdfs_user", "hdfs_kerb_ticket", "hdfs_extra_conf"):
+                if field in kwargs:
+                    hdfs_config[field] = kwargs.pop(field)
+            hdfs_pyarrow_fs = create_pyarrow_hdfs_filesystem(hdfs_config)
+            wrapped = ArrowFSWrapper(hdfs_pyarrow_fs)
+            self.storage_options = {"filesystem": wrapped}
+            logger.info(f"Detected HDFS export path: {export_path}. " f"ArrowFSWrapper storage_options configured.")
 
         # get the string format of shard size
         self.max_shard_size_str = byte_size_to_size_str(self.export_shard_size)
@@ -226,7 +244,7 @@ class Exporter:
                 ds_stats = Exporter._ensure_meta_stats_dicts_for_export(ds_stats)
                 stats_file = export_path.replace("." + suffix, "_stats.jsonl")
                 export_kwargs = {"num_proc": self.num_proc if self.export_in_parallel else 1}
-                # Add storage_options if available (for S3 export)
+                # Add storage_options if available (for S3/HDFS export)
                 if self.storage_options is not None:
                     export_kwargs["storage_options"] = self.storage_options
                 Exporter.to_jsonl(ds_stats, stats_file, **export_kwargs)
@@ -255,7 +273,7 @@ class Exporter:
                 # export the whole dataset into one single file.
                 logger.info("Export dataset into a single file...")
                 export_kwargs = {"num_proc": self.num_proc if self.export_in_parallel else 1}
-                # Add storage_options if available (for S3 export)
+                # Add storage_options if available (for S3/HDFS export)
                 if self.storage_options is not None:
                     export_kwargs["storage_options"] = self.storage_options
                 export_method(dataset, export_path, **export_kwargs)
@@ -297,6 +315,21 @@ class Exporter:
                         f"s3://{bucket}/{prefix_base}-{num_fmt % index}-of-{num_fmt % num_shards}.{self.suffix}"
                         for index in range(num_shards)
                     ]
+                elif self.export_path.startswith("hdfs://"):
+                    # For HDFS paths, construct HDFS URIs for each shard
+                    # (same pattern as S3)
+                    hdfs_path_parts = self.export_path.replace("hdfs://", "").split("/", 1)
+                    authority = hdfs_path_parts[0]
+                    prefix = hdfs_path_parts[1] if len(hdfs_path_parts) > 1 else ""
+                    # Remove extension from prefix
+                    if "." in prefix:
+                        prefix_base = ".".join(prefix.split(".")[:-1])
+                    else:
+                        prefix_base = prefix
+                    filenames = [
+                        f"hdfs://{authority}/{prefix_base}-{num_fmt % index}-of-{num_fmt % num_shards}.{self.suffix}"
+                        for index in range(num_shards)
+                    ]
                 else:
                     # For local paths, use standard directory structure
                     dirname = os.path.dirname(os.path.abspath(self.export_path))
@@ -314,7 +347,7 @@ class Exporter:
                 pool = Pool(self.num_proc)
                 for i in range(num_shards):
                     export_kwargs = {"num_proc": 1}  # Each shard export uses single process
-                    # Add storage_options if available (for S3 export)
+                    # Add storage_options if available (for S3/HDFS export)
                     if self.storage_options is not None:
                         export_kwargs["storage_options"] = self.storage_options
                     pool.apply_async(

--- a/data_juicer/core/ray_exporter.py
+++ b/data_juicer/core/ray_exporter.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from loguru import logger
 
 from data_juicer.utils.constant import Fields, HashKeys
-from data_juicer.utils.file_utils import Sizes, byte_size_to_size_str
+from data_juicer.utils.file_utils import Sizes, byte_size_to_size_str, is_remote_path
 from data_juicer.utils.model_utils import filter_arguments
 from data_juicer.utils.webdataset_utils import reconstruct_custom_webdataset_format
 
@@ -73,17 +73,31 @@ class RayExporter:
         self.encrypt_before_export = encrypt_before_export
         self._fernet = None
         if encrypt_before_export:
-            if export_path.startswith("s3://"):
+            if export_path.startswith("s3://") or export_path.startswith("hdfs://"):
                 logger.warning(
-                    "encrypt_before_export is True but export_path is an S3 "
-                    "path. Local-file encryption is skipped for S3 exports. "
-                    "Use S3 server-side encryption (SSE) to protect data at rest."
+                    "encrypt_before_export is True but export_path is a remote "
+                    f"path ({export_path}). Local-file encryption is skipped. "
+                    "Use server-side encryption to protect data at rest."
                 )
                 self.encrypt_before_export = False
             else:
                 from data_juicer.utils.encryption_utils import load_fernet_key
 
                 self._fernet = load_fernet_key(encryption_key_path)
+
+        # Check if export_path is HDFS and create filesystem if needed.
+        # PyArrow's HadoopFileSystem expects paths WITHOUT the hdfs:// scheme,
+        # so we also strip the scheme and use the bare path for writing.
+        self.hdfs_filesystem = None
+        if export_path.startswith("hdfs://"):
+            from data_juicer.utils.hdfs_utils import create_pyarrow_hdfs_filesystem
+
+            hdfs_config = {"path": export_path}
+            for field in ("hdfs_host", "hdfs_port", "hdfs_user", "hdfs_kerb_ticket", "hdfs_extra_conf"):
+                if field in self.export_extra_args:
+                    hdfs_config[field] = self.export_extra_args.pop(field)
+            self.hdfs_filesystem = create_pyarrow_hdfs_filesystem(hdfs_config)
+            logger.info(f"Detected HDFS export path: {export_path}. HDFS filesystem configured.")
 
         # Check if export_path is S3 and create filesystem if needed
         self.s3_filesystem = None
@@ -195,6 +209,16 @@ class RayExporter:
         # Add S3 filesystem if available
         if self.s3_filesystem is not None:
             export_kwargs["export_extra_args"]["filesystem"] = self.s3_filesystem
+        # Add HDFS filesystem if available; PyArrow needs the bare path
+        # (without the hdfs:// scheme) when a filesystem is provided.
+        # Keep the original path for remote-path checks below;
+        # only strip the scheme when passing it to export_method.
+        export_path_for_checks = export_path
+        if self.hdfs_filesystem is not None:
+            from data_juicer.utils.hdfs_utils import strip_hdfs_scheme
+
+            export_kwargs["export_extra_args"]["filesystem"] = self.hdfs_filesystem
+            export_path = strip_hdfs_scheme(export_path)
         if self.export_shard_size > 0:
             # compute the min_rows_per_file for export methods
             dataset_nbytes = dataset.size_bytes()
@@ -204,14 +228,16 @@ class RayExporter:
             rows_per_file = int(dataset_num_rows / num_shards)
             export_kwargs["export_extra_args"]["min_rows_per_file"] = rows_per_file
 
-        # Ensure export directory exists (Ray's write_json treats export_path as a directory)
-        if not export_path.startswith("s3://"):
-            os.makedirs(export_path, exist_ok=True)
+        # Ensure export directory exists (Ray's write_json treats export_path as a directory).
+        # Skip for any remote path (s3://, hdfs://, ...); the remote filesystem
+        # creates directories automatically during write.
+        if not is_remote_path(export_path_for_checks):
+            os.makedirs(export_path_for_checks, exist_ok=True)
 
         result = export_method(dataset, export_path, **export_kwargs)
 
         # Encrypt all exported files in-place after Ray has finished writing
-        if self.encrypt_before_export and self._fernet is not None and not export_path.startswith("s3://"):
+        if self.encrypt_before_export and self._fernet is not None and not is_remote_path(export_path_for_checks):
             from data_juicer.utils.encryption_utils import encrypt_file
 
             export_dir = Path(export_path)

--- a/data_juicer/utils/hdfs_utils.py
+++ b/data_juicer/utils/hdfs_utils.py
@@ -13,10 +13,13 @@ before use:
     export ARROW_LIBHDFS_DIR=$HADOOP_HOME/lib/native   # depends on env
 """
 
-from typing import Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
 from loguru import logger
+
+if TYPE_CHECKING:
+    import pyarrow.fs
 
 
 def parse_hdfs_path(path: str) -> Tuple[Optional[str], Optional[int]]:

--- a/data_juicer/utils/hdfs_utils.py
+++ b/data_juicer/utils/hdfs_utils.py
@@ -1,0 +1,123 @@
+"""
+HDFS utilities for Data-Juicer.
+
+Provides unified HDFS filesystem creation for the default executor
+and Ray executor (PyArrow backend). PyArrow's HadoopFileSystem relies
+on libhdfs and a working Hadoop/JVM environment on every node, so make
+sure the following environment variables are configured on all nodes
+before use:
+
+    export HADOOP_HOME=/path/to/hadoop
+    export JAVA_HOME=/path/to/java
+    export CLASSPATH=$($HADOOP_HOME/bin/hadoop classpath --glob)
+    export ARROW_LIBHDFS_DIR=$HADOOP_HOME/lib/native   # depends on env
+"""
+
+from typing import Dict, Optional, Tuple
+from urllib.parse import urlparse
+
+import pyarrow.fs
+from loguru import logger
+
+
+def parse_hdfs_path(path: str) -> Tuple[Optional[str], Optional[int]]:
+    """
+    Parse the host and port from an HDFS URI.
+
+    e.g. 'hdfs://namenode:8020/user/data' -> ('namenode', 8020)
+         'hdfs://namenode/user/data'      -> ('namenode', None)
+         'hdfs:///user/data'              -> (None, None)  # rely on default fs
+
+    Args:
+        path: HDFS path to parse.
+
+    Returns:
+        A tuple of (host, port). host/port may be None, in which case
+        PyArrow will fall back to the default filesystem configured via
+        Hadoop conf (fs.defaultFS).
+    """
+    parsed = urlparse(path)
+    host = parsed.hostname
+    port = parsed.port
+    return host, port
+
+
+def strip_hdfs_scheme(path: str) -> str:
+    """
+    Strip the hdfs:// scheme/authority from a path, returning the bare
+    filesystem path that PyArrow HadoopFileSystem expects.
+
+    e.g. 'hdfs://namenode:8020/user/data/file.jsonl' -> '/user/data/file.jsonl'
+
+    Args:
+        path: HDFS path to strip.
+
+    Returns:
+        Bare filesystem path without the hdfs:// scheme.
+    """
+    parsed = urlparse(path)
+    return parsed.path or path
+
+
+def create_pyarrow_hdfs_filesystem(ds_config: Dict = {}) -> "pyarrow.fs.HadoopFileSystem":
+    """
+    Create a PyArrow HadoopFileSystem for reading/writing HDFS.
+
+    Configuration priority for host/port:
+    1. Explicit fields in ``ds_config`` ('hdfs_host', 'hdfs_port').
+    2. Parsed from the 'path' field in ``ds_config``.
+    3. Default ('default'), letting PyArrow use Hadoop conf (fs.defaultFS).
+
+    Optional ``ds_config`` fields:
+      - hdfs_host: namenode host, or 'default'.
+      - hdfs_port: namenode port (int).
+      - hdfs_user: user name for HDFS access.
+      - hdfs_kerb_ticket: path to the Kerberos ticket cache.
+      - hdfs_extra_conf: dict of extra Hadoop configurations.
+
+    Args:
+        ds_config: Dataset/export configuration dictionary.
+
+    Returns:
+        A configured pyarrow.fs.HadoopFileSystem instance.
+    """
+    host = ds_config.get("hdfs_host")
+    port = ds_config.get("hdfs_port")
+
+    # fall back to parsing from path if host is not explicitly provided
+    if host is None and ds_config.get("path"):
+        parsed_host, parsed_port = parse_hdfs_path(ds_config["path"])
+        host = parsed_host
+        if port is None:
+            port = parsed_port
+
+    # PyArrow uses 'default' to indicate reliance on Hadoop conf (fs.defaultFS)
+    if not host:
+        host = "default"
+
+    fs_kwargs = {"host": host}
+    if port is not None:
+        fs_kwargs["port"] = int(port)
+    if "hdfs_user" in ds_config:
+        fs_kwargs["user"] = ds_config["hdfs_user"]
+    if "hdfs_kerb_ticket" in ds_config:
+        fs_kwargs["kerb_ticket"] = ds_config["hdfs_kerb_ticket"]
+    if "hdfs_extra_conf" in ds_config:
+        fs_kwargs["extra_conf"] = ds_config["hdfs_extra_conf"]
+
+    logger.info(f"Creating PyArrow HadoopFileSystem with host={host}, port={port}")
+    return pyarrow.fs.HadoopFileSystem(**fs_kwargs)
+
+
+def validate_hdfs_path(path: str) -> None:
+    """
+    Validate that a path is a valid HDFS path.
+
+    Args:
+        path: Path to validate.
+
+    Raises:
+        ValueError: If path doesn't start with 'hdfs://'.
+    """
+    if not path.startswith("hdfs://"):
+        raise ValueError(f"HDFS path must start with 'hdfs://', got: {path}")

--- a/data_juicer/utils/hdfs_utils.py
+++ b/data_juicer/utils/hdfs_utils.py
@@ -16,7 +16,6 @@ before use:
 from typing import Dict, Optional, Tuple
 from urllib.parse import urlparse
 
-import pyarrow.fs
 from loguru import logger
 
 
@@ -59,7 +58,9 @@ def strip_hdfs_scheme(path: str) -> str:
     return parsed.path or path
 
 
-def create_pyarrow_hdfs_filesystem(ds_config: Dict = {}) -> "pyarrow.fs.HadoopFileSystem":
+def create_pyarrow_hdfs_filesystem(
+    ds_config: Optional[Dict] = None,
+) -> "pyarrow.fs.HadoopFileSystem":
     """
     Create a PyArrow HadoopFileSystem for reading/writing HDFS.
 
@@ -81,6 +82,13 @@ def create_pyarrow_hdfs_filesystem(ds_config: Dict = {}) -> "pyarrow.fs.HadoopFi
     Returns:
         A configured pyarrow.fs.HadoopFileSystem instance.
     """
+    # Avoid the mutable-default-argument pitfall: default to None and create
+    # a fresh dict per call so callers never share state.
+    if ds_config is None:
+        ds_config = {}
+
+    import pyarrow.fs
+
     host = ds_config.get("hdfs_host")
     port = ds_config.get("hdfs_port")
 

--- a/demos/process_on_ray/configs/demo_hdfs.yaml
+++ b/demos/process_on_ray/configs/demo_hdfs.yaml
@@ -1,0 +1,73 @@
+# Process config example for dataset
+
+# global parameters
+project_name: 'ray-demo'
+
+dataset:
+  configs:
+    - type: remote
+      source: hdfs
+      format: jsonl
+      path: 'hdfs://****/user/***/data-juicer/demos/process_on_ray/data/demo-dataset.jsonl'
+export_path: 'hdfs://****/user/***/data-juicer/outputs/demo/demo-processed'
+
+executor_type: 'ray'
+ray_address: 'auto'                     # change to your ray cluster address, e.g., ray://<hostname>:<port>
+
+# process schedule
+# a list of several process operators with their arguments
+process:
+  # Filter ops
+  - alphanumeric_filter:                                    # filter text with alphabet/numeric ratio out of specific range.
+      tokenization: false                                     # Whether to count the ratio of alphanumeric to the total number of tokens.
+      min_ratio: 0.0                                          # the min ratio of filter range
+      max_ratio: 0.9                                          # the max ratio of filter range
+  - average_line_length_filter:                             # filter text with the average length of lines out of specific range.
+      min_len: 10                                             # the min length of filter range
+      max_len: 10000                                          # the max length of filter range
+  - character_repetition_filter:                            # filter text with the character repetition ratio out of specific range
+      rep_len: 10                                             # repetition length for char-level n-gram
+      min_ratio: 0.0                                          # the min ratio of filter range
+      max_ratio: 0.5                                          # the max ratio of filter range
+  - flagged_words_filter:                                   # filter text with the flagged-word ratio larger than a specific max value
+      lang: en                                                # consider flagged words in what language
+      tokenization: false                                     # whether to use model to tokenize documents
+      max_ratio: 0.0045                                       # the max ratio to filter text
+      flagged_words_dir: ./assets                             # directory to store flagged words dictionaries
+      use_words_aug: false                                    # whether to augment words, especially for Chinese and Vietnamese
+      words_aug_group_sizes: [2]                              # the group size of words to augment
+      words_aug_join_char: ""                                 # the join char between words to augment
+  - language_id_score_filter:                               # filter text in specific language with language scores larger than a specific max value
+      lang: en                                                # keep text in what language
+      min_score: 0.8                                          # the min language scores to filter text
+  - maximum_line_length_filter:                             # filter text with the maximum length of lines out of specific range
+      min_len: 10                                             # the min length of filter range
+      max_len: 10000                                          # the max length of filter range
+  - perplexity_filter:                                      # filter text with perplexity score out of specific range
+      lang: en                                                # compute perplexity in what language
+      max_ppl: 1500                                           # the max perplexity score to filter text
+  - special_characters_filter:                              # filter text with special-char ratio out of specific range
+      min_ratio: 0.0                                          # the min ratio of filter range
+      max_ratio: 0.25                                         # the max ratio of filter range
+  - stopwords_filter:                                       # filter text with stopword ratio smaller than a specific min value
+      lang: en                                                # consider stopwords in what language
+      tokenization: false                                     # whether to use model to tokenize documents
+      min_ratio: 0.3                                          # the min ratio to filter text
+      stopwords_dir: ./assets                                 # directory to store stopwords dictionaries
+      use_words_aug: false                                    # whether to augment words, especially for Chinese and Vietnamese
+      words_aug_group_sizes: [2]                              # the group size of words to augment
+      words_aug_join_char: ""                                 # the join char between words to augment
+  - text_length_filter:                                     # filter text with length out of specific range
+      min_len: 10                                             # the min length of filter range
+      max_len: 10000                                          # the max length of filter range
+  - words_num_filter:                                       # filter text with number of words out of specific range
+      lang: en                                                # sample in which language
+      tokenization: false                                     # whether to use model to tokenize documents
+      min_num: 10                                             # the min number of filter range
+      max_num: 10000                                          # the max number of filter range
+  - word_repetition_filter:                                 # filter text with the word repetition ratio out of specific range
+      lang: en                                                # sample in which language
+      tokenization: false                                     # whether to use model to tokenize documents
+      rep_len: 10                                             # repetition length for word-level n-gram
+      min_ratio: 0.0                                          # the min ratio of filter range
+      max_ratio: 0.5                                          # the max ratio of filter range

--- a/demos/process_simple/process_hdfs.yaml
+++ b/demos/process_simple/process_hdfs.yaml
@@ -1,0 +1,22 @@
+# Process config example for dataset
+
+# global parameters
+project_name: 'demo-process'
+
+dataset:
+  configs:
+    - type: remote
+      source: hdfs
+      format: jsonl
+      path: 'hdfs://****/user/**/data-juicer/demos/data/demo-dataset.jsonl'
+
+np: 4  # number of subprocess to process your dataset
+
+export_path: 'hdfs://****/user/**/data-juicer/outputs/demo-process/demo-processed.jsonl'
+
+# process schedule
+# a list of several process operators with their arguments
+process:
+  - language_id_score_filter:
+      lang: 'zh'
+      min_score: 0.8

--- a/tests/core/data/test_load_strategy.py
+++ b/tests/core/data/test_load_strategy.py
@@ -26,6 +26,7 @@ from data_juicer.core.data.load_strategy import (
     DefaultHdfsDataLoadStrategy,
     RayHdfsDataLoadStrategy,
 )
+from data_juicer.core.data.config_validator import ConfigValidationError
 from data_juicer.utils.constant import Fields
 from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase, TEST_TAG
 
@@ -849,7 +850,7 @@ class TestDefaultHdfsDataLoadStrategy(DataJuicerTestCaseBase):
             "type": "remote",
             "source": "hdfs",
         }
-        with self.assertRaises((ValueError, KeyError)):
+        with self.assertRaises((ConfigValidationError, ValueError, KeyError)):
             DefaultHdfsDataLoadStrategy(ds_config, self.cfg)
 
 

--- a/tests/core/data/test_load_strategy.py
+++ b/tests/core/data/test_load_strategy.py
@@ -23,6 +23,8 @@ from data_juicer.core.data.load_strategy import (
     RayLocalJsonDataLoadStrategy,
     RayS3DataLoadStrategy,
     StrategyKey,
+    DefaultHdfsDataLoadStrategy,
+    RayHdfsDataLoadStrategy,
 )
 from data_juicer.utils.constant import Fields
 from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase, TEST_TAG
@@ -780,6 +782,134 @@ class LocalAndS3PathValidationTest(DataJuicerTestCaseBase):
             )
             with self.assertRaises(ValueError):
                 ray_s3.load_data()
+
+
+class TestDefaultHdfsDataLoadStrategy(DataJuicerTestCaseBase):
+    """Test cases for DefaultHdfsDataLoadStrategy"""
+
+    def setUp(self):
+        super().setUp()
+        self.cfg = get_default_cfg()
+        self.cfg.text_keys = ["text"]
+
+    def test_strategy_registration(self):
+        """Test that DefaultHdfsDataLoadStrategy is registered correctly"""
+        strategy_class = DataLoadStrategyRegistry.get_strategy_class(
+            executor_type="default", data_type="remote", data_source="hdfs"
+        )
+        self.assertIsNotNone(strategy_class)
+        self.assertEqual(strategy_class, DefaultHdfsDataLoadStrategy)
+
+    def test_config_validation_valid_path(self):
+        """Test config validation with valid HDFS path"""
+        ds_config = {
+            "type": "remote",
+            "source": "hdfs",
+            "path": "hdfs://namenode:8020/user/data/file.jsonl"
+        }
+        strategy = DefaultHdfsDataLoadStrategy(ds_config, self.cfg)
+        self.assertEqual(strategy.ds_config["path"], "hdfs://namenode:8020/user/data/file.jsonl")
+
+    def test_config_validation_invalid_path(self):
+        """Test config validation with invalid HDFS path"""
+        from data_juicer.utils.hdfs_utils import validate_hdfs_path
+
+        ds_config = {
+            "type": "remote",
+            "source": "hdfs",
+            "path": "s3://bucket/file.jsonl"  # Not hdfs://
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            validate_hdfs_path(ds_config["path"])
+        self.assertIn("hdfs://", str(ctx.exception))
+
+    def test_config_validation_optional_fields(self):
+        """Test config validation with optional HDFS fields"""
+        ds_config = {
+            "type": "remote",
+            "source": "hdfs",
+            "path": "hdfs://namenode:8020/user/data/file.jsonl",
+            "hdfs_host": "namenode",
+            "hdfs_port": 8020,
+            "hdfs_user": "data_juicer",
+            "hdfs_kerb_ticket": "/tmp/krb5cc",
+            "hdfs_extra_conf": {"dfs.replication": "3"},
+        }
+        strategy = DefaultHdfsDataLoadStrategy(ds_config, self.cfg)
+        self.assertEqual(strategy.ds_config["hdfs_host"], "namenode")
+        self.assertEqual(strategy.ds_config["hdfs_port"], 8020)
+        self.assertEqual(strategy.ds_config["hdfs_user"], "data_juicer")
+        self.assertEqual(strategy.ds_config["hdfs_kerb_ticket"], "/tmp/krb5cc")
+        self.assertEqual(strategy.ds_config["hdfs_extra_conf"], {"dfs.replication": "3"})
+
+    def test_config_validation_missing_required_path(self):
+        """Test that missing required path field raises error"""
+        ds_config = {
+            "type": "remote",
+            "source": "hdfs",
+        }
+        with self.assertRaises((ValueError, KeyError)):
+            DefaultHdfsDataLoadStrategy(ds_config, self.cfg)
+
+
+class TestRayHdfsDataLoadStrategy(DataJuicerTestCaseBase):
+    """Test cases for RayHdfsDataLoadStrategy"""
+
+    def setUp(self):
+        super().setUp()
+        self.cfg = get_default_cfg()
+        self.cfg.text_keys = ["text"]
+
+    def test_strategy_registration(self):
+        """Test that RayHdfsDataLoadStrategy is registered correctly"""
+        strategy_class = DataLoadStrategyRegistry.get_strategy_class(
+            executor_type="ray", data_type="remote", data_source="hdfs"
+        )
+        self.assertIsNotNone(strategy_class)
+        self.assertEqual(strategy_class, RayHdfsDataLoadStrategy)
+
+    def test_config_validation_valid_path(self):
+        """Test config validation with valid HDFS path"""
+        ds_config = {
+            "type": "remote",
+            "source": "hdfs",
+            "path": "hdfs://namenode:8020/user/data/file.jsonl"
+        }
+        strategy = RayHdfsDataLoadStrategy(ds_config, self.cfg)
+        self.assertEqual(strategy.ds_config["path"], "hdfs://namenode:8020/user/data/file.jsonl")
+
+    def test_config_validation_invalid_path(self):
+        """Test config validation with invalid HDFS path"""
+        from data_juicer.utils.hdfs_utils import validate_hdfs_path
+
+        ds_config = {
+            "type": "remote",
+            "source": "hdfs",
+            "path": "/local/path/file.jsonl"
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            validate_hdfs_path(ds_config["path"])
+        self.assertIn("hdfs://", str(ctx.exception))
+
+    def test_config_validation_optional_fields(self):
+        """Test config validation with optional HDFS fields"""
+        ds_config = {
+            "type": "remote",
+            "source": "hdfs",
+            "path": "hdfs://namenode:8020/user/data/file.jsonl",
+            "format": "jsonl",
+            "hdfs_host": "namenode",
+            "hdfs_port": 8020,
+            "hdfs_user": "data_juicer",
+        }
+        strategy = RayHdfsDataLoadStrategy(ds_config, self.cfg)
+        self.assertEqual(strategy.ds_config["hdfs_host"], "namenode")
+        self.assertEqual(strategy.ds_config["hdfs_port"], 8020)
+        self.assertEqual(strategy.ds_config["format"], "jsonl")
+
+
 
 
 if __name__ == '__main__':

--- a/tests/core/test_exporter.py
+++ b/tests/core/test_exporter.py
@@ -258,6 +258,33 @@ class ExporterEncryptTest(DataJuicerTestCaseBase):
             'Expected a loguru WARNING about S3 path skipping encryption',
         )
 
+    def test_hdfs_path_disables_encryption_with_warning(self):
+        """HDFS export_path should disable local-file encryption with a warning."""
+        from loguru import logger
+
+        key_file = self._write_key_file()
+        warning_messages = []
+        handler_id = logger.add(
+            lambda msg: warning_messages.append(str(msg)),
+            level='WARNING',
+            format='{message}',
+        )
+        try:
+            exporter = Exporter(
+                export_path='hdfs://namenode:8020/user/data/out.jsonl',
+                encrypt_before_export=True,
+                encryption_key_path=key_file,
+            )
+        finally:
+            logger.remove(handler_id)
+
+        self.assertFalse(exporter.encrypt_before_export)
+        self.assertTrue(
+            len(warning_messages) > 0,
+            'Expected a loguru WARNING about HDFS path skipping encryption',
+        )
+
+
     # ------------------------------------------------------------------
     # _encrypt_local_file helper
     # ------------------------------------------------------------------

--- a/tests/core/test_exporter.py
+++ b/tests/core/test_exporter.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 import jsonlines as jl
+from unittest.mock import patch
 
 import numpy as np
 from datasets import Dataset
@@ -258,7 +259,9 @@ class ExporterEncryptTest(DataJuicerTestCaseBase):
             'Expected a loguru WARNING about S3 path skipping encryption',
         )
 
-    def test_hdfs_path_disables_encryption_with_warning(self):
+    @patch("fsspec.implementations.arrow.ArrowFSWrapper")
+    @patch("data_juicer.utils.hdfs_utils.create_pyarrow_hdfs_filesystem")
+    def test_hdfs_path_disables_encryption_with_warning(self, mock_create_hdfs_fs, mock_arrow_wrapper):
         """HDFS export_path should disable local-file encryption with a warning."""
         from loguru import logger
 

--- a/tests/core/test_ray_exporter.py
+++ b/tests/core/test_ray_exporter.py
@@ -363,12 +363,13 @@ class RayExporterEncryptTest(DataJuicerTestCaseBase):
         self.assertTrue(exporter.encrypt_before_export)
         self.assertIsNotNone(exporter._fernet)
 
-    def test_s3_path_disables_encryption_with_warning(self):
+    @patch("data_juicer.utils.s3_utils.create_pyarrow_s3_filesystem")
+    def test_s3_path_disables_encryption_with_warning(self, mock_create_s3_fs):
         """S3 export path silently disables local-file encryption."""
         warnings_seen = []
         from loguru import logger as _logger
         handler_id = _logger.add(
-            lambda msg: warnings_seen.append(msg),
+            lambda msg: warnings_seen.append(str(msg)),
             level='WARNING',
             format='{message}',
         )
@@ -382,16 +383,18 @@ class RayExporterEncryptTest(DataJuicerTestCaseBase):
             _logger.remove(handler_id)
         self.assertFalse(exporter.encrypt_before_export)
         self.assertTrue(
-            any('encrypt_before_export' in str(w) and 'S3' in str(w)
+            any('encrypt_before_export' in str(w) and 's3' in str(w).lower()
                 for w in warnings_seen),
             'Expected warning about S3 + encrypt_before_export not found',
         )
-    def test_hdfs_path_disables_encryption_with_warning(self):
+
+    @patch("data_juicer.utils.hdfs_utils.create_pyarrow_hdfs_filesystem")
+    def test_hdfs_path_disables_encryption_with_warning(self, mock_create_hdfs_fs):
         """HDFS export path silently disables local-file encryption."""
         warnings_seen = []
         from loguru import logger as _logger
         handler_id = _logger.add(
-            lambda msg: warnings_seen.append(msg),
+            lambda msg: warnings_seen.append(str(msg)),
             level='WARNING',
             format='{message}',
         )
@@ -409,8 +412,9 @@ class RayExporterEncryptTest(DataJuicerTestCaseBase):
             'Expected warning about HDFS + encrypt_before_export not found',
         )
 
+    @patch("data_juicer.utils.hdfs_utils.create_pyarrow_hdfs_filesystem")
     @patch("data_juicer.core.ray_exporter.is_remote_path")
-    def test_hdfs_path_skips_local_makedirs(self, mock_is_remote):
+    def test_hdfs_path_skips_local_makedirs(self, mock_is_remote, mock_create_hdfs_fs):
         """HDFS export_path should skip local os.makedirs via is_remote_path."""
         mock_is_remote.return_value = True
 

--- a/tests/core/test_ray_exporter.py
+++ b/tests/core/test_ray_exporter.py
@@ -386,6 +386,54 @@ class RayExporterEncryptTest(DataJuicerTestCaseBase):
                 for w in warnings_seen),
             'Expected warning about S3 + encrypt_before_export not found',
         )
+    def test_hdfs_path_disables_encryption_with_warning(self):
+        """HDFS export path silently disables local-file encryption."""
+        warnings_seen = []
+        from loguru import logger as _logger
+        handler_id = _logger.add(
+            lambda msg: warnings_seen.append(msg),
+            level='WARNING',
+            format='{message}',
+        )
+        try:
+            exporter = RayExporter(
+                export_path='hdfs://namenode:8020/user/data/out.jsonl',
+                encrypt_before_export=True,
+                encryption_key_path=self._key_file,
+            )
+        finally:
+            _logger.remove(handler_id)
+        self.assertFalse(exporter.encrypt_before_export)
+        self.assertTrue(
+            any('encrypt_before_export' in str(w) for w in warnings_seen),
+            'Expected warning about HDFS + encrypt_before_export not found',
+        )
+
+    @patch("data_juicer.core.ray_exporter.is_remote_path")
+    def test_hdfs_path_skips_local_makedirs(self, mock_is_remote):
+        """HDFS export_path should skip local os.makedirs via is_remote_path."""
+        mock_is_remote.return_value = True
+
+        exporter = RayExporter(
+            export_path='hdfs://namenode:8020/user/data',
+            export_type='jsonl',
+        )
+
+        mock_dataset = MagicMock()
+        mock_dataset.columns.return_value = ['text']
+        mock_dataset.count.return_value = 1
+        mock_dataset.size_bytes.return_value = 50
+        mock_dataset.drop_columns.return_value = mock_dataset
+
+        with patch.object(RayExporter, '_router') as mock_router:
+            mock_write = MagicMock(return_value=None)
+            mock_router.return_value = {'jsonl': mock_write}
+            with patch("data_juicer.core.ray_exporter.os.makedirs") as mock_makedirs:
+                exporter._export_impl(mock_dataset, 'hdfs://namenode:8020/user/data')
+
+        # os.makedirs should NOT be called because is_remote_path returned True
+        mock_makedirs.assert_not_called()
+
 
     # ------------------------------------------------------------------
     # _export_impl – encrypt_file called for each file in the output dir

--- a/tests/utils/test_hdfs_utils.py
+++ b/tests/utils/test_hdfs_utils.py
@@ -1,0 +1,218 @@
+"""
+Test cases for HDFS utilities, focusing on path parsing, validation,
+and filesystem creation logic.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from data_juicer.utils.hdfs_utils import (
+    create_pyarrow_hdfs_filesystem,
+    parse_hdfs_path,
+    strip_hdfs_scheme,
+    validate_hdfs_path,
+)
+from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
+
+
+class TestHdfsUtils(DataJuicerTestCaseBase):
+    """Test cases for HDFS utility functions"""
+
+    # ── validate_hdfs_path ──────────────────────────────────────────
+
+    def test_validate_hdfs_path_valid(self):
+        """Test HDFS path validation with valid paths"""
+        valid_paths = [
+            "hdfs://namenode:8020/user/data/file.jsonl",
+            "hdfs://namenode/user/data",
+            "hdfs:///user/data",
+            "hdfs://localhost/data",
+        ]
+
+        for path in valid_paths:
+            try:
+                validate_hdfs_path(path)
+            except ValueError:
+                self.fail(f"validate_hdfs_path raised ValueError for valid path: {path}")
+
+    def test_validate_hdfs_path_invalid(self):
+        """Test HDFS path validation with invalid paths (no hdfs:// prefix)"""
+        invalid_paths = [
+            "s3://bucket/file.jsonl",
+            "https://example.com/file.jsonl",
+            "/local/path/file.jsonl",
+            "file:///tmp/data",
+            "",
+            "hdfs-without-scheme/path",
+        ]
+
+        for path in invalid_paths:
+            with self.assertRaises(ValueError) as ctx:
+                validate_hdfs_path(path)
+            self.assertIn("hdfs://", str(ctx.exception))
+
+    # ── parse_hdfs_path ─────────────────────────────────────────────
+
+    def test_parse_hdfs_path_with_host_and_port(self):
+        """Test parsing HDFS URI with explicit host and port"""
+        host, port = parse_hdfs_path("hdfs://namenode:8020/user/data")
+        self.assertEqual(host, "namenode")
+        self.assertEqual(port, 8020)
+
+    def test_parse_hdfs_path_with_host_only(self):
+        """Test parsing HDFS URI with host but no port"""
+        host, port = parse_hdfs_path("hdfs://namenode/user/data")
+        self.assertEqual(host, "namenode")
+        self.assertIsNone(port)
+
+    def test_parse_hdfs_path_default_fs(self):
+        """Test parsing HDFS URI that relies on default filesystem (no authority)"""
+        host, port = parse_hdfs_path("hdfs:///user/data")
+        self.assertIsNone(host)
+        self.assertIsNone(port)
+
+    def test_parse_hdfs_path_nested_path(self):
+        """Test parsing HDFS URI with deeply nested path"""
+        host, port = parse_hdfs_path("hdfs://nn:9000/a/b/c/d/e.jsonl")
+        self.assertEqual(host, "nn")
+        self.assertEqual(port, 9000)
+
+    # ── strip_hdfs_scheme ───────────────────────────────────────────
+
+    def test_strip_hdfs_scheme_with_authority(self):
+        """Test stripping scheme from a full HDFS URI"""
+        result = strip_hdfs_scheme("hdfs://namenode:8020/user/data/file.jsonl")
+        self.assertEqual(result, "/user/data/file.jsonl")
+
+    def test_strip_hdfs_scheme_without_port(self):
+        """Test stripping scheme when port is omitted"""
+        result = strip_hdfs_scheme("hdfs://namenode/user/data")
+        self.assertEqual(result, "/user/data")
+
+    def test_strip_hdfs_scheme_default_fs(self):
+        """Test stripping scheme from default-filesystem URI"""
+        result = strip_hdfs_scheme("hdfs:///user/data")
+        self.assertEqual(result, "/user/data")
+
+    def test_strip_hdfs_scheme_fallback(self):
+        """Test strip_hdfs_scheme falls back to original path when urlparse gives empty path"""
+        # urlparse on a bare path without scheme gives empty path
+        result = strip_hdfs_scheme("/user/data")
+        self.assertEqual(result, "/user/data")
+
+    # ── create_pyarrow_hdfs_filesystem ──────────────────────────────
+
+    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    def test_create_hdfs_fs_with_host_port_in_path(self, mock_hdfs_fs):
+        """Test filesystem creation when host/port come from the path field"""
+        ds_config = {"path": "hdfs://namenode:8020/user/data"}
+        create_pyarrow_hdfs_filesystem(ds_config)
+
+        mock_hdfs_fs.assert_called_once()
+        call_kwargs = mock_hdfs_fs.call_args[1]
+        self.assertEqual(call_kwargs["host"], "namenode")
+        self.assertEqual(call_kwargs["port"], 8020)
+
+    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    def test_create_hdfs_fs_with_explicit_host_port(self, mock_hdfs_fs):
+        """Test that explicit hdfs_host/hdfs_port override path-parsed values"""
+        ds_config = {
+            "path": "hdfs://old-nn:8020/user/data",
+            "hdfs_host": "new-nn",
+            "hdfs_port": 9000,
+        }
+        create_pyarrow_hdfs_filesystem(ds_config)
+
+        mock_hdfs_fs.assert_called_once()
+        call_kwargs = mock_hdfs_fs.call_args[1]
+        self.assertEqual(call_kwargs["host"], "new-nn")
+        self.assertEqual(call_kwargs["port"], 9000)
+
+    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    def test_create_hdfs_fs_default(self, mock_hdfs_fs):
+        """Test filesystem creation falls back to 'default' when no host is provided"""
+        ds_config = {"path": "hdfs:///user/data"}
+        create_pyarrow_hdfs_filesystem(ds_config)
+
+        mock_hdfs_fs.assert_called_once()
+        call_kwargs = mock_hdfs_fs.call_args[1]
+        self.assertEqual(call_kwargs["host"], "default")
+
+    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    def test_create_hdfs_fs_with_user(self, mock_hdfs_fs):
+        """Test filesystem creation includes user when specified"""
+        ds_config = {
+            "path": "hdfs://namenode:8020/user/data",
+            "hdfs_user": "data_juicer",
+        }
+        create_pyarrow_hdfs_filesystem(ds_config)
+
+        mock_hdfs_fs.assert_called_once()
+        call_kwargs = mock_hdfs_fs.call_args[1]
+        self.assertEqual(call_kwargs["user"], "data_juicer")
+
+    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    def test_create_hdfs_fs_with_kerb_ticket(self, mock_hdfs_fs):
+        """Test filesystem creation includes Kerberos ticket when specified"""
+        ds_config = {
+            "path": "hdfs://namenode:8020/user/data",
+            "hdfs_kerb_ticket": "/tmp/krb5cc_1000",
+        }
+        create_pyarrow_hdfs_filesystem(ds_config)
+
+        mock_hdfs_fs.assert_called_once()
+        call_kwargs = mock_hdfs_fs.call_args[1]
+        self.assertEqual(call_kwargs["kerb_ticket"], "/tmp/krb5cc_1000")
+
+    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    def test_create_hdfs_fs_with_extra_conf(self, mock_hdfs_fs):
+        """Test filesystem creation includes extra Hadoop configurations"""
+        extra_conf = {"dfs.replication": "3", "dfs.block.size": "134217728"}
+        ds_config = {
+            "path": "hdfs://namenode:8020/user/data",
+            "hdfs_extra_conf": extra_conf,
+        }
+        create_pyarrow_hdfs_filesystem(ds_config)
+
+        mock_hdfs_fs.assert_called_once()
+        call_kwargs = mock_hdfs_fs.call_args[1]
+        self.assertEqual(call_kwargs["extra_conf"], extra_conf)
+
+    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    def test_create_hdfs_fs_host_default_when_empty_string(self, mock_hdfs_fs):
+        """Test that an empty hdfs_host string falls back to 'default'"""
+        ds_config = {
+            "path": "hdfs:///user/data",
+            "hdfs_host": "",
+        }
+        create_pyarrow_hdfs_filesystem(ds_config)
+
+        mock_hdfs_fs.assert_called_once()
+        call_kwargs = mock_hdfs_fs.call_args[1]
+        self.assertEqual(call_kwargs["host"], "default")
+
+    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    def test_create_hdfs_fs_explicit_port_overrides_path_port(self, mock_hdfs_fs):
+        """Test that explicit hdfs_port overrides the port parsed from path"""
+        ds_config = {
+            "path": "hdfs://namenode:8020/user/data",
+            "hdfs_port": 9999,
+        }
+        create_pyarrow_hdfs_filesystem(ds_config)
+
+        mock_hdfs_fs.assert_called_once()
+        call_kwargs = mock_hdfs_fs.call_args[1]
+        self.assertEqual(call_kwargs["port"], 9999)
+
+    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    def test_create_hdfs_fs_no_path_field(self, mock_hdfs_fs):
+        """Test filesystem creation with empty config (no path field)"""
+        create_pyarrow_hdfs_filesystem({})
+
+        mock_hdfs_fs.assert_called_once()
+        call_kwargs = mock_hdfs_fs.call_args[1]
+        self.assertEqual(call_kwargs["host"], "default")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/test_hdfs_utils.py
+++ b/tests/utils/test_hdfs_utils.py
@@ -102,7 +102,7 @@ class TestHdfsUtils(DataJuicerTestCaseBase):
 
     # ── create_pyarrow_hdfs_filesystem ──────────────────────────────
 
-    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    @patch("pyarrow.fs.HadoopFileSystem")
     def test_create_hdfs_fs_with_host_port_in_path(self, mock_hdfs_fs):
         """Test filesystem creation when host/port come from the path field"""
         ds_config = {"path": "hdfs://namenode:8020/user/data"}
@@ -113,7 +113,7 @@ class TestHdfsUtils(DataJuicerTestCaseBase):
         self.assertEqual(call_kwargs["host"], "namenode")
         self.assertEqual(call_kwargs["port"], 8020)
 
-    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    @patch("pyarrow.fs.HadoopFileSystem")
     def test_create_hdfs_fs_with_explicit_host_port(self, mock_hdfs_fs):
         """Test that explicit hdfs_host/hdfs_port override path-parsed values"""
         ds_config = {
@@ -128,7 +128,7 @@ class TestHdfsUtils(DataJuicerTestCaseBase):
         self.assertEqual(call_kwargs["host"], "new-nn")
         self.assertEqual(call_kwargs["port"], 9000)
 
-    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    @patch("pyarrow.fs.HadoopFileSystem")
     def test_create_hdfs_fs_default(self, mock_hdfs_fs):
         """Test filesystem creation falls back to 'default' when no host is provided"""
         ds_config = {"path": "hdfs:///user/data"}
@@ -138,7 +138,7 @@ class TestHdfsUtils(DataJuicerTestCaseBase):
         call_kwargs = mock_hdfs_fs.call_args[1]
         self.assertEqual(call_kwargs["host"], "default")
 
-    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    @patch("pyarrow.fs.HadoopFileSystem")
     def test_create_hdfs_fs_with_user(self, mock_hdfs_fs):
         """Test filesystem creation includes user when specified"""
         ds_config = {
@@ -151,7 +151,7 @@ class TestHdfsUtils(DataJuicerTestCaseBase):
         call_kwargs = mock_hdfs_fs.call_args[1]
         self.assertEqual(call_kwargs["user"], "data_juicer")
 
-    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    @patch("pyarrow.fs.HadoopFileSystem")
     def test_create_hdfs_fs_with_kerb_ticket(self, mock_hdfs_fs):
         """Test filesystem creation includes Kerberos ticket when specified"""
         ds_config = {
@@ -164,7 +164,7 @@ class TestHdfsUtils(DataJuicerTestCaseBase):
         call_kwargs = mock_hdfs_fs.call_args[1]
         self.assertEqual(call_kwargs["kerb_ticket"], "/tmp/krb5cc_1000")
 
-    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    @patch("pyarrow.fs.HadoopFileSystem")
     def test_create_hdfs_fs_with_extra_conf(self, mock_hdfs_fs):
         """Test filesystem creation includes extra Hadoop configurations"""
         extra_conf = {"dfs.replication": "3", "dfs.block.size": "134217728"}
@@ -178,7 +178,7 @@ class TestHdfsUtils(DataJuicerTestCaseBase):
         call_kwargs = mock_hdfs_fs.call_args[1]
         self.assertEqual(call_kwargs["extra_conf"], extra_conf)
 
-    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    @patch("pyarrow.fs.HadoopFileSystem")
     def test_create_hdfs_fs_host_default_when_empty_string(self, mock_hdfs_fs):
         """Test that an empty hdfs_host string falls back to 'default'"""
         ds_config = {
@@ -191,7 +191,7 @@ class TestHdfsUtils(DataJuicerTestCaseBase):
         call_kwargs = mock_hdfs_fs.call_args[1]
         self.assertEqual(call_kwargs["host"], "default")
 
-    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    @patch("pyarrow.fs.HadoopFileSystem")
     def test_create_hdfs_fs_explicit_port_overrides_path_port(self, mock_hdfs_fs):
         """Test that explicit hdfs_port overrides the port parsed from path"""
         ds_config = {
@@ -204,7 +204,7 @@ class TestHdfsUtils(DataJuicerTestCaseBase):
         call_kwargs = mock_hdfs_fs.call_args[1]
         self.assertEqual(call_kwargs["port"], 9999)
 
-    @patch("data_juicer.utils.hdfs_utils.pyarrow.fs.HadoopFileSystem")
+    @patch("pyarrow.fs.HadoopFileSystem")
     def test_create_hdfs_fs_no_path_field(self, mock_hdfs_fs):
         """Test filesystem creation with empty config (no path field)"""
         create_pyarrow_hdfs_filesystem({})


### PR DESCRIPTION
<h2>PR Description</h2><h3>What does this PR do?</h3><p>This PR adds HDFS (<code>hdfs://</code>) protocol support to data-juicer, enabling users to read datasets from and write processed results to HDFS — consistent with the existing S3 remote storage workflow.</p><h3>Motivation</h3><p>Many production environments store large-scale datasets on HDFS clusters. Supporting HDFS natively allows users to process data in-place without manually staging files to local disk first.</p><h3>Changes</h3><ul><li><strong><code>data_juicer/utils/hdfs_utils.py</code></strong> (new): HDFS utility module — path validation (<code>validate_hdfs_path</code>, <code>strip_hdfs_scheme</code>) and PyArrow <code>HadoopFileSystem</code> creation with configurable host/port/user/Kerberos/extra_conf.</li><li><strong><code>data_juicer/core/data/load_strategy.py</code></strong>: Added <code>DefaultHdfsDataLoadStrategy</code> (local executor) and <code>RayHdfsDataLoadStrategy</code> (Ray executor), registered via <code>DataLoadStrategyRegistry</code> under <code>("default"/"ray", "remote", "hdfs")</code>. Uses <code>fsspec</code> <code>ArrowFSWrapper</code> for filesystem abstraction.</li><li><strong><code>data_juicer/core/exporter.py</code></strong> / <strong><code>ray_exporter.py</code></strong>: Extended exporters to detect <code>hdfs://</code> export paths and create a PyArrow HDFS filesystem for writing output.</li><li><strong><code>data_juicer/config/config.py</code></strong>: Generalized the S3-only remote path handling to cover both <code>s3://</code> and <code>hdfs://</code> schemes (log filename generation, <code>work_dir</code> fallback, etc.).</li><li><strong>Demos</strong>: Added <code>demos/process_simple/process_hdfs.yaml</code> (local executor) and <code>demos/process_on_ray/configs/demo_hdfs.yaml</code> (Ray executor) as usage examples.</li><li><strong>Tests</strong>: Comprehensive unit tests for HDFS load strategies, exporters, and <code>hdfs_utils</code>.</li></ul><h3>Usage</h3><p>Users can now specify HDFS paths in their YAML config:</p><pre><code>dataset:
  configs:
    - type: remote
      source: hdfs
      format: jsonl
      path: 'hdfs://namenode:8020/user/data/demo-dataset.jsonl'

export_path: 'hdfs://namenode:8020/user/data/outputs/result.jsonl'</code></pre><p>Optional HDFS connection parameters can be set in the dataset config:</p><div><div>
Parameter | Description
-- | --
hdfs_host | NameNode hostname (overrides host parsed from path)
hdfs_port | NameNode port (overrides port parsed from path)
hdfs_user | HDFS user name
hdfs_kerb_ticket | Path to Kerberos ticket cache
hdfs_extra_conf | Extra Hadoop config dict (e.g. dfs.replication)

</div></div><h3>Checklist</h3><ul><li><div></div>Code follows the project style</li><li><div></div>Tests added for new functionality</li><li><div></div>Demo configs included for both local and Ray executors</li><li><div></div>Documentation / inline comments updated</li></ul>