### PR TITLE
fix(calibrate_response_mapper): honor output_pattern when set

### DIFF
--- a/data_juicer/ops/mapper/calibrate_response_mapper.py
+++ b/data_juicer/ops/mapper/calibrate_response_mapper.py
@@ -21,4 +21,10 @@ class CalibrateResponseMapper(CalibrateQAMapper):
         使其更加详细、准确，且仍可以回答原问题。只输出校准后的回答，不要输出多余内容。"
 
     def parse_output(self, raw_output):
+        if self.output_pattern != self.DEFAULT_OUTPUT_PATTERN:
+            import re
+
+            match = re.match(self.output_pattern, raw_output)
+            if match:
+                return None, match.group(match.lastindex).strip()
         return None, raw_output.strip()


### PR DESCRIPTION
## Problem

`CalibrateResponseMapper.parse_output()` ignores the `output_pattern` parameter entirely. The parent class `CalibrateQAMapper` uses `self.output_pattern` for regex extraction, but `CalibrateResponseMapper` overrides `parse_output` to always return `raw_output.strip()`, making the parameter a no-op.

**Before fix:** User sets `output_pattern: 'Answer:\\s*(.*)''`, gets back full raw text `'Answer: my calibrated response'`.

**After fix:** Regex is applied, correctly extracts `'my calibrated response'`.

## Fix

When the user provides a custom `output_pattern` (different from `DEFAULT_OUTPUT_PATTERN`), apply regex matching. Fall back to the original strip behavior if no custom pattern is set or if regex doesn't match.

## Test

```python
mapper = CalibrateResponseMapper(output_pattern=r'Answer:\\s*(.*)')
# Before: parse_output('Answer: foo') → (None, 'Answer: foo')  # BUG
# After:  parse_output('Answer: foo') → (None, 'foo')          # FIXED
# Default behavior (no custom pattern) unchanged
```