### PR TITLE
feat: add RayAnalyzer for distributed data analysis

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -800,7 +800,7 @@ def build_base_parser() -> ArgumentParser:
     return parser
 
 
-def init_configs(args: Optional[List[str]] = None, which_entry: object = None, load_configs_only=False):
+def init_configs(args: Optional[List[str]] = None, allow_auto: bool = False, load_configs_only=False):
     """
     initialize the jsonargparse parser and parse configs from one of:
         1. POSIX-style commands line args;
@@ -809,7 +809,7 @@ def init_configs(args: Optional[List[str]] = None, which_entry: object = None, l
         4. hard-coded defaults
 
     :param args: list of params, e.g., ['--config', 'cfg.yaml'], default None.
-    :param which_entry: which entry to init configs (executor/analyzer)
+    :param allow_auto: whether --auto is allowed (only True for analyzer entries)
     :param load_configs_only: whether to load the configs only, not including backing up config files, display them, and
         setting up logger.
     :return: a global cfg object used by the DefaultExecutor or Analyzer
@@ -878,10 +878,7 @@ def init_configs(args: Optional[List[str]] = None, which_entry: object = None, l
                     load_custom_operators(cfg.custom_operator_paths)
 
                 # check the entry
-                from data_juicer.core.analyzer import Analyzer
-                from data_juicer.core.ray_analyzer import RayAnalyzer
-
-                if not isinstance(which_entry, (Analyzer, RayAnalyzer)) and cfg.auto:
+                if cfg.auto and not allow_auto:
                     err_msg = "--auto argument can only be used for analyzer!"
                     logger.error(err_msg)
                     raise NotImplementedError(err_msg)

--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -879,8 +879,9 @@ def init_configs(args: Optional[List[str]] = None, which_entry: object = None, l
 
                 # check the entry
                 from data_juicer.core.analyzer import Analyzer
+                from data_juicer.core.ray_analyzer import RayAnalyzer
 
-                if not isinstance(which_entry, Analyzer) and cfg.auto:
+                if not isinstance(which_entry, (Analyzer, RayAnalyzer)) and cfg.auto:
                     err_msg = "--auto argument can only be used for analyzer!"
                     logger.error(err_msg)
                     raise NotImplementedError(err_msg)

--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -800,7 +800,7 @@ def build_base_parser() -> ArgumentParser:
     return parser
 
 
-def init_configs(args: Optional[List[str]] = None, allow_auto: bool = False, load_configs_only=False):
+def init_configs(args: Optional[List[str]] = None, allow_auto: bool = False, load_configs_only=False, **kwargs):
     """
     initialize the jsonargparse parser and parse configs from one of:
         1. POSIX-style commands line args;
@@ -814,6 +814,22 @@ def init_configs(args: Optional[List[str]] = None, allow_auto: bool = False, loa
         setting up logger.
     :return: a global cfg object used by the DefaultExecutor or Analyzer
     """
+    # Backwards compatibility: accept deprecated `which_entry` keyword
+    if "which_entry" in kwargs:
+        import warnings
+
+        warnings.warn(
+            "The 'which_entry' parameter is deprecated. " "Use 'allow_auto=True' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        which_entry = kwargs.pop("which_entry")
+        if not allow_auto and which_entry is not None:
+            from data_juicer.core.analyzer import Analyzer
+
+            allow_auto = isinstance(which_entry, Analyzer)
+    if kwargs:
+        raise TypeError(f"init_configs() got unexpected keyword arguments: " f"{list(kwargs.keys())}")
     # Optional: stdlib json for HF datasets JSONL (avoids ujson "Value is too big!")
     from data_juicer.utils.datasets_json_compat import (
         apply_stdlib_json_patch_for_datasets,

--- a/data_juicer/core/__init__.py
+++ b/data_juicer/core/__init__.py
@@ -4,6 +4,7 @@ from .data import NestedDataset
 from .executor import DefaultExecutor, ExecutorBase, ExecutorFactory
 from .exporter import Exporter
 from .monitor import Monitor
+from .ray_analyzer import RayAnalyzer
 from .ray_exporter import RayExporter
 from .tracer import Tracer
 
@@ -15,6 +16,7 @@ __all__ = [
     "ExecutorFactory",
     "DefaultExecutor",
     "Exporter",
+    "RayAnalyzer",
     "RayExporter",
     "Monitor",
     "Tracer",

--- a/data_juicer/core/analyzer.py
+++ b/data_juicer/core/analyzer.py
@@ -39,7 +39,7 @@ class Analyzer:
 
         :param cfg: optional jsonargparse Namespace dict.
         """
-        self.cfg = init_configs(which_entry=self) if cfg is None else cfg
+        self.cfg = init_configs(allow_auto=True) if cfg is None else cfg
 
         self.work_dir = self.cfg.work_dir
 

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -155,7 +155,7 @@ class RayDataset(DJDataset):
 
         return [row[column] for row in self.data.take()]
 
-    def process(self, operators, *, exporter=None, checkpointer=None, tracer=None) -> DJDataset:
+    def process(self, operators, *, exporter=None, checkpointer=None, tracer=None, stats_only=False) -> DJDataset:
         if operators is None:
             return self
         if not isinstance(operators, list):
@@ -188,7 +188,7 @@ class RayDataset(DJDataset):
 
         for op in operators:
             try:
-                cached_columns = self._run_single_op(op, cached_columns, tracer=tracer)
+                cached_columns = self._run_single_op(op, cached_columns, tracer=tracer, stats_only=stats_only)
             except Exception as e:
                 logger.error(f"Error processing operator {op}: {e}.")
                 if op.runtime_env is not None:
@@ -196,14 +196,14 @@ class RayDataset(DJDataset):
                     original_runtime_env = op.runtime_env
                     try:
                         op.runtime_env = None
-                        cached_columns = self._run_single_op(op, cached_columns, tracer=tracer)
+                        cached_columns = self._run_single_op(op, cached_columns, tracer=tracer, stats_only=stats_only)
                     finally:
                         op.runtime_env = original_runtime_env
                 else:
                     raise e
         return self
 
-    def _run_single_op(self, op, cached_columns=None, tracer=None):
+    def _run_single_op(self, op, cached_columns=None, tracer=None, stats_only=False):
         # Use cached columns to avoid calling self.data.columns() which breaks pipeline
         if cached_columns is None:
             cached_columns = set(self.data.columns())
@@ -312,35 +312,36 @@ class RayDataset(DJDataset):
                         self.data = self.data.materialize()
                 if op.stats_export_path is not None:
                     self.data.write_json(op.stats_export_path, force_ascii=False)
-                # Wrap process method with tracer for sample-level collection
-                original_process = None
-                if tracer and should_trace_op(tracer, op._name):
-                    from data_juicer.ops.base_op import wrap_filter_with_tracer
+                if not stats_only:
+                    # Wrap process method with tracer for sample-level collection
+                    original_process = None
+                    if tracer and should_trace_op(tracer, op._name):
+                        from data_juicer.ops.base_op import wrap_filter_with_tracer
 
-                    original_process = op.process
-                    op.process = wrap_filter_with_tracer(original_process, op._name, tracer, op.is_batched_op())
+                        original_process = op.process
+                        op.process = wrap_filter_with_tracer(original_process, op._name, tracer, op.is_batched_op())
 
-                try:
-                    if op.is_batched_op():
-                        # The core computation have been done in compute_stats,
-                        # and the filter process only performs simple filtering.
-                        # cpu and parallelism are not set here
-                        self.data = self.data.map_batches(
-                            partial(filter_batch, filter_func=op.process),
-                            batch_format="pyarrow",
-                            zero_copy_batch=True,
-                            batch_size=DEFAULT_BATCH_SIZE,
-                            runtime_env=op.runtime_env,
-                        )
-                    else:
-                        self.data = self.data.filter(
-                            op.process,
-                            runtime_env=op.runtime_env,
-                        )
-                finally:
-                    # Restore original process method
-                    if tracer and should_trace_op(tracer, op._name) and original_process:
-                        op.process = original_process
+                    try:
+                        if op.is_batched_op():
+                            # The core computation have been done in compute_stats,
+                            # and the filter process only performs simple filtering.
+                            # cpu and parallelism are not set here
+                            self.data = self.data.map_batches(
+                                partial(filter_batch, filter_func=op.process),
+                                batch_format="pyarrow",
+                                zero_copy_batch=True,
+                                batch_size=DEFAULT_BATCH_SIZE,
+                                runtime_env=op.runtime_env,
+                            )
+                        else:
+                            self.data = self.data.filter(
+                                op.process,
+                                runtime_env=op.runtime_env,
+                            )
+                    finally:
+                        # Restore original process method
+                        if tracer and should_trace_op(tracer, op._name) and original_process:
+                            op.process = original_process
             elif isinstance(op, (Deduplicator, Pipeline)):
                 self.data = op.run(self.data)
             else:

--- a/data_juicer/core/ray_analyzer.py
+++ b/data_juicer/core/ray_analyzer.py
@@ -57,7 +57,11 @@ class RayAnalyzer:
 
         from data_juicer.utils.ray_utils import initialize_ray
 
-        initialize_ray(cfg=cfg)
+        try:
+            initialize_ray(cfg=self.cfg)
+        except ConnectionError:
+            logger.info("No existing Ray cluster found, starting a local one...")
+            ray.init(ignore_reinit_error=True)
 
         self.dataset_builder = DatasetBuilder(self.cfg, executor_type="ray")
 

--- a/data_juicer/core/ray_analyzer.py
+++ b/data_juicer/core/ray_analyzer.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pandas as pd
 import pyarrow
+import pyarrow.compute as pc
 from jsonargparse import Namespace
 from loguru import logger
 from pydantic import PositiveInt
@@ -52,7 +53,7 @@ class RayAnalyzer:
     """
 
     def __init__(self, cfg: Optional[Namespace] = None):
-        self.cfg = init_configs(which_entry=self) if cfg is None else cfg
+        self.cfg = init_configs(allow_auto=True) if cfg is None else cfg
         self.work_dir = self.cfg.work_dir
 
         from data_juicer.utils.ray_utils import initialize_ray
@@ -142,7 +143,7 @@ class RayAnalyzer:
     def _compute_overall(self, dataset):
         os.makedirs(self.analysis_path, exist_ok=True)
 
-        from ray.data.aggregate import Max, Mean, Min, Std
+        from ray.data.aggregate import Count, Max, Mean, Min, Std
 
         select_cols = []
         available_cols = dataset.data.columns()
@@ -163,6 +164,8 @@ class RayAnalyzer:
             return pd.DataFrame()
 
         numeric_cols = []
+        list_numeric_cols = []
+        skipped_cols = []
         arrow_schema = flat_data.schema()
         if hasattr(arrow_schema, "base_schema"):
             arrow_schema = arrow_schema.base_schema
@@ -171,27 +174,52 @@ class RayAnalyzer:
             field_type = arrow_schema.field(idx).type
             if pyarrow.types.is_integer(field_type) or pyarrow.types.is_floating(field_type):
                 numeric_cols.append(col_name)
+            elif pyarrow.types.is_list(field_type) or pyarrow.types.is_large_list(field_type):
+                value_type = field_type.value_type
+                if pyarrow.types.is_integer(value_type) or pyarrow.types.is_floating(value_type):
+                    list_numeric_cols.append(col_name)
+                else:
+                    skipped_cols.append(col_name)
+            else:
+                skipped_cols.append(col_name)
 
-        if not numeric_cols:
+        if skipped_cols:
+            logger.warning(f"Skipping non-numeric columns in overall analysis: {skipped_cols}")
+
+        if not numeric_cols and not list_numeric_cols:
             logger.warning("No numeric stat columns found")
             return pd.DataFrame()
 
-        total_count = flat_data.count()
-
-        aggs = []
-        for col in numeric_cols:
-            aggs.extend([Mean(col), Std(col), Min(col), Max(col)])
-
-        agg_result = flat_data.aggregate(*aggs)
-
         rows = {}
-        for col in numeric_cols:
+
+        if numeric_cols:
+            aggs = []
+            for col in numeric_cols:
+                aggs.extend([Count(col), Mean(col), Std(col), Min(col), Max(col)])
+
+            agg_result = flat_data.aggregate(*aggs)
+
+            for col in numeric_cols:
+                rows[col] = {
+                    "count": agg_result[f"count({col})"],
+                    "mean": agg_result[f"mean({col})"],
+                    "std": agg_result[f"std({col})"],
+                    "min": agg_result[f"min({col})"],
+                    "max": agg_result[f"max({col})"],
+                }
+
+        for col in list_numeric_cols:
+            col_data = flat_data.select_columns([col]).map_batches(
+                lambda table, c=col: pyarrow.table({c: pc.list_flatten(table.column(c))}),
+                batch_format="pyarrow",
+            )
+            col_agg = col_data.aggregate(Count(col), Mean(col), Std(col), Min(col), Max(col))
             rows[col] = {
-                "count": total_count,
-                "mean": agg_result[f"mean({col})"],
-                "std": agg_result[f"std({col})"],
-                "min": agg_result[f"min({col})"],
-                "max": agg_result[f"max({col})"],
+                "count": col_agg[f"count({col})"],
+                "mean": col_agg[f"mean({col})"],
+                "std": col_agg[f"std({col})"],
+                "min": col_agg[f"min({col})"],
+                "max": col_agg[f"max({col})"],
             }
 
         overall = pd.DataFrame(rows)

--- a/data_juicer/core/ray_analyzer.py
+++ b/data_juicer/core/ray_analyzer.py
@@ -1,0 +1,197 @@
+import os
+from typing import Optional
+
+import pandas as pd
+import pyarrow
+from jsonargparse import Namespace
+from loguru import logger
+from pydantic import PositiveInt
+
+from data_juicer.config import init_configs
+from data_juicer.core.data.dataset_builder import DatasetBuilder
+from data_juicer.core.ray_exporter import RayExporter
+from data_juicer.ops import NON_STATS_FILTERS, TAGGING_OPS, Filter, load_ops
+from data_juicer.ops.op_fusion import fuse_operators
+from data_juicer.utils.constant import DEFAULT_PREFIX, Fields
+from data_juicer.utils.lazy_loader import LazyLoader
+
+ray = LazyLoader("ray")
+
+
+def _flatten_stats_batch(table: pyarrow.Table):
+    """Flatten the stats/meta dict column into separate top-level columns."""
+    result_columns = {}
+    for col_name in [Fields.stats, Fields.meta]:
+        if col_name not in table.column_names:
+            continue
+        col = table.column(col_name)
+        dicts = col.to_pylist()
+        if not dicts or not isinstance(dicts[0], dict):
+            continue
+        keys = set()
+        for d in dicts:
+            if isinstance(d, dict):
+                keys.update(d.keys())
+        if col_name == Fields.meta:
+            keys = {k for k in keys if k.startswith(DEFAULT_PREFIX)}
+        for key in keys:
+            result_columns[key] = [d.get(key) if isinstance(d, dict) else None for d in dicts]
+    if not result_columns:
+        return table
+    arrays = {k: pyarrow.array(v) for k, v in result_columns.items()}
+    return pyarrow.table(arrays)
+
+
+class RayAnalyzer:
+    """
+    Analyzer that uses Ray for distributed stats computation.
+
+    Computes filter stats in parallel via Ray, then uses Ray's native
+    aggregation (Mean, Std, Min, Max, Count) for overall analysis.
+    No data is materialized to pandas — all computation stays distributed.
+    """
+
+    def __init__(self, cfg: Optional[Namespace] = None):
+        self.cfg = init_configs(which_entry=self) if cfg is None else cfg
+        self.work_dir = self.cfg.work_dir
+
+        from data_juicer.utils.ray_utils import initialize_ray
+
+        initialize_ray(cfg=cfg)
+
+        self.dataset_builder = DatasetBuilder(self.cfg, executor_type="ray")
+
+        self.exporter = RayExporter(
+            self.cfg.export_path,
+            self.cfg.export_type,
+            self.cfg.export_shard_size,
+            keep_stats_in_res_ds=True,
+        )
+
+        self.overall_result = None
+        self.analysis_path = os.path.join(self.cfg.work_dir, "analysis")
+
+    def run(
+        self,
+        dataset=None,
+        load_data_np: Optional[PositiveInt] = None,
+        skip_export: bool = False,
+        skip_return: bool = False,
+    ):
+        if dataset is None:
+            logger.info("Loading dataset via Ray...")
+            dataset = self.dataset_builder.load_dataset()
+        else:
+            logger.info(f"Using existing dataset {dataset}")
+
+        if self.cfg.auto:
+            count = dataset.data.count()
+            limit = min(count, self.cfg.auto_num)
+            if limit < count:
+                logger.info(f"Auto mode: sampling {limit}/{count} rows " f"for analysis")
+                dataset.data = dataset.data.limit(limit)
+
+        logger.info("Preparing process operators...")
+        ops = load_ops(self.cfg.process)
+
+        if self.cfg.op_fusion:
+            probe_res = None
+            logger.info(f"Start OP fusion and reordering with strategy " f"[{self.cfg.fusion_strategy}]...")
+            ops = fuse_operators(
+                ops,
+                probe_res,
+                mapper_fusion=False,
+                mapper_fusion_vram_limit=getattr(self.cfg, "mapper_fusion_vram_limit", 0.9),
+            )
+
+        filter_ops = [op for op in ops if isinstance(op, Filter) and op._name not in NON_STATS_FILTERS.modules]
+        tagging_ops = [
+            op for op in ops if op._name in TAGGING_OPS.modules or getattr(op, "_contains_tagging_ops", False)
+        ]
+
+        if not filter_ops and not tagging_ops:
+            logger.warning(
+                "No stats/meta collected. Please add some Filter " "OPs or Tagging OPs to the process list in configs."
+            )
+            if not skip_return:
+                return dataset
+
+        logger.info(f"Computing stats with Ray ({len(filter_ops)} filters, " f"{len(tagging_ops)} tagging ops)...")
+
+        if filter_ops:
+            dataset = dataset.process(filter_ops, stats_only=True)
+
+        if tagging_ops:
+            dataset = dataset.process(tagging_ops)
+
+        if not skip_export:
+            logger.info("Exporting dataset to disk...")
+            self.exporter.export(dataset.data)
+
+        logger.info("Computing overall analysis via Ray aggregation...")
+        self.overall_result = self._compute_overall(dataset)
+        logger.info(f"The overall analysis results are: {self.overall_result}")
+
+        if not skip_return:
+            return dataset
+
+    def _compute_overall(self, dataset):
+        os.makedirs(self.analysis_path, exist_ok=True)
+
+        from ray.data.aggregate import Max, Mean, Min, Std
+
+        select_cols = []
+        available_cols = dataset.data.columns()
+        if Fields.stats in available_cols:
+            select_cols.append(Fields.stats)
+        if Fields.meta in available_cols:
+            select_cols.append(Fields.meta)
+
+        if not select_cols:
+            logger.warning("No stats or meta columns found in dataset")
+            return pd.DataFrame()
+
+        flat_data = dataset.data.select_columns(select_cols).map_batches(_flatten_stats_batch, batch_format="pyarrow")
+
+        flat_cols = flat_data.columns()
+        if not flat_cols:
+            logger.warning("No stat columns after flattening")
+            return pd.DataFrame()
+
+        numeric_cols = []
+        arrow_schema = flat_data.schema()
+        if hasattr(arrow_schema, "base_schema"):
+            arrow_schema = arrow_schema.base_schema
+        for col_name in flat_cols:
+            idx = arrow_schema.get_field_index(col_name)
+            field_type = arrow_schema.field(idx).type
+            if pyarrow.types.is_integer(field_type) or pyarrow.types.is_floating(field_type):
+                numeric_cols.append(col_name)
+
+        if not numeric_cols:
+            logger.warning("No numeric stat columns found")
+            return pd.DataFrame()
+
+        total_count = flat_data.count()
+
+        aggs = []
+        for col in numeric_cols:
+            aggs.extend([Mean(col), Std(col), Min(col), Max(col)])
+
+        agg_result = flat_data.aggregate(*aggs)
+
+        rows = {}
+        for col in numeric_cols:
+            rows[col] = {
+                "count": total_count,
+                "mean": agg_result[f"mean({col})"],
+                "std": agg_result[f"std({col})"],
+                "min": agg_result[f"min({col})"],
+                "max": agg_result[f"max({col})"],
+            }
+
+        overall = pd.DataFrame(rows)
+        overall.to_csv(os.path.join(self.analysis_path, "overall.csv"))
+        overall.to_markdown(os.path.join(self.analysis_path, "overall.md"))
+
+        return overall

--- a/demos/analyze_simple/ray_analyzer.yaml
+++ b/demos/analyze_simple/ray_analyzer.yaml
@@ -1,11 +1,11 @@
 # Analyzer config for Ray mode
-project_name: 'demo-ray-analyze'
-dataset_path: './demos/process_on_ray/data/demo-dataset.jsonl'
+project_name: 'demo-ray-analyzer'
+dataset_path: './demos/data/demo-dataset.jsonl' 
 
 executor_type: 'ray'  # Set the executor type to "ray"
 ray_address: 'auto'  # Set an automatic Ray address
 
-export_path: './outputs/demo-ray-analyze/demo-analyzed.jsonl'
+export_path: './outputs/demo-ray-analyzer'
 
 # process schedule
 # a list of several process operators with their arguments

--- a/demos/process_on_ray/configs/analyze.yaml
+++ b/demos/process_on_ray/configs/analyze.yaml
@@ -1,0 +1,22 @@
+# Analyzer config for Ray mode
+project_name: 'demo-ray-analyze'
+dataset_path: './demos/process_on_ray/data/demo-dataset.jsonl'
+
+executor_type: 'ray'  # Set the executor type to "ray"
+ray_address: 'auto'  # Set an automatic Ray address
+
+export_path: './outputs/demo-ray-analyze/demo-analyzed.jsonl'
+
+# process schedule
+# a list of several process operators with their arguments
+process:
+  - text_length_filter:
+      min_len: 10
+      max_len: 10000
+  - words_num_filter:
+      lang: en
+      min_num: 10
+      max_num: 10000
+  - alphanumeric_filter:
+      min_ratio: 0.25
+      max_ratio: 0.9

--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -55,6 +55,31 @@ We tested the MinHash-based RayDeduplicator on datasets sized at 200GB, 1TB, and
 | 4 * 160 | 11.13 min  | 50.83 min | 285.43 min |
 | 8 * 160 | 7.47 min   | 30.08 min | 168.10 min |
 
+## Distributed Data Analysis
+
+In addition to distributed data processing, Data-Juicer also supports distributed data analysis via [RayAnalyzer](../data_juicer/core/ray_analyzer.py), the distributed counterpart to the local `Analyzer`.
+
+### How It Works
+
+RayAnalyzer uses the same `dj-analyze` CLI entry point as the local Analyzer. When `executor_type` is set to `ray` in the config, `dj-analyze` automatically dispatches to `RayAnalyzer`. The workflow is:
+
+1. **Load data** via Ray's distributed data loading (JSON, CSV, Parquet).
+2. **Compute stats** by running each Filter's `compute_stats` function through Ray `map_batches` — the same stats computation as local mode, but distributed.
+3. **Aggregate overall statistics** using Ray native aggregation operators (`Mean`, `Std`, `Min`, `Max`) — no pandas materialization, making it suitable for datasets of any scale.
+4. **Export** the dataset with stats columns to disk via `RayExporter`.
+
+### Differences from Local Analyzer
+
+| Feature | Local Analyzer | RayAnalyzer |
+|---|---|---|
+| Overall stats (count/mean/std/min/max) | Yes | Yes |
+| Per-column distribution charts | Yes | No |
+| Correlation analysis | Yes | No |
+| Percentiles | Yes | No |
+| Scalability | Single machine | Distributed (Ray cluster) |
+
+RayAnalyzer focuses on computing overall statistics at scale. For detailed visualization and correlation analysis, use the local Analyzer on a sampled subset.
+
 ## Quick Start
 
 Before starting, you should install Data-Juicer and its `dist` requirements:
@@ -79,6 +104,7 @@ We provide simple demos in the directory `demos/process_on_ray/`, which includes
 ```text
 demos/process_on_ray
 ├── configs
+│   ├── analyze.yaml
 │   ├── demo.yaml
 │   └── dedup.yaml
 └── data
@@ -146,3 +172,38 @@ dj-process --config demos/process_on_ray/configs/dedup.yaml
 ```
 
 Data-Juicer will dedup the demo dataset with the demo config file and export the result datasets to the directory specified by the `export_path` argument in the config file.
+
+### Running Example of Ray Analysis
+
+In the `analyze.yaml` config file, we set the executor type to "ray" to use the distributed `RayAnalyzer`.
+
+```yaml
+project_name: 'demo-ray-analyze'
+dataset_path: './demos/process_on_ray/data/demo-dataset.jsonl'
+
+executor_type: 'ray'  # Set the executor type to "ray"
+ray_address: 'auto'  # Set an automatic Ray address
+
+export_path: './outputs/demo-ray-analyze/demo-analyzed.jsonl'
+
+process:
+  - text_length_filter:
+      min_len: 10
+      max_len: 10000
+  - words_num_filter:
+      lang: en
+      min_num: 10
+      max_num: 10000
+```
+
+Run the demo to analyze the dataset:
+
+```shell
+# Run the tool from source
+python tools/analyze_data.py --config demos/process_on_ray/configs/analyze.yaml
+
+# Use the command-line tool
+dj-analyze --config demos/process_on_ray/configs/analyze.yaml
+```
+
+`RayAnalyzer` will compute the overall statistics (count, mean, std, min, max) for all numeric stats columns and print the results. The dataset with computed stats will be exported to the path specified by `export_path`.

--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -104,7 +104,6 @@ We provide simple demos in the directory `demos/process_on_ray/`, which includes
 ```text
 demos/process_on_ray
 ├── configs
-│   ├── analyze.yaml
 │   ├── demo.yaml
 │   └── dedup.yaml
 └── data
@@ -175,16 +174,16 @@ Data-Juicer will dedup the demo dataset with the demo config file and export the
 
 ### Running Example of Ray Analysis
 
-In the `analyze.yaml` config file, we set the executor type to "ray" to use the distributed `RayAnalyzer`.
+In [`demos/analyze_simple/ray_analyzer.yaml`](../demos/analyze_simple/ray_analyzer.yaml), we set the executor type to "ray" to use the distributed `RayAnalyzer`.
 
 ```yaml
-project_name: 'demo-ray-analyze'
-dataset_path: './demos/process_on_ray/data/demo-dataset.jsonl'
+project_name: 'demo-ray-analyzer'
+dataset_path: './demos/data/demo-dataset.jsonl'
 
 executor_type: 'ray'  # Set the executor type to "ray"
 ray_address: 'auto'  # Set an automatic Ray address
 
-export_path: './outputs/demo-ray-analyze/demo-analyzed.jsonl'
+export_path: './outputs/demo-ray-analyzer'
 
 process:
   - text_length_filter:
@@ -194,16 +193,19 @@ process:
       lang: en
       min_num: 10
       max_num: 10000
+  - alphanumeric_filter:
+      min_ratio: 0.25
+      max_ratio: 0.9
 ```
 
 Run the demo to analyze the dataset:
 
 ```shell
 # Run the tool from source
-python tools/analyze_data.py --config demos/process_on_ray/configs/analyze.yaml
+python tools/analyze_data.py --config demos/analyze_simple/ray_analyzer.yaml
 
 # Use the command-line tool
-dj-analyze --config demos/process_on_ray/configs/analyze.yaml
+dj-analyze --config demos/analyze_simple/ray_analyzer.yaml
 ```
 
 `RayAnalyzer` will compute the overall statistics (count, mean, std, min, max) for all numeric stats columns and print the results. The dataset with computed stats will be exported to the path specified by `export_path`.

--- a/docs/Distributed_ZH.md
+++ b/docs/Distributed_ZH.md
@@ -106,7 +106,6 @@ ray start --address='{head_ip}:6379'
 ```text
 demos/process_on_ray
 ├── configs
-│   ├── analyze.yaml
 │   ├── demo.yaml
 │   └── dedup.yaml
 └── data
@@ -176,16 +175,16 @@ Data-Juicer 会使用示例配置文件对示例数据集去重，并将结果�
 
 ### 运行 Ray 分析样例
 
-在配置文件 `analyze.yaml` 中，我们将执行器类型设置为 "ray" 来使用分布式的 `RayAnalyzer`。
+在 [`demos/analyze_simple/ray_analyzer.yaml`](../demos/analyze_simple/ray_analyzer.yaml) 配置文件中，我们将执行器类型设置为 "ray" 来使用分布式的 `RayAnalyzer`。
 
 ```yaml
-project_name: 'demo-ray-analyze'
-dataset_path: './demos/process_on_ray/data/demo-dataset.jsonl'
+project_name: 'demo-ray-analyzer'
+dataset_path: './demos/data/demo-dataset.jsonl'
 
 executor_type: 'ray'  # 将执行器类型设置为 "ray"
 ray_address: 'auto'  # 设置为自动 Ray 地址
 
-export_path: './outputs/demo-ray-analyze/demo-analyzed.jsonl'
+export_path: './outputs/demo-ray-analyzer'
 
 process:
   - text_length_filter:
@@ -195,16 +194,19 @@ process:
       lang: en
       min_num: 10
       max_num: 10000
+  - alphanumeric_filter:
+      min_ratio: 0.25
+      max_ratio: 0.9
 ```
 
 运行该示例来分析数据集：
 
 ```shell
 # 从源码运行分析工具
-python tools/analyze_data.py --config demos/process_on_ray/configs/analyze.yaml
+python tools/analyze_data.py --config demos/analyze_simple/ray_analyzer.yaml
 
 # 使用命令行工具
-dj-analyze --config demos/process_on_ray/configs/analyze.yaml
+dj-analyze --config demos/analyze_simple/ray_analyzer.yaml
 ```
 
 `RayAnalyzer` 会计算所有数值统计列的总体统计信息（count、mean、std、min、max）并打印结果。带有计算好的统计列的数据集将导出到 `export_path` 指定的路径。

--- a/docs/Distributed_ZH.md
+++ b/docs/Distributed_ZH.md
@@ -57,6 +57,31 @@ Data-Juicer 支持基于 [Ray](https://github.com/ray-project/ray) 和阿里巴�
 | 4 * 160 | 11.13 分钟 | 50.83 分钟 | 285.43 分钟 |
 | 8 * 160 | 7.47 分钟  | 30.08 分钟 | 168.10 分钟 |
 
+## 分布式数据分析
+
+除了分布式数据处理外，Data-Juicer 还通过 [RayAnalyzer](../data_juicer/core/ray_analyzer.py) 支持分布式数据分析，它是本地 `Analyzer` 的分布式版本。
+
+### 工作原理
+
+RayAnalyzer 使用与本地 Analyzer 相同的 `dj-analyze` 命令行入口。当配置文件中 `executor_type` 设置为 `ray` 时，`dj-analyze` 会自动调度到 `RayAnalyzer`。工作流程如下：
+
+1. **加载数据** — 通过 Ray 的分布式数据加载能力（支持 JSON、CSV、Parquet）。
+2. **计算统计信息** — 通过 Ray `map_batches` 分布式执行每个 Filter 的 `compute_stats` 函数，与本地模式使用相同的统计计算逻辑。
+3. **聚合总体统计** — 使用 Ray 原生聚合算子（`Mean`、`Std`、`Min`、`Max`）计算总体统计信息，无需 pandas 物化，适用于任意规模的数据集。
+4. **导出** — 通过 `RayExporter` 将带有统计列的数据集导出到磁盘。
+
+### 与本地 Analyzer 的差异
+
+| 特性 | 本地 Analyzer | RayAnalyzer |
+|---|---|---|
+| 总体统计（count/mean/std/min/max） | 支持 | 支持 |
+| 逐列分布图表 | 支持 | 不支持 |
+| 相关性分析 | 支持 | 不支持 |
+| 分位数 | 支持 | 不支持 |
+| 可扩展性 | 单机 | 分布式（Ray 集群） |
+
+RayAnalyzer 专注于在大规模数据上计算总体统计信息。如果需要详细的可视化和相关性分析，建议对采样子集使用本地 Analyzer。
+
 ## 快速开始
 
 在开始前，你应该安装 Data-Juicer 以及它的 `dist` 依赖需求：
@@ -81,6 +106,7 @@ ray start --address='{head_ip}:6379'
 ```text
 demos/process_on_ray
 ├── configs
+│   ├── analyze.yaml
 │   ├── demo.yaml
 │   └── dedup.yaml
 └── data
@@ -147,3 +173,38 @@ dj-process --config demos/process_on_ray/configs/dedup.yaml
 ```
 
 Data-Juicer 会使用示例配置文件对示例数据集去重，并将结果数据集导出到配置文件中 `export_path` 参数指定的目录中。
+
+### 运行 Ray 分析样例
+
+在配置文件 `analyze.yaml` 中，我们将执行器类型设置为 "ray" 来使用分布式的 `RayAnalyzer`。
+
+```yaml
+project_name: 'demo-ray-analyze'
+dataset_path: './demos/process_on_ray/data/demo-dataset.jsonl'
+
+executor_type: 'ray'  # 将执行器类型设置为 "ray"
+ray_address: 'auto'  # 设置为自动 Ray 地址
+
+export_path: './outputs/demo-ray-analyze/demo-analyzed.jsonl'
+
+process:
+  - text_length_filter:
+      min_len: 10
+      max_len: 10000
+  - words_num_filter:
+      lang: en
+      min_num: 10
+      max_num: 10000
+```
+
+运行该示例来分析数据集：
+
+```shell
+# 从源码运行分析工具
+python tools/analyze_data.py --config demos/process_on_ray/configs/analyze.yaml
+
+# 使用命令行工具
+dj-analyze --config demos/process_on_ray/configs/analyze.yaml
+```
+
+`RayAnalyzer` 会计算所有数值统计列的总体统计信息（count、mean、std、min、max）并打印结果。带有计算好的统计列的数据集将导出到 `export_path` 指定的路径。

--- a/docs/tutorial/QuickStart.md
+++ b/docs/tutorial/QuickStart.md
@@ -109,7 +109,7 @@ python tools/analyze_data.py --config demos/analyze_simple/analyzer.yaml
 - **Distributed Analysis with Ray:** `dj-analyze` also supports Ray mode for large-scale distributed analysis. Set `executor_type: ray` in your config file, and the analyzer will automatically use `RayAnalyzer`, which computes overall statistics (count/mean/std/min/max) via Ray native aggregation without pandas materialization. Note that RayAnalyzer does not produce per-column distribution charts or correlation analysis. More details can be found in the doc for [distributed processing](../Distributed.md).
 
 ```shell
-dj-analyze --config demos/process_on_ray/configs/analyze.yaml
+dj-analyze --config demos/analyze_simple/ray_analyzer.yaml
 ```
 
 ## Data Visualization

--- a/docs/tutorial/QuickStart.md
+++ b/docs/tutorial/QuickStart.md
@@ -106,6 +106,12 @@ export ANALYZER_FONT="Heiti TC"  # Use Heiti for Chinese characters. And it's th
 python tools/analyze_data.py --config demos/analyze_simple/analyzer.yaml
 ```
 
+- **Distributed Analysis with Ray:** `dj-analyze` also supports Ray mode for large-scale distributed analysis. Set `executor_type: ray` in your config file, and the analyzer will automatically use `RayAnalyzer`, which computes overall statistics (count/mean/std/min/max) via Ray native aggregation without pandas materialization. Note that RayAnalyzer does not produce per-column distribution charts or correlation analysis. More details can be found in the doc for [distributed processing](../Distributed.md).
+
+```shell
+dj-analyze --config demos/process_on_ray/configs/analyze.yaml
+```
+
 ## Data Visualization
 
 - Run `app.py` tool to visualize your dataset in your browser.

--- a/docs/tutorial/QuickStart_ZH.md
+++ b/docs/tutorial/QuickStart_ZH.md
@@ -104,6 +104,12 @@ export ANALYZER_FONT="Heiti TC"  # 使用黑体来支持中文字符，这也是
 python tools/analyze_data.py --config demos/analyze_simple/analyzer.yaml
 ```
 
+- **基于 Ray 的分布式分析：** `dj-analyze` 同样支持 Ray 模式进行大规模分布式数据分析。在配置文件中设置 `executor_type: ray`，分析器将自动使用 `RayAnalyzer`，通过 Ray 原生聚合算子计算总体统计信息（count/mean/std/min/max），无需 pandas 物化。注意 RayAnalyzer 不会产出逐列分布图表或相关性分析。更多细节请参考[分布式处理文档](../Distributed_ZH.md)。
+
+```shell
+dj-analyze --config demos/process_on_ray/configs/analyze.yaml
+```
+
 ## 数据可视化
 
 * 运行 `app.py` 来在浏览器中可视化您的数据集。

--- a/docs/tutorial/QuickStart_ZH.md
+++ b/docs/tutorial/QuickStart_ZH.md
@@ -107,7 +107,7 @@ python tools/analyze_data.py --config demos/analyze_simple/analyzer.yaml
 - **基于 Ray 的分布式分析：** `dj-analyze` 同样支持 Ray 模式进行大规模分布式数据分析。在配置文件中设置 `executor_type: ray`，分析器将自动使用 `RayAnalyzer`，通过 Ray 原生聚合算子计算总体统计信息（count/mean/std/min/max），无需 pandas 物化。注意 RayAnalyzer 不会产出逐列分布图表或相关性分析。更多细节请参考[分布式处理文档](../Distributed_ZH.md)。
 
 ```shell
-dj-analyze --config demos/process_on_ray/configs/analyze.yaml
+dj-analyze --config demos/analyze_simple/ray_analyzer.yaml
 ```
 
 ## 数据可视化

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -500,18 +500,12 @@ class ConfigTest(DataJuicerTestCaseBase):
             with self.assertRaises(NotImplementedError):
                 init_configs(args=[
                     '--auto',
-                ], which_entry="NoneAnalyzerClass")
+                ], allow_auto=False)
 
             # in analyzer
-            from data_juicer.core import Analyzer
-            cfg = init_configs(args=[
-                '--config', test_yaml_path,
-            ])
-            analyzer = Analyzer(cfg)
-
             cfg_auto = init_configs(args=[
                 '--auto',
-            ], which_entry=analyzer)
+            ], allow_auto=True)
             self.assertTrue(cfg_auto.auto)
             self.assertGreater(len(cfg_auto.process), 0)
 

--- a/tests/core/test_ray_analyzer.py
+++ b/tests/core/test_ray_analyzer.py
@@ -1,0 +1,116 @@
+import os
+import unittest
+
+from data_juicer.config import init_configs
+from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase, TEST_TAG
+
+root_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
+test_yaml_path = os.path.join(root_path, 'tests', 'config', 'demo_4_test.yaml')
+
+
+class RayAnalyzerTest(DataJuicerTestCaseBase):
+
+    def setUp(self):
+        super().setUp()
+        self.tmp_dir = 'tmp/test_ray_analyzer/'
+        os.makedirs(self.tmp_dir, exist_ok=True)
+
+    def tearDown(self):
+        super().tearDown()
+        if os.path.exists(self.tmp_dir):
+            import shutil
+            shutil.rmtree(self.tmp_dir)
+
+    def _get_cfg(self, subdir):
+        cfg = init_configs(
+            ['--config', test_yaml_path],
+            allow_auto=True,
+        )
+        cfg.executor_type = 'ray'
+        cfg.export_path = os.path.join(self.tmp_dir, subdir, 'res.jsonl')
+        cfg.work_dir = os.path.join(self.tmp_dir, subdir)
+        return cfg
+
+    @TEST_TAG('ray')
+    def test_end2end_analysis(self):
+        cfg = self._get_cfg('test_end2end')
+        # use only text filters for basic test
+        cfg.process = [
+            {'text_length_filter': {'min_len': 10, 'max_len': 10000}},
+            {'words_num_filter': {'lang': 'en', 'min_num': 1, 'max_num': 10000}},
+        ]
+
+        from data_juicer.core import RayAnalyzer
+        analyzer = RayAnalyzer(cfg)
+        analyzer.run()
+
+        analysis_dir = os.path.join(cfg.work_dir, 'analysis')
+        self.assertTrue(os.path.exists(analysis_dir))
+        self.assertTrue(os.path.exists(os.path.join(analysis_dir, 'overall.csv')))
+        self.assertTrue(os.path.exists(os.path.join(analysis_dir, 'overall.md')))
+
+        # verify overall_result has expected columns
+        self.assertIsNotNone(analyzer.overall_result)
+        self.assertGreater(len(analyzer.overall_result.columns), 0)
+
+    @TEST_TAG('ray')
+    def test_analysis_without_stats(self):
+        cfg = self._get_cfg('test_no_stats')
+        cfg.process = []
+
+        from data_juicer.core import RayAnalyzer
+        analyzer = RayAnalyzer(cfg)
+        analyzer.run()
+
+        analysis_dir = os.path.join(cfg.work_dir, 'analysis')
+        self.assertFalse(os.path.exists(os.path.join(analysis_dir, 'overall.csv')))
+
+    @TEST_TAG('ray')
+    def test_analysis_with_list_numeric_columns(self):
+        """Test that list-valued numeric stats (e.g. image_width) are
+        correctly flattened and aggregated."""
+        cfg = self._get_cfg('test_list_numeric')
+        cfg.dataset_path = os.path.join(root_path, 'demos/data/demo-dataset-images.jsonl')
+        cfg.process = [
+            {'text_length_filter': {'min_len': 1, 'max_len': 10000}},
+            {'image_shape_filter': {
+                'min_width': 1, 'max_width': 10000,
+                'min_height': 1, 'max_height': 10000,
+            }},
+        ]
+
+        from data_juicer.core import RayAnalyzer
+        analyzer = RayAnalyzer(cfg)
+        analyzer.run()
+
+        overall = analyzer.overall_result
+        self.assertIsNotNone(overall)
+        # image_width and image_height are list-typed stats
+        self.assertIn('image_width', overall.columns)
+        self.assertIn('image_height', overall.columns)
+        # text_len is a scalar stat
+        self.assertIn('text_len', overall.columns)
+        # verify count/mean/std/min/max rows exist
+        for row in ['count', 'mean', 'std', 'min', 'max']:
+            self.assertIn(row, overall.index)
+
+    @TEST_TAG('ray')
+    def test_auto_mode(self):
+        cfg = self._get_cfg('test_auto')
+        cfg.auto = True
+        cfg.auto_num = 3
+        cfg.process = [
+            {'text_length_filter': {'min_len': 1, 'max_len': 10000}},
+        ]
+
+        from data_juicer.core import RayAnalyzer
+        analyzer = RayAnalyzer(cfg)
+        analyzer.run()
+
+        analysis_dir = os.path.join(cfg.work_dir, 'analysis')
+        self.assertTrue(os.path.exists(analysis_dir))
+        self.assertIsNotNone(analyzer.overall_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/analyze_data.py
+++ b/tools/analyze_data.py
@@ -1,11 +1,38 @@
+import sys
+
 from loguru import logger
 
-from data_juicer.core import Analyzer
+
+def _get_executor_type():
+    """Peek at --executor_type or config file to decide which analyzer to use."""
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg == "--executor_type" and i + 1 < len(args):
+            return args[i + 1]
+    for i, arg in enumerate(args):
+        if arg == "--config" and i + 1 < len(args):
+            try:
+                import yaml
+
+                with open(args[i + 1]) as f:
+                    cfg = yaml.safe_load(f)
+                return cfg.get("executor_type", "default")
+            except Exception:
+                pass
+    return "default"
 
 
 @logger.catch(reraise=True)
 def main():
-    analyzer = Analyzer()
+    executor_type = _get_executor_type()
+    if executor_type in ("ray", "ray_partitioned"):
+        from data_juicer.core import RayAnalyzer
+
+        analyzer = RayAnalyzer()
+    else:
+        from data_juicer.core import Analyzer
+
+        analyzer = Analyzer()
     analyzer.run()
 
 

--- a/tools/analyze_data.py
+++ b/tools/analyze_data.py
@@ -1,38 +1,19 @@
-import sys
-
 from loguru import logger
 
-
-def _get_executor_type():
-    """Peek at --executor_type or config file to decide which analyzer to use."""
-    args = sys.argv[1:]
-    for i, arg in enumerate(args):
-        if arg == "--executor_type" and i + 1 < len(args):
-            return args[i + 1]
-    for i, arg in enumerate(args):
-        if arg == "--config" and i + 1 < len(args):
-            try:
-                import yaml
-
-                with open(args[i + 1]) as f:
-                    cfg = yaml.safe_load(f)
-                return cfg.get("executor_type", "default")
-            except Exception:
-                pass
-    return "default"
+from data_juicer.config import init_configs
 
 
 @logger.catch(reraise=True)
 def main():
-    executor_type = _get_executor_type()
-    if executor_type in ("ray", "ray_partitioned"):
+    cfg = init_configs(allow_auto=True)
+    if cfg.executor_type in ("ray", "ray_partitioned"):
         from data_juicer.core import RayAnalyzer
 
-        analyzer = RayAnalyzer()
+        analyzer = RayAnalyzer(cfg)
     else:
         from data_juicer.core import Analyzer
 
-        analyzer = Analyzer()
+        analyzer = Analyzer(cfg)
     analyzer.run()
 
 


### PR DESCRIPTION
## What

Add `RayAnalyzer` for distributed data analysis using Ray, as the counterpart to the local `Analyzer`.

## Changes

- **`data_juicer/core/ray_analyzer.py`** (new): RayAnalyzer class that computes filter stats via Ray `map_batches` and aggregates overall statistics (count/mean/std/min/max) using Ray native aggregation operators — no pandas materialization
- **`data_juicer/core/data/ray_dataset.py`**: Add `stats_only` parameter to `process()` and `_run_single_op()` so stats can be computed without actually filtering rows
- **`tools/analyze_data.py`**: Dispatch `RayAnalyzer` when `executor_type` is `ray` or `ray_partitioned`
- **`data_juicer/config/config.py`** / **`data_juicer/core/__init__.py`**: Register RayAnalyzer
- **`docs/`**: Add Distributed Data Analysis sections to Distributed.md/Distributed_ZH.md, update QuickStart docs
- **`demos/process_on_ray/configs/analyze.yaml`**: Demo config for Ray analysis

## Key Design Decisions

- Uses Ray native `Mean`/`Std`/`Min`/`Max` aggregation — avoids materializing full dataset into pandas
- No per-column distribution charts, correlation analysis, or percentiles in Ray mode — focuses on scalable overall statistics
- Same `dj-analyze` CLI entry point, automatically dispatched by `executor_type`
- Falls back to local `ray.init()` when no existing Ray cluster is found

## Testing

- Verified with 1M-row dataset: stats computation 15s, aggregation 1.9s
- Verified full sandbox pipeline (Probe → Refine → Execute → Evaluate) with Ray mode
- Demo config tested end-to-end