### PR TITLE
fix: misc bug fixes and bump fsspec for pyarrow>=17 compat

### DIFF
--- a/data_juicer/core/executor/default_executor.py
+++ b/data_juicer/core/executor/default_executor.py
@@ -167,6 +167,11 @@ class DefaultExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin):
         logger.info("Preparing process operators...")
         ops = load_ops(self.cfg.process)
 
+        if not ops:
+            logger.warning(
+                "No process operators configured. " "The dataset will be exported as-is without any processing."
+            )
+
         # Initialize DAG execution planning (pass ops to avoid redundant loading)
         self._initialize_dag_execution(self.cfg, ops=ops)
 

--- a/data_juicer/core/executor/ray_executor.py
+++ b/data_juicer/core/executor/ray_executor.py
@@ -168,6 +168,11 @@ class RayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin):
         logger.info("Preparing process operators...")
         ops = load_ops(self.cfg.process, self.op_env_manager)
 
+        if not ops:
+            logger.warning(
+                "No process operators configured. " "The dataset will be exported as-is without any processing."
+            )
+
         # Initialize DAG execution planning (pass ops to avoid redundant loading)
         self._initialize_dag_execution(self.cfg, ops=ops)
 

--- a/data_juicer/ops/mapper/image_diffusion_mapper.py
+++ b/data_juicer/ops/mapper/image_diffusion_mapper.py
@@ -155,13 +155,24 @@ class ImageDiffusionMapper(Mapper):
 
         # load captions
         if self.caption_key:
-            captions = ori_sample[self.caption_key]
-            if not isinstance(captions, list):
+            captions = ori_sample.get(self.caption_key)
+            num_images = len(loaded_image_keys)
+            if not captions:
+                # no caption at all (missing key, None or an empty list): an
+                # empty prompt is a valid unconditional prompt for
+                # image-to-image generation, so fall back to it
+                captions = [""] * num_images
+            elif not isinstance(captions, list):
                 # one caption for all images
-                captions = [captions] * len(images)
+                captions = [captions] * num_images
             else:
-                assert len(captions) == len(images), "The num of captions must match the num of images."
-            captions = [remove_special_tokens(c) for c in captions]
+                # a partially filled list carries no hint about which image the
+                # missing captions belong to, so keep failing loudly here; use
+                # None or "" as an explicit placeholder to skip a single image
+                assert len(captions) == num_images, "The num of captions must match the num of images."
+            # a blank entry inside the list is an explicit "no guidance for this
+            # image" placeholder, so normalize it instead of skipping
+            captions = [remove_special_tokens(c) if isinstance(c, str) else "" for c in captions]
         else:
             caption_samples = {
                 self.text_key: [SpecialTokens.image] * len(images),
@@ -226,6 +237,10 @@ class ImageDiffusionMapper(Mapper):
                 samples_after_generation.extend(generated_samples)
 
         # reconstruct samples from "list of dicts" to "dict of lists"
+        if not samples_after_generation:
+            # every sample in this batch was skipped (e.g. no images at all);
+            # keep the "dict of lists" schema so downstream stays consistent
+            return {key: [] for key in samples}
         keys = samples_after_generation[0].keys()
         res_samples = {}
         for key in keys:

--- a/data_juicer/ops/mapper/vggt_mapper.py
+++ b/data_juicer/ops/mapper/vggt_mapper.py
@@ -132,6 +132,10 @@ class VggtMapper(Mapper):
 
     def process_single(self, sample=None, rank=None):
 
+        # ensure __dj__meta__ exists
+        if Fields.meta not in sample or not isinstance(sample[Fields.meta], dict):
+            sample[Fields.meta] = {}
+
         # check if it's generated already
         if self.tag_field_name in sample[Fields.meta]:
             return sample

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 # Core dependencies
 dependencies = [
     "datasets>=4.7.0", # core data loading
-    "fsspec==2023.5.0", # file system operations
+    "fsspec>=2026.1.0", # file system operations; >=2026.1.0 for ArrowFile.size compat with pyarrow>=17
     "pandas", # data manipulation
     "numpy>=1.26.4,<2.0.0", # numerical operations
     "loguru", # logging

--- a/tests/ops/mapper/test_image_diffusion_mapper.py
+++ b/tests/ops/mapper/test_image_diffusion_mapper.py
@@ -1,6 +1,10 @@
+import copy
 import os
 import shutil
 import unittest
+from unittest.mock import patch
+
+from PIL import Image
 
 from data_juicer.utils.resource_utils import cuda_device_count
 from data_juicer.core.data import NestedDataset as Dataset
@@ -183,6 +187,203 @@ class ImageDiffusionMapperTest(DataJuicerTestCaseBase):
                                       'test_for_given_caption_string'),
                          num_proc=num_proc,
                          total_num=aug_num * len(ds_list))
+
+
+class ImageDiffusionMapperEmptyCaptionTest(DataJuicerTestCaseBase):
+    """Regression tests for missing/empty captions.
+
+    An empty prompt is a valid input for image-to-image generation: it simply
+    means "no text guidance, redraw from the image alone". The OP already
+    behaved this way for an empty string, so a missing key, None, an empty list
+    or None entries inside a list must be normalized to an empty prompt and
+    generate as usual, rather than silently dropping the sample.
+
+    ``_real_guidance`` is stubbed so the caption handling runs for real without
+    downloading a diffusion model.
+    """
+
+    data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..',
+                             'data')
+
+    cat_path = os.path.join(data_path, 'cat.jpg')
+    img3_path = os.path.join(data_path, 'img3.jpg')
+
+    aug_num = 2
+
+    def _build_op(self, keep_original_sample, caption_key='caption'):
+        with patch('data_juicer.ops.mapper.image_diffusion_mapper.'
+                   'prepare_model',
+                   return_value='fake_model_key'):
+            return ImageDiffusionMapper(
+                aug_num=self.aug_num,
+                keep_original_sample=keep_original_sample,
+                caption_key=caption_key)
+
+    def _run(self, op, samples):
+        """Run the OP with generation stubbed, returning recorded prompts."""
+        prompts = []
+
+        def fake_guidance(inner_self, caption, image, rank=None):
+            prompts.append(caption)
+            return Image.new('RGB', (8, 8))
+
+        with patch.object(ImageDiffusionMapper, '_real_guidance',
+                          fake_guidance):
+            res = op.process_batched(copy.deepcopy(samples))
+        return res, prompts
+
+    def _assert_generated_with_empty_prompt(self, samples, num_images=1):
+        """Empty captions still generate, using an empty prompt."""
+        num_samples = len(samples['images'])
+
+        # keep_original_sample=False -> only the generated samples remain
+        op = self._build_op(keep_original_sample=False)
+        res, prompts = self._run(op, samples)
+        self.assertEqual(set(res.keys()), set(samples.keys()))
+        self.assertEqual(len(res['images']), self.aug_num * num_samples)
+        # every image of every augmentation is generated from an empty prompt
+        self.assertEqual(len(prompts),
+                         self.aug_num * num_samples * num_images)
+        self.assertTrue(all(p == '' for p in prompts),
+                        f'expected only empty prompts, got {prompts}')
+
+        # keep_original_sample=True -> originals are kept alongside
+        op = self._build_op(keep_original_sample=True)
+        res, _ = self._run(op, samples)
+        self.assertEqual(len(res['images']),
+                         (self.aug_num + 1) * num_samples)
+
+    def test_missing_caption_key(self):
+        samples = {
+            'text': [f'{SpecialTokens.image}a photo of a cat'],
+            'images': [[self.cat_path]],
+        }
+        self._assert_generated_with_empty_prompt(samples)
+
+    def test_none_caption(self):
+        samples = {
+            'text': [f'{SpecialTokens.image}a photo of a cat'],
+            'caption': [None],
+            'images': [[self.cat_path]],
+        }
+        self._assert_generated_with_empty_prompt(samples)
+
+    def test_blank_string_caption(self):
+        samples = {
+            'text': [
+                f'{SpecialTokens.image}a photo of a cat',
+                f'{SpecialTokens.image}a women with an umbrella',
+            ],
+            'caption': ['', '   \t\n'],
+            'images': [[self.cat_path], [self.img3_path]],
+        }
+        self._assert_generated_with_empty_prompt(samples)
+
+    def test_empty_list_caption(self):
+        samples = {
+            'text': [f'{SpecialTokens.image}a photo of a cat'],
+            'caption': [[]],
+            'images': [[self.cat_path]],
+        }
+        self._assert_generated_with_empty_prompt(samples)
+
+    def test_list_with_none_entries(self):
+        samples = {
+            'text': [f'{SpecialTokens.image}, {SpecialTokens.image}'],
+            'caption': [[None, '  ']],
+            'images': [[self.cat_path, self.img3_path]],
+        }
+        self._assert_generated_with_empty_prompt(samples, num_images=2)
+
+    def test_partial_caption_list_still_raises(self):
+        """A partially filled caption list keeps failing loudly.
+
+        Padding a short list would silently pair captions with the wrong
+        images, so the length check is kept. Callers must use an explicit
+        placeholder instead of omitting entries.
+        """
+        samples = {
+            'text': [f'{SpecialTokens.image}, {SpecialTokens.image}'],
+            'caption': [['a photo of a cat']],
+            'images': [[self.cat_path, self.img3_path]],
+        }
+        op = self._build_op(keep_original_sample=False)
+        with self.assertRaises(AssertionError):
+            self._run(op, samples)
+
+    def test_none_placeholder_keeps_alignment(self):
+        """An explicit None placeholder maps to an empty prompt in place."""
+        samples = {
+            'text': [f'{SpecialTokens.image}, {SpecialTokens.image}'],
+            'caption': [['a photo of a cat', None]],
+            'images': [[self.cat_path, self.img3_path]],
+        }
+        op = self._build_op(keep_original_sample=False)
+        res, prompts = self._run(op, samples)
+
+        self.assertEqual(len(res['images']), self.aug_num)
+        self.assertEqual(prompts, ['a photo of a cat', ''] * self.aug_num)
+
+    def test_leading_none_placeholder_keeps_alignment(self):
+        """A placeholder in the first slot must not shift the later caption."""
+        samples = {
+            'text': [f'{SpecialTokens.image}, {SpecialTokens.image}'],
+            'caption': [[None, 'a women with an umbrella']],
+            'images': [[self.cat_path, self.img3_path]],
+        }
+        op = self._build_op(keep_original_sample=False)
+        res, prompts = self._run(op, samples)
+
+        self.assertEqual(len(res['images']), self.aug_num)
+        self.assertEqual(prompts,
+                         ['', 'a women with an umbrella'] * self.aug_num)
+
+    def test_duplicate_images_align_with_key_list(self):
+        """Captions align with the image key list, not the deduplicated dict.
+
+        ``load_data_with_context`` returns a dict keyed by image path, so
+        repeating the same path collapses it. Alignment must follow the image
+        key list, otherwise captions get truncated and indexing overflows.
+        """
+        samples = {
+            'text': [f'{SpecialTokens.image}, {SpecialTokens.image}'],
+            'caption': [['first caption', 'second caption']],
+            'images': [[self.cat_path, self.cat_path]],
+        }
+        op = self._build_op(keep_original_sample=False)
+        res, prompts = self._run(op, samples)
+
+        self.assertEqual(len(res['images']), self.aug_num)
+        self.assertEqual(prompts,
+                         ['first caption', 'second caption'] * self.aug_num)
+
+    def test_empty_list_caption_with_duplicate_images(self):
+        """An empty caption list pads to the full image key count."""
+        samples = {
+            'text': [f'{SpecialTokens.image}, {SpecialTokens.image}'],
+            'caption': [[]],
+            'images': [[self.cat_path, self.cat_path]],
+        }
+        op = self._build_op(keep_original_sample=False)
+        res, prompts = self._run(op, samples)
+
+        self.assertEqual(len(res['images']), self.aug_num)
+        self.assertEqual(prompts, ['', ''] * self.aug_num)
+
+    def test_no_images_returns_empty_batch(self):
+        """Samples without images are skipped, but the schema is preserved."""
+        samples = {
+            'text': [f'{SpecialTokens.image}a photo of a cat'],
+            'caption': ['a photo of a cat'],
+            'images': [[]],
+        }
+        op = self._build_op(keep_original_sample=False)
+        res, prompts = self._run(op, samples)
+
+        self.assertEqual(set(res.keys()), set(samples.keys()))
+        for key in samples:
+            self.assertEqual(res[key], [])
+        self.assertEqual(prompts, [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

A collection of small bug fixes and a dependency bump.

### Changes

1. **fix(image_diffusion_mapper)**: handle missing or null captions gracefully — prevents crash when samples have missing or empty caption fields. (Related: cmgzn/data-juicer#60)

2. **fix: warn when process operator list is empty** — adds a warning in both `DefaultExecutor` and `RayExecutor` when the user provides an empty process operator list, preventing silent no-op execution. (Related: cmgzn/data-juicer#69)

3. **fix(vggt_mapper)**: guard and initialize `__dj__meta__` before access — ensures `__dj__meta__` is initialized before `VggtMapper` accesses it, preventing `KeyError` on samples without prior metadata. (Related: cmgzn/data-juicer#93)

4. **deps: bump fsspec from `==2023.5.0` to `>=2026.1.0`** — the old pin is incompatible with `pyarrow>=17`. Root cause: `fsspec<=2025.9.0` mirrors `ArrowFile.size` from the pyarrow stream via `@mirror_from` (treats it as an attribute), but `pyarrow>=17` changed `NativeFile.size` to a method. This causes `TypeError: unsupported operand type(s) for +: 'method' and 'float'` in tqdm during HDFS downloads through `ArrowFSWrapper`. `fsspec>=2026.1.0` replaces the mirror with an explicit `@property` that calls `stream.size()`, returning the correct int. Verified end-to-end with `fsspec==2026.4.0` + `pyarrow==24.0.0` on a Docker HDFS setup (load → filter → export).

   Note: `datasets==5.0.0` declares `fsspec<=2026.4.0`, so the effective resolved range is `2026.1.0–2026.4.0`. `s3fs` versions are co-released with matching fsspec versions (e.g. `s3fs==2026.4.0` requires `fsspec==2026.4.0`), so no resolver conflicts.