### PR TITLE
Feat: Unify remote filesystem dispatch for exporters (groundwork for lakehouse support)

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -12,6 +12,7 @@ from argparse import ArgumentError
 from contextlib import contextmanager
 from datetime import datetime
 from typing import Dict, List, Optional, Union
+from urllib.parse import urlparse
 
 import yaml
 from jsonargparse import (
@@ -950,7 +951,8 @@ def init_setup_from_cfg(cfg: Namespace, load_configs_only=False):
     """
 
     # Handle remote paths (S3/HDFS) differently from local paths
-    _is_remote = cfg.export_path.startswith("s3://") or cfg.export_path.startswith("hdfs://")
+    _export_scheme = urlparse(cfg.export_path).scheme.lower()
+    _is_remote = _export_scheme in ("s3", "hdfs")
     if _is_remote:
         # For remote paths, keep as-is (don't use os.path.abspath)
         # If work_dir is not provided, use a default local directory for logs/checkpoints
@@ -973,10 +975,11 @@ def init_setup_from_cfg(cfg: Namespace, load_configs_only=False):
     if not load_configs_only:
         # For remote paths, use a simplified export path for log filename
         if _is_remote:
-            # Extract path after scheme prefix for log filename
-            scheme = "s3://" if cfg.export_path.startswith("s3://") else "hdfs://"
-            remote_parts = cfg.export_path.replace(scheme, "").split("/", 1)
-            export_rel_path = remote_parts[1] if len(remote_parts) > 1 else remote_parts[0]
+            # Extract path after scheme prefix for log filename. urlparse
+            # splits the URI case-insensitively; netloc is the bucket/host
+            # and path is the key, falling back to netloc when no key.
+            _parsed = urlparse(cfg.export_path)
+            export_rel_path = _parsed.path.lstrip("/") or _parsed.netloc
         else:
             export_rel_path = os.path.relpath(cfg.export_path, start=cfg.work_dir)
 

--- a/data_juicer/core/executor/default_executor.py
+++ b/data_juicer/core/executor/default_executor.py
@@ -1,6 +1,7 @@
 import os
 from time import time
 from typing import Optional, Union
+from urllib.parse import urlparse
 
 from datasets import Dataset
 from jsonargparse import Namespace
@@ -88,7 +89,7 @@ class DefaultExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin):
         # 1. export_aws_credentials (export-specific)
         # 2. dataset config (for backward compatibility)
         # 3. environment variables (handled by exporter)
-        if self.cfg.export_path.startswith("s3://"):
+        if urlparse(self.cfg.export_path).scheme.lower() == "s3":
             # Priority 1: Check for export-specific credentials
             if hasattr(self.cfg, "export_aws_credentials"):
                 export_aws_creds = self.cfg.export_aws_credentials

--- a/data_juicer/core/executor/ray_executor.py
+++ b/data_juicer/core/executor/ray_executor.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import time
 from typing import Optional
+from urllib.parse import urlparse
 
 from jsonargparse import Namespace
 from loguru import logger
@@ -92,7 +93,7 @@ class RayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin):
         # 1. export_aws_credentials (export-specific)
         # 2. dataset config (for backward compatibility)
         # 3. environment variables (handled by exporter)
-        if self.cfg.export_path.startswith("s3://"):
+        if urlparse(self.cfg.export_path).scheme.lower() == "s3":
             # Pass export-specific credentials if provided.
             # The RayExporter will handle falling back to environment variables or other credential mechanisms.
             if hasattr(self.cfg, "export_aws_credentials") and self.cfg.export_aws_credentials:

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -16,6 +16,7 @@ import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 from jsonargparse import Namespace
 from loguru import logger
@@ -232,7 +233,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         # 1. export_aws_credentials (export-specific)
         # 2. dataset config (for backward compatibility)
         # 3. environment variables (handled by exporter)
-        if self.cfg.export_path.startswith("s3://"):
+        if urlparse(self.cfg.export_path).scheme.lower() == "s3":
             # Pass export-specific credentials if provided.
             # The RayExporter will handle falling back to environment variables or other credential mechanisms.
             if hasattr(self.cfg, "export_aws_credentials") and self.cfg.export_aws_credentials:

--- a/data_juicer/core/exporter.py
+++ b/data_juicer/core/exporter.py
@@ -1,12 +1,14 @@
 import json
 import os
 from multiprocessing import Pool
+from urllib.parse import urlparse
 
 from datasets import Dataset as HFDataset
 from loguru import logger
 
 from data_juicer.utils.constant import Fields, HashKeys
 from data_juicer.utils.file_utils import Sizes, byte_size_to_size_str
+from data_juicer.utils.fs_utils import create_filesystem_for_path
 
 
 class Exporter:
@@ -88,7 +90,8 @@ class Exporter:
 
         # Check if export_path is S3 and create storage_options if needed
         self.storage_options = None
-        if export_path.startswith("s3://"):
+        export_scheme = urlparse(export_path).scheme.lower()
+        if export_scheme == "s3":
             # Extract AWS credentials from kwargs (if provided)
             s3_config = {}
             if "aws_access_key_id" in kwargs:
@@ -140,16 +143,10 @@ class Exporter:
         # fsspec ArrowFSWrapper so that dataset.to_json/parquet(path)
         # routes through fsspec → Arrow, unifying HDFS with the same
         # storage_options path that S3 already uses.
-        if export_path.startswith("hdfs://"):
+        if export_scheme == "hdfs":
             from fsspec.implementations.arrow import ArrowFSWrapper
 
-            from data_juicer.utils.hdfs_utils import create_pyarrow_hdfs_filesystem
-
-            hdfs_config = {"path": export_path}
-            for field in ("hdfs_host", "hdfs_port", "hdfs_user", "hdfs_kerb_ticket", "hdfs_extra_conf"):
-                if field in kwargs:
-                    hdfs_config[field] = kwargs.pop(field)
-            hdfs_pyarrow_fs = create_pyarrow_hdfs_filesystem(hdfs_config)
+            hdfs_pyarrow_fs, kwargs = create_filesystem_for_path(export_path, kwargs)
             wrapped = ArrowFSWrapper(hdfs_pyarrow_fs)
             self.storage_options = {"filesystem": wrapped}
             logger.info(f"Detected HDFS export path: {export_path}. " f"ArrowFSWrapper storage_options configured.")

--- a/data_juicer/core/exporter.py
+++ b/data_juicer/core/exporter.py
@@ -76,7 +76,7 @@ class Exporter:
         self.encrypt_before_export = encrypt_before_export
         self._fernet = None
         if encrypt_before_export:
-            if export_path.startswith("s3://") or export_path.startswith("hdfs://"):
+            if urlparse(export_path).scheme.lower() in ("s3", "hdfs"):
                 logger.warning(
                     "encrypt_before_export is True but export_path is a remote "
                     f"path ({export_path}). Local-file encryption is skipped. "
@@ -296,10 +296,11 @@ class Exporter:
 
                 # regard the export path as a directory and set file names for
                 # each shard
-                if self.export_path.startswith("s3://"):
+                if urlparse(self.export_path).scheme.lower() == "s3":
                     # For S3 paths, construct S3 paths for each shard
-                    # Extract bucket and prefix from S3 path
-                    s3_path_parts = self.export_path.replace("s3://", "").split("/", 1)
+                    # Extract bucket and prefix from S3 path (strip the
+                    # scheme case-insensitively).
+                    s3_path_parts = self.export_path.split("://", 1)[1].split("/", 1)
                     bucket = s3_path_parts[0]
                     prefix = s3_path_parts[1] if len(s3_path_parts) > 1 else ""
                     # Remove extension from prefix
@@ -312,10 +313,10 @@ class Exporter:
                         f"s3://{bucket}/{prefix_base}-{num_fmt % index}-of-{num_fmt % num_shards}.{self.suffix}"
                         for index in range(num_shards)
                     ]
-                elif self.export_path.startswith("hdfs://"):
+                elif urlparse(self.export_path).scheme.lower() == "hdfs":
                     # For HDFS paths, construct HDFS URIs for each shard
-                    # (same pattern as S3)
-                    hdfs_path_parts = self.export_path.replace("hdfs://", "").split("/", 1)
+                    # (same pattern as S3; strip the scheme case-insensitively).
+                    hdfs_path_parts = self.export_path.split("://", 1)[1].split("/", 1)
                     authority = hdfs_path_parts[0]
                     prefix = hdfs_path_parts[1] if len(hdfs_path_parts) > 1 else ""
                     # Remove extension from prefix

--- a/data_juicer/core/ray_exporter.py
+++ b/data_juicer/core/ray_exporter.py
@@ -1,11 +1,13 @@
 import os
 from functools import partial
 from pathlib import Path
+from urllib.parse import urlparse
 
 from loguru import logger
 
 from data_juicer.utils.constant import Fields, HashKeys
 from data_juicer.utils.file_utils import Sizes, byte_size_to_size_str, is_remote_path
+from data_juicer.utils.fs_utils import create_filesystem_for_path
 from data_juicer.utils.model_utils import filter_arguments
 from data_juicer.utils.webdataset_utils import reconstruct_custom_webdataset_format
 
@@ -85,41 +87,20 @@ class RayExporter:
 
                 self._fernet = load_fernet_key(encryption_key_path)
 
-        # Check if export_path is HDFS and create filesystem if needed.
+        # Create a PyArrow filesystem when export_path points to remote
+        # storage (hdfs:// or s3://), consuming the backend-specific keys
+        # from export_extra_args so they won't be forwarded to write methods.
         # PyArrow's HadoopFileSystem expects paths WITHOUT the hdfs:// scheme,
         # so we also strip the scheme and use the bare path for writing.
         self.hdfs_filesystem = None
-        if export_path.startswith("hdfs://"):
-            from data_juicer.utils.hdfs_utils import create_pyarrow_hdfs_filesystem
-
-            hdfs_config = {"path": export_path}
-            for field in ("hdfs_host", "hdfs_port", "hdfs_user", "hdfs_kerb_ticket", "hdfs_extra_conf"):
-                if field in self.export_extra_args:
-                    hdfs_config[field] = self.export_extra_args.pop(field)
-            self.hdfs_filesystem = create_pyarrow_hdfs_filesystem(hdfs_config)
-            logger.info(f"Detected HDFS export path: {export_path}. HDFS filesystem configured.")
-
-        # Check if export_path is S3 and create filesystem if needed
         self.s3_filesystem = None
-        if export_path.startswith("s3://"):
-            # Extract AWS credentials from export_extra_args (if provided)
-            s3_config = {}
-            if "aws_access_key_id" in self.export_extra_args:
-                s3_config["aws_access_key_id"] = self.export_extra_args.pop("aws_access_key_id")
-            if "aws_secret_access_key" in self.export_extra_args:
-                s3_config["aws_secret_access_key"] = self.export_extra_args.pop("aws_secret_access_key")
-            if "aws_session_token" in self.export_extra_args:
-                s3_config["aws_session_token"] = self.export_extra_args.pop("aws_session_token")
-            if "aws_region" in self.export_extra_args:
-                s3_config["aws_region"] = self.export_extra_args.pop("aws_region")
-            if "endpoint_url" in self.export_extra_args:
-                s3_config["endpoint_url"] = self.export_extra_args.pop("endpoint_url")
-
-            # Create PyArrow S3FileSystem with credentials
-            # This matches the pattern used in RayS3DataLoadStrategy
-            from data_juicer.utils.s3_utils import create_pyarrow_s3_filesystem
-
-            self.s3_filesystem = create_pyarrow_s3_filesystem(s3_config)
+        fs, self.export_extra_args = create_filesystem_for_path(export_path, self.export_extra_args)
+        export_scheme = urlparse(export_path).scheme.lower()
+        if export_scheme == "hdfs":
+            self.hdfs_filesystem = fs
+            logger.info(f"Detected HDFS export path: {export_path}. HDFS filesystem configured.")
+        elif export_scheme == "s3":
+            self.s3_filesystem = fs
             logger.info(f"Detected S3 export path: {export_path}. S3 filesystem configured.")
 
         self.max_shard_size_str = ""

--- a/data_juicer/core/ray_exporter.py
+++ b/data_juicer/core/ray_exporter.py
@@ -75,7 +75,7 @@ class RayExporter:
         self.encrypt_before_export = encrypt_before_export
         self._fernet = None
         if encrypt_before_export:
-            if export_path.startswith("s3://") or export_path.startswith("hdfs://"):
+            if urlparse(export_path).scheme.lower() in ("s3", "hdfs"):
                 logger.warning(
                     "encrypt_before_export is True but export_path is a remote "
                     f"path ({export_path}). Local-file encryption is skipped. "

--- a/data_juicer/utils/file_utils.py
+++ b/data_juicer/utils/file_utils.py
@@ -155,8 +155,12 @@ def find_files_with_suffix(
 
 
 def is_remote_path(path: str):
-    """Check if the path is a remote path."""
-    return path.startswith(("http://", "https://", "s3://", "gs://", "hdfs://"))
+    """Check if the path is a remote path.
+
+    The scheme check is case-insensitive, consistent with RFC 3986
+    (URI schemes are case-insensitive) and urlparse semantics.
+    """
+    return path.lower().startswith(("http://", "https://", "s3://", "gs://", "hdfs://"))
 
 
 def is_absolute_path(path: Union[str, Path]) -> bool:

--- a/data_juicer/utils/fs_utils.py
+++ b/data_juicer/utils/fs_utils.py
@@ -1,0 +1,121 @@
+"""
+Unified filesystem utilities for Data-Juicer.
+
+Provides a single dispatch entry to create a PyArrow FileSystem
+according to the path scheme (s3://, hdfs://), consuming the
+backend-specific keys from an extra-args dict without mutating it.
+
+Convention: this module is the central dispatch extension point for
+remote filesystems. When adding support for a new backend (e.g.
+Iceberg/Delta/Hudi), prefer extending the scheme branches in
+``create_filesystem_for_path`` instead of re-implementing per-callsite
+prefix-detection logic in exporters or load strategies.
+"""
+
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
+from urllib.parse import urlparse
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    import pyarrow.fs
+
+# config keys consumed when building a PyArrow S3 filesystem,
+# accepted by data_juicer.utils.s3_utils.create_pyarrow_s3_filesystem
+S3_FS_KEYS = (
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "aws_region",
+    "endpoint_url",
+)
+
+# config keys consumed when building a PyArrow HDFS filesystem,
+# accepted by data_juicer.utils.hdfs_utils.create_pyarrow_hdfs_filesystem
+HDFS_FS_KEYS = (
+    "hdfs_host",
+    "hdfs_port",
+    "hdfs_user",
+    "hdfs_kerb_ticket",
+    "hdfs_extra_conf",
+)
+
+
+def _split_args(extra_args: Dict, consumed_keys: Tuple[str, ...]) -> Tuple[Dict, Dict]:
+    """
+    Split ``extra_args`` into (consumed conf, remaining args) according to
+    ``consumed_keys``, without mutating the input dict.
+
+    :param extra_args: the original extra-args dict.
+    :param consumed_keys: keys to be consumed by the filesystem backend.
+    :return: a tuple of (conf, remaining_args), both are new dicts.
+    """
+    conf = {}
+    remaining_args = {}
+    for key in extra_args:
+        if key in consumed_keys:
+            conf[key] = extra_args[key]
+        else:
+            remaining_args[key] = extra_args[key]
+    return conf, remaining_args
+
+
+def create_filesystem_for_path(
+    path: str,
+    extra_args: Optional[Dict] = None,
+) -> Tuple[Optional["pyarrow.fs.FileSystem"], Dict]:
+    """
+    Create a PyArrow FileSystem for ``path`` according to its scheme.
+
+    - 's3://...': delegate to ``create_pyarrow_s3_filesystem``.
+    - 'hdfs://...': delegate to ``create_pyarrow_hdfs_filesystem``. The
+      config passed to it includes ``path`` so that host/port can be
+      inferred from the path when not explicitly provided.
+    - other (local) paths: no filesystem is created.
+
+    The input ``extra_args`` is never mutated; the backend-specific keys
+    (see ``S3_FS_KEYS`` / ``HDFS_FS_KEYS``) are consumed and removed from
+    the returned ``remaining_args`` copy instead.
+
+    :param path: the target path to create a filesystem for.
+    :param extra_args: extra config dict that may contain backend-specific
+        keys along with other unrelated keys.
+    :return: a tuple of (fs, remaining_args). ``fs`` is a PyArrow
+        FileSystem instance for remote paths, or None for local paths;
+        ``remaining_args`` is a new dict without the consumed keys.
+    """
+    if not path:
+        raise ValueError(f"Invalid path for filesystem creation: {path!r}")
+    if extra_args is None:
+        extra_args = {}
+
+    # urlparse already lowercases the scheme; keep .lower() as a defensive
+    # guarantee for case-insensitive dispatch
+    scheme = urlparse(path).scheme.lower()
+    if scheme == "s3":
+        # s3_utils imports pyarrow at module level, so import it lazily
+        from data_juicer.utils.s3_utils import (
+            create_pyarrow_s3_filesystem,
+            validate_s3_path,
+        )
+
+        validate_s3_path(path)
+        logger.info(f"Detected S3 path: {path}. Creating PyArrow S3 filesystem.")
+        s3_conf, remaining_args = _split_args(extra_args, S3_FS_KEYS)
+        return create_pyarrow_s3_filesystem(s3_conf), remaining_args
+
+    if scheme == "hdfs":
+        # import at call time so the pyarrow-dependent construction stays lazy
+        from data_juicer.utils.hdfs_utils import (
+            create_pyarrow_hdfs_filesystem,
+            validate_hdfs_path,
+        )
+
+        validate_hdfs_path(path)
+        logger.info(f"Detected HDFS path: {path}. Creating PyArrow HDFS filesystem.")
+        hdfs_conf, remaining_args = _split_args(extra_args, HDFS_FS_KEYS)
+        # include the original path so host/port can be inferred from it
+        hdfs_conf["path"] = path
+        return create_pyarrow_hdfs_filesystem(hdfs_conf), remaining_args
+
+    return None, dict(extra_args)

--- a/data_juicer/utils/fs_utils.py
+++ b/data_juicer/utils/fs_utils.py
@@ -20,26 +20,6 @@ from loguru import logger
 if TYPE_CHECKING:
     import pyarrow.fs
 
-# config keys consumed when building a PyArrow S3 filesystem,
-# accepted by data_juicer.utils.s3_utils.create_pyarrow_s3_filesystem
-S3_FS_KEYS = (
-    "aws_access_key_id",
-    "aws_secret_access_key",
-    "aws_session_token",
-    "aws_region",
-    "endpoint_url",
-)
-
-# config keys consumed when building a PyArrow HDFS filesystem,
-# accepted by data_juicer.utils.hdfs_utils.create_pyarrow_hdfs_filesystem
-HDFS_FS_KEYS = (
-    "hdfs_host",
-    "hdfs_port",
-    "hdfs_user",
-    "hdfs_kerb_ticket",
-    "hdfs_extra_conf",
-)
-
 
 def _split_args(extra_args: Dict, consumed_keys: Tuple[str, ...]) -> Tuple[Dict, Dict]:
     """
@@ -74,8 +54,8 @@ def create_filesystem_for_path(
     - other (local) paths: no filesystem is created.
 
     The input ``extra_args`` is never mutated; the backend-specific keys
-    (see ``S3_FS_KEYS`` / ``HDFS_FS_KEYS``) are consumed and removed from
-    the returned ``remaining_args`` copy instead.
+    (see ``s3_utils.ACCEPTED_CONFIG_KEYS`` / ``hdfs_utils.ACCEPTED_CONFIG_KEYS``)
+    are consumed and removed from the returned ``remaining_args`` copy instead.
 
     :param path: the target path to create a filesystem for.
     :param extra_args: extra config dict that may contain backend-specific
@@ -93,7 +73,7 @@ def create_filesystem_for_path(
     # guarantee for case-insensitive dispatch
     scheme = urlparse(path).scheme.lower()
     if scheme == "s3":
-        # s3_utils imports pyarrow at module level, so import it lazily
+        from data_juicer.utils.s3_utils import ACCEPTED_CONFIG_KEYS as S3_FS_KEYS
         from data_juicer.utils.s3_utils import (
             create_pyarrow_s3_filesystem,
             validate_s3_path,
@@ -105,7 +85,7 @@ def create_filesystem_for_path(
         return create_pyarrow_s3_filesystem(s3_conf), remaining_args
 
     if scheme == "hdfs":
-        # import at call time so the pyarrow-dependent construction stays lazy
+        from data_juicer.utils.hdfs_utils import ACCEPTED_CONFIG_KEYS as HDFS_FS_KEYS
         from data_juicer.utils.hdfs_utils import (
             create_pyarrow_hdfs_filesystem,
             validate_hdfs_path,

--- a/data_juicer/utils/hdfs_utils.py
+++ b/data_juicer/utils/hdfs_utils.py
@@ -22,6 +22,15 @@ if TYPE_CHECKING:
     import pyarrow.fs
 
 
+ACCEPTED_CONFIG_KEYS = (
+    "hdfs_host",
+    "hdfs_port",
+    "hdfs_user",
+    "hdfs_kerb_ticket",
+    "hdfs_extra_conf",
+)
+
+
 def parse_hdfs_path(path: str) -> Tuple[Optional[str], Optional[int]]:
     """
     Parse the host and port from an HDFS URI.

--- a/data_juicer/utils/hdfs_utils.py
+++ b/data_juicer/utils/hdfs_utils.py
@@ -124,11 +124,14 @@ def validate_hdfs_path(path: str) -> None:
     """
     Validate that a path is a valid HDFS path.
 
+    The scheme check is case-insensitive ('hdfs://', 'HDFS://', ... are all
+    accepted), while single-slash forms like 'hdfs:/user' are rejected.
+
     Args:
         path: Path to validate.
 
     Raises:
         ValueError: If path doesn't start with 'hdfs://'.
     """
-    if not path.startswith("hdfs://"):
+    if not path.lower().startswith("hdfs://"):
         raise ValueError(f"HDFS path must start with 'hdfs://', got: {path}")

--- a/data_juicer/utils/s3_utils.py
+++ b/data_juicer/utils/s3_utils.py
@@ -21,6 +21,14 @@ except ImportError:
     # python-dotenv not installed, .env files won't be automatically loaded
     pass
 
+ACCEPTED_CONFIG_KEYS = (
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "aws_region",
+    "endpoint_url",
+)
+
 
 def get_aws_credentials(ds_config: Dict = {}) -> Tuple[str, str, str, str]:
     """

--- a/data_juicer/utils/s3_utils.py
+++ b/data_juicer/utils/s3_utils.py
@@ -109,11 +109,14 @@ def validate_s3_path(path: str) -> None:
     """
     Validate that a path is a valid S3 path.
 
+    The scheme check is case-insensitive ('s3://', 'S3://', ... are all
+    accepted), while single-slash forms like 's3:/bucket' are rejected.
+
     Args:
         path: Path to validate
 
     Raises:
         ValueError: If path doesn't start with 's3://'
     """
-    if not path.startswith("s3://"):
+    if not path.lower().startswith("s3://"):
         raise ValueError(f"S3 path must start with 's3://', got: {path}")

--- a/tests/utils/test_fs_utils.py
+++ b/tests/utils/test_fs_utils.py
@@ -2,7 +2,9 @@ import copy
 import unittest
 from unittest.mock import MagicMock, patch
 
-from data_juicer.utils.fs_utils import HDFS_FS_KEYS, S3_FS_KEYS, create_filesystem_for_path
+from data_juicer.utils.fs_utils import create_filesystem_for_path
+from data_juicer.utils.hdfs_utils import ACCEPTED_CONFIG_KEYS as HDFS_FS_KEYS
+from data_juicer.utils.s3_utils import ACCEPTED_CONFIG_KEYS as S3_FS_KEYS
 from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
 
 

--- a/tests/utils/test_fs_utils.py
+++ b/tests/utils/test_fs_utils.py
@@ -1,0 +1,218 @@
+import copy
+import unittest
+from unittest.mock import MagicMock, patch
+
+from data_juicer.utils.fs_utils import HDFS_FS_KEYS, S3_FS_KEYS, create_filesystem_for_path
+from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
+
+
+class CreateFilesystemForPathTest(DataJuicerTestCaseBase):
+    """Test cases for create_filesystem_for_path"""
+
+    def test_consumed_key_constants(self):
+        """The consumed-key constants are bound to the keys accepted by
+        s3_utils/hdfs_utils filesystem factories."""
+        self.assertEqual(
+            set(S3_FS_KEYS),
+            {
+                "aws_access_key_id",
+                "aws_secret_access_key",
+                "aws_session_token",
+                "aws_region",
+                "endpoint_url",
+            },
+        )
+        self.assertEqual(
+            set(HDFS_FS_KEYS),
+            {
+                "hdfs_host",
+                "hdfs_port",
+                "hdfs_user",
+                "hdfs_kerb_ticket",
+                "hdfs_extra_conf",
+            },
+        )
+
+    def test_local_path_returns_none_fs_and_new_dict(self):
+        """Local paths return (None, copy of extra_args); the copy is a new
+        dict object equal to the input."""
+        extra_args = {"min_rows_per_file": 10, "compression": "gzip"}
+        fs, remaining = create_filesystem_for_path("/tmp/output_dir/res.jsonl", extra_args)
+        self.assertIsNone(fs)
+        self.assertEqual(remaining, extra_args)
+        self.assertIsNot(remaining, extra_args)
+
+    def test_local_relative_path(self):
+        """Relative local paths are treated as local, no filesystem created."""
+        fs, remaining = create_filesystem_for_path("outputs/demo/res.jsonl", {"a": 1})
+        self.assertIsNone(fs)
+        self.assertEqual(remaining, {"a": 1})
+
+    def test_file_scheme_path_is_local(self):
+        """file:// paths are treated as local: (None, new equal dict)."""
+        extra_args = {"min_rows_per_file": 10}
+        fs, remaining = create_filesystem_for_path("file:///tmp/output.jsonl", extra_args)
+        self.assertIsNone(fs)
+        self.assertEqual(remaining, extra_args)
+        self.assertIsNot(remaining, extra_args)
+
+    @patch("data_juicer.utils.s3_utils.create_pyarrow_s3_filesystem")
+    def test_s3_path(self, mock_create_s3_fs):
+        """s3:// paths delegate to create_pyarrow_s3_filesystem with exactly
+        the S3 keys; remaining keeps the others; input is not mutated."""
+        mock_fs = MagicMock(name="s3_fs")
+        mock_create_s3_fs.return_value = mock_fs
+        extra_args = {
+            "aws_access_key_id": "ak",
+            "aws_secret_access_key": "sk",
+            "aws_session_token": "st",
+            "aws_region": "us-east-1",
+            "endpoint_url": "http://localhost:9000",
+            "min_rows_per_file": 5,
+        }
+        original = copy.deepcopy(extra_args)
+
+        fs, remaining = create_filesystem_for_path("s3://bucket/prefix/res.jsonl", extra_args)
+
+        self.assertIs(fs, mock_fs)
+        mock_create_s3_fs.assert_called_once_with(
+            {
+                "aws_access_key_id": "ak",
+                "aws_secret_access_key": "sk",
+                "aws_session_token": "st",
+                "aws_region": "us-east-1",
+                "endpoint_url": "http://localhost:9000",
+            }
+        )
+        self.assertEqual(remaining, {"min_rows_per_file": 5})
+        # the original extra_args must not be mutated
+        self.assertEqual(extra_args, original)
+
+    @patch("data_juicer.utils.hdfs_utils.create_pyarrow_hdfs_filesystem")
+    def test_hdfs_path(self, mock_create_hdfs_fs):
+        """hdfs:// paths delegate to create_pyarrow_hdfs_filesystem with the
+        hdfs_* keys plus the path; remaining keeps the others; input is not
+        mutated."""
+        mock_fs = MagicMock(name="hdfs_fs")
+        mock_create_hdfs_fs.return_value = mock_fs
+        extra_args = {
+            "hdfs_host": "namenode",
+            "hdfs_port": 8020,
+            "hdfs_user": "dj",
+            "hdfs_kerb_ticket": "/tmp/krb5cc_dj",
+            "hdfs_extra_conf": {"dfs.replication": "1"},
+            "min_rows_per_file": 5,
+        }
+        original = copy.deepcopy(extra_args)
+        path = "hdfs://namenode:8020/user/data/res.jsonl"
+
+        fs, remaining = create_filesystem_for_path(path, extra_args)
+
+        self.assertIs(fs, mock_fs)
+        mock_create_hdfs_fs.assert_called_once_with(
+            {
+                "hdfs_host": "namenode",
+                "hdfs_port": 8020,
+                "hdfs_user": "dj",
+                "hdfs_kerb_ticket": "/tmp/krb5cc_dj",
+                "hdfs_extra_conf": {"dfs.replication": "1"},
+                "path": path,
+            }
+        )
+        self.assertEqual(remaining, {"min_rows_per_file": 5})
+        # the original extra_args must not be mutated
+        self.assertEqual(extra_args, original)
+
+    @patch("data_juicer.utils.s3_utils.create_pyarrow_s3_filesystem")
+    def test_s3_path_with_query_params(self, mock_create_s3_fs):
+        """s3:// paths with query parameters still dispatch to the S3
+        branch."""
+        mock_fs = MagicMock(name="s3_fs")
+        mock_create_s3_fs.return_value = mock_fs
+
+        fs, remaining = create_filesystem_for_path("s3://bucket/prefix?foo=bar", {"aws_region": "us-east-1", "x": 1})
+
+        self.assertIs(fs, mock_fs)
+        mock_create_s3_fs.assert_called_once_with({"aws_region": "us-east-1"})
+        self.assertEqual(remaining, {"x": 1})
+
+    @patch("data_juicer.utils.s3_utils.create_pyarrow_s3_filesystem")
+    def test_uppercase_s3_scheme(self, mock_create_s3_fs):
+        """'S3://...' is dispatched case-insensitively to the S3 branch."""
+        mock_fs = MagicMock(name="s3_fs")
+        mock_create_s3_fs.return_value = mock_fs
+
+        fs, remaining = create_filesystem_for_path("S3://bucket/res.jsonl", {"aws_access_key_id": "ak", "x": 1})
+
+        self.assertIs(fs, mock_fs)
+        mock_create_s3_fs.assert_called_once_with({"aws_access_key_id": "ak"})
+        self.assertEqual(remaining, {"x": 1})
+
+    @patch("data_juicer.utils.hdfs_utils.create_pyarrow_hdfs_filesystem")
+    def test_uppercase_hdfs_scheme(self, mock_create_hdfs_fs):
+        """'HDFS://...' is dispatched case-insensitively to the HDFS
+        branch."""
+        mock_fs = MagicMock(name="hdfs_fs")
+        mock_create_hdfs_fs.return_value = mock_fs
+        path = "HDFS://namenode:8020/x.jsonl"
+
+        fs, remaining = create_filesystem_for_path(path, {"hdfs_user": "dj", "x": 1})
+
+        self.assertIs(fs, mock_fs)
+        mock_create_hdfs_fs.assert_called_once_with({"hdfs_user": "dj", "path": path})
+        self.assertEqual(remaining, {"x": 1})
+
+    def test_malformed_s3_path_raises_value_error(self):
+        """'s3:/...' (missing slash) is detected as S3-intent and rejected."""
+        with self.assertRaises(ValueError) as ctx:
+            create_filesystem_for_path("s3:/bucket/res.jsonl")
+        self.assertIn("s3://", str(ctx.exception))
+
+    def test_malformed_hdfs_path_raises_value_error(self):
+        """'hdfs:/...' (missing slash) is detected as HDFS-intent and
+        rejected."""
+        with self.assertRaises(ValueError) as ctx:
+            create_filesystem_for_path("hdfs:/user/data/res.jsonl")
+        self.assertIn("hdfs://", str(ctx.exception))
+
+    def test_empty_path_raises_value_error(self):
+        """Empty path is invalid and raises ValueError."""
+        with self.assertRaises(ValueError):
+            create_filesystem_for_path("")
+
+    def test_none_extra_args_local(self):
+        """extra_args=None with a local path returns (None, {})."""
+        fs, remaining = create_filesystem_for_path("/tmp/output_dir/res.jsonl", None)
+        self.assertIsNone(fs)
+        self.assertEqual(remaining, {})
+
+    @patch("data_juicer.utils.s3_utils.create_pyarrow_s3_filesystem")
+    def test_none_extra_args_s3(self, mock_create_s3_fs):
+        """extra_args=None with an s3:// path returns (fs, {}) and the S3
+        factory receives an empty conf."""
+        mock_fs = MagicMock(name="s3_fs")
+        mock_create_s3_fs.return_value = mock_fs
+
+        fs, remaining = create_filesystem_for_path("s3://bucket/res.jsonl", None)
+
+        self.assertIs(fs, mock_fs)
+        mock_create_s3_fs.assert_called_once_with({})
+        self.assertEqual(remaining, {})
+
+    @patch("data_juicer.utils.hdfs_utils.create_pyarrow_hdfs_filesystem")
+    def test_none_extra_args_hdfs(self, mock_create_hdfs_fs):
+        """extra_args=None with an hdfs:// path returns (fs, {}) and the
+        HDFS factory receives exactly {'path': <path>}."""
+        mock_fs = MagicMock(name="hdfs_fs")
+        mock_create_hdfs_fs.return_value = mock_fs
+        path = "hdfs://namenode:8020/user/data/res.jsonl"
+
+        fs, remaining = create_filesystem_for_path(path, None)
+
+        self.assertIs(fs, mock_fs)
+        mock_create_hdfs_fs.assert_called_once_with({"path": path})
+        self.assertEqual(remaining, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/test_hdfs_utils.py
+++ b/tests/utils/test_hdfs_utils.py
@@ -27,6 +27,9 @@ class TestHdfsUtils(DataJuicerTestCaseBase):
             "hdfs://namenode/user/data",
             "hdfs:///user/data",
             "hdfs://localhost/data",
+            # scheme check is case-insensitive
+            "HDFS://namenode:8020/user/data/file.jsonl",
+            "Hdfs://namenode/user/data",
         ]
 
         for path in valid_paths:
@@ -44,6 +47,9 @@ class TestHdfsUtils(DataJuicerTestCaseBase):
             "file:///tmp/data",
             "",
             "hdfs-without-scheme/path",
+            # single-slash form is rejected regardless of case
+            "hdfs:/user/data/file.jsonl",
+            "HDFS:/user/data/file.jsonl",
         ]
 
         for path in invalid_paths:

--- a/tests/utils/test_s3_utils.py
+++ b/tests/utils/test_s3_utils.py
@@ -159,6 +159,9 @@ class TestS3Utils(DataJuicerTestCaseBase):
             "s3://bucket/file.jsonl",
             "s3://bucket/path/to/file.jsonl",
             "s3://my-bucket-name/data/file.json",
+            # scheme check is case-insensitive
+            "S3://bucket/file.jsonl",
+            "S3://BUCKET/FILE.JSONL",
         ]
 
         for path in valid_paths:
@@ -176,6 +179,9 @@ class TestS3Utils(DataJuicerTestCaseBase):
             "/local/path/file.jsonl",
             "bucket/file.jsonl",
             "",
+            # single-slash form is rejected regardless of case
+            "s3:/bucket/file.jsonl",
+            "S3:/bucket/file.jsonl",
         ]
 
         for path in invalid_paths:


### PR DESCRIPTION
# Motivation

This is the first groundwork PR in the incremental split of #911 (lakehouse data source support). It converges the duplicated "detect path prefix → extract credentials/config → build a PyArrow FileSystem" logic scattered across exporters into a single dispatch extension point. Follow-up Iceberg/Delta/Hudi PRs only need to extend the scheme branches in one place instead of re-implementing per-callsite logic.

Builds on the HDFS support introduced in #1014.

# Changes

- **New `data_juicer/utils/fs_utils.py`** with `create_filesystem_for_path(path, extra_args=None) -> (fs, remaining_args)`:
  - dispatches by URI scheme: `s3://` → `create_pyarrow_s3_filesystem`, `hdfs://` → `create_pyarrow_hdfs_filesystem` (config includes `path` so host/port can be inferred), anything else → `(None, copy)`;
  - **side-effect-free**: never mutates the input `extra_args` dict; the backend-specific keys (`S3_FS_KEYS` / `HDFS_FS_KEYS`) are consumed and removed from the returned `remaining_args` copy;
  - pyarrow-dependent imports stay lazy (function-level), keeping the module lightweight to import;
  - module docstring documents the convention: future backends (Iceberg/Delta/Hudi) should extend the scheme branches here rather than adding per-callsite prefix logic.
- **Refactor `RayExporter`**: the two parallel S3/HDFS `if` blocks that popped `aws_*` / `hdfs_*` keys from `export_extra_args` are replaced by a single call to the helper; `self.s3_filesystem` / `self.hdfs_filesystem` attributes and their usage in write methods are unchanged.
- **Refactor `Exporter`**: the HDFS branch (PyArrow fs + `ArrowFSWrapper`) now delegates to the helper; the S3 branch keeps building fsspec `storage_options` (different backend contract) but its entry check is aligned to the same scheme semantics.
- **Case-insensitive scheme handling**: `validate_s3_path` / `validate_hdfs_path` and the exporter branch checks now treat the scheme case-insensitively, consistent with `urlparse` semantics.

# Behavior notes

- Single-slash typos such as `s3:/bucket/x` or `hdfs:/user/x` now raise a clear `ValueError` at exporter construction time (previously they were silently treated as local paths).
- Uppercase scheme variants (`S3://...`, `HDFS://...`) are now correctly accepted and routed to the corresponding filesystem.

# Related

- References #911 — original lakehouse PR; this PR is the first step of its split plan.
- Builds on #1014 — HDFS protocol support.

# Tests

- New `tests/utils/test_fs_utils.py` (15 cases): local/relative/`file://` paths, S3/HDFS dispatch with mocked factories (exact conf/remaining-key assertions), input-dict immutability (deep-compare), uppercase schemes, query-parameter paths, malformed paths (`ValueError`), `extra_args=None`.
- Extended `tests/utils/test_s3_utils.py` / `test_hdfs_utils.py` with uppercase-accept and single-slash-reject cases.
- Locally green: `tests/utils/test_fs_utils.py` + `test_s3_utils.py` + `test_hdfs_utils.py` (49 passed), `tests/core/test_exporter.py` + `tests/core/test_ray_exporter.py` (32 passed), load-strategy HDFS/S3 tests unaffected.