### PR TITLE
[Bugfix] Process partitioned Ray datasets concurrently

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -709,6 +709,12 @@ def build_base_parser() -> ArgumentParser:
         help="Number of partitions for manual mode (ignored in auto mode)",
     )
     parser.add_argument(
+        "--partition.max_concurrent_partitions",
+        type=PositiveInt,
+        default=32,
+        help="Maximum number of partition jobs submitted concurrently by the driver.",
+    )
+    parser.add_argument(
         "--partition.target_size_mb",
         type=int,
         default=256,

--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -11,7 +11,7 @@ import uuid
 from argparse import ArgumentError
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 import yaml
 from jsonargparse import (
@@ -710,9 +710,13 @@ def build_base_parser() -> ArgumentParser:
     )
     parser.add_argument(
         "--partition.max_concurrent_partitions",
-        type=PositiveInt,
-        default=32,
-        help="Maximum number of partition jobs submitted concurrently by the driver.",
+        type=Union[PositiveInt, Literal["auto"]],
+        default="auto",
+        help=(
+            "Maximum number of partition jobs submitted concurrently by the driver. "
+            "The default 'auto' derives a resource-aware limit from the Ray cluster "
+            "and operator requirements."
+        ),
     )
     parser.add_argument(
         "--partition.target_size_mb",

--- a/data_juicer/config/config_all.yaml
+++ b/data_juicer/config/config_all.yaml
@@ -87,6 +87,7 @@ override_num_blocks: null                                   # override the numbe
 partition:
   mode: auto                                                # partition mode: "auto" (use optimizer) or "manual" (specify count)
   num_of_partitions: 4                                      # number of partitions for manual mode
+  max_concurrent_partitions: 32                             # maximum partition jobs driven concurrently; Ray still controls resource scheduling
   target_size_mb: 256                                       # target partition size in MB for auto mode (128, 256, 512, or 1024). 256MB balances memory safety and efficiency.
 
 # only for data analysis

--- a/data_juicer/config/config_all.yaml
+++ b/data_juicer/config/config_all.yaml
@@ -87,7 +87,7 @@ override_num_blocks: null                                   # override the numbe
 partition:
   mode: auto                                                # partition mode: "auto" (use optimizer) or "manual" (specify count)
   num_of_partitions: 4                                      # number of partitions for manual mode
-  max_concurrent_partitions: 32                             # maximum partition jobs driven concurrently; Ray still controls resource scheduling
+  max_concurrent_partitions: auto                           # resource-aware driver concurrency; set a positive integer to override
   target_size_mb: 256                                       # target partition size in MB for auto mode (128, 256, 512, or 1024). 256MB balances memory safety and efficiency.
 
 # only for data analysis

--- a/data_juicer/core/executor/dag_execution_mixin.py
+++ b/data_juicer/core/executor/dag_execution_mixin.py
@@ -7,6 +7,7 @@ into existing executors to provide intelligent pipeline analysis and execution t
 
 import json
 import os
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -38,10 +39,25 @@ class DAGExecutionMixin:
         """Initialize the DAG execution mixin."""
         self.pipeline_dag: Optional[PipelineDAG] = None
         self.dag_initialized = False
+        self._dag_state_lock = threading.RLock()
+        self._dag_thread_state = threading.local()
+        self.current_dag_nodes: Dict[Optional[int], str] = {}
         self.current_dag_node: Optional[str] = None
         self.dag_execution_start_time: Optional[float] = None
         self.dag_execution_strategy: Optional[DAGExecutionStrategy] = None
         self._dag_ops: Optional[List] = None  # Cached operations for DAG planning
+
+    @property
+    def current_dag_node(self) -> Optional[str]:
+        """Return the current DAG node for the calling partition thread."""
+        thread_state = getattr(self, "_dag_thread_state", None)
+        return getattr(thread_state, "current_node", None)
+
+    @current_dag_node.setter
+    def current_dag_node(self, node_id: Optional[str]) -> None:
+        if not hasattr(self, "_dag_thread_state"):
+            self._dag_thread_state = threading.local()
+        self._dag_thread_state.current_node = node_id
 
     def _initialize_dag_execution(self, cfg, ops: List = None) -> None:
         """Initialize DAG execution planning with appropriate strategy.
@@ -245,22 +261,25 @@ class DAGExecutionMixin:
         if not self.pipeline_dag or node_id not in self.pipeline_dag.nodes:
             return
 
-        node = self.pipeline_dag.nodes[node_id]
+        with self._dag_state_lock:
+            node = self.pipeline_dag.nodes[node_id]
 
-        # Validate state transition
-        current_status = node.get("status", "pending")
-        DAGNodeStatusTransition.validate_and_log(node_id, current_status, "running")
+            # Validate state transition
+            current_status = node.get("status", "pending")
+            DAGNodeStatusTransition.validate_and_log(node_id, current_status, "running")
 
-        self.pipeline_dag.mark_node_started(node_id)
-        self.current_dag_node = node_id
-
-        # Log DAG node start
-        if log_method := getattr(self, "log_dag_node_start", None):
+            self.pipeline_dag.mark_node_started(node_id)
+            partition_id = node.get("partition_id")
+            self.current_dag_nodes[partition_id] = node_id
+            self.current_dag_node = node_id
             node_info = {
                 "op_name": node.get("op_name") or node.get("operation_name", ""),
                 "op_type": node.get("op_type") or node.get("node_type", "operation"),
                 "execution_order": node.get("execution_order", 0),
             }
+
+        # Log DAG node start
+        if log_method := getattr(self, "log_dag_node_start", None):
             log_method(node_id, node_info)
 
     def _mark_dag_node_completed(self, node_id: str, duration: float = None) -> None:
@@ -268,48 +287,56 @@ class DAGExecutionMixin:
         if not self.pipeline_dag or node_id not in self.pipeline_dag.nodes:
             return
 
-        node = self.pipeline_dag.nodes[node_id]
+        with self._dag_state_lock:
+            node = self.pipeline_dag.nodes[node_id]
 
-        # Validate state transition
-        current_status = node.get("status", "pending")
-        DAGNodeStatusTransition.validate_and_log(node_id, current_status, "completed")
+            # Validate state transition
+            current_status = node.get("status", "pending")
+            DAGNodeStatusTransition.validate_and_log(node_id, current_status, "completed")
 
-        self.pipeline_dag.mark_node_completed(node_id, duration)
-
-        # Log DAG node completion
-        if log_method := getattr(self, "log_dag_node_complete", None):
+            self.pipeline_dag.mark_node_completed(node_id, duration)
+            partition_id = node.get("partition_id")
+            if self.current_dag_nodes.get(partition_id) == node_id:
+                self.current_dag_nodes.pop(partition_id, None)
+            if self.current_dag_node == node_id:
+                self.current_dag_node = None
             node_info = {
                 "op_name": node.get("op_name") or node.get("operation_name", ""),
                 "op_type": node.get("op_type") or node.get("node_type", "operation"),
                 "execution_order": node.get("execution_order", 0),
             }
-            log_method(node_id, node_info, duration or 0)
 
-        self.current_dag_node = None
+        # Log DAG node completion
+        if log_method := getattr(self, "log_dag_node_complete", None):
+            log_method(node_id, node_info, duration or 0)
 
     def _mark_dag_node_failed(self, node_id: str, error_message: str, duration: float = 0) -> None:
         """Mark a DAG node as failed."""
         if not self.pipeline_dag or node_id not in self.pipeline_dag.nodes:
             return
 
-        node = self.pipeline_dag.nodes[node_id]
+        with self._dag_state_lock:
+            node = self.pipeline_dag.nodes[node_id]
 
-        # Validate state transition
-        current_status = node.get("status", "pending")
-        DAGNodeStatusTransition.validate_and_log(node_id, current_status, "failed")
+            # Validate state transition
+            current_status = node.get("status", "pending")
+            DAGNodeStatusTransition.validate_and_log(node_id, current_status, "failed")
 
-        self.pipeline_dag.mark_node_failed(node_id, error_message)
-
-        # Log DAG node failure
-        if log_method := getattr(self, "log_dag_node_failed", None):
+            self.pipeline_dag.mark_node_failed(node_id, error_message)
+            partition_id = node.get("partition_id")
+            if self.current_dag_nodes.get(partition_id) == node_id:
+                self.current_dag_nodes.pop(partition_id, None)
+            if self.current_dag_node == node_id:
+                self.current_dag_node = None
             node_info = {
                 "op_name": node.get("op_name") or node.get("operation_name", ""),
                 "op_type": node.get("op_type") or node.get("node_type", "operation"),
                 "execution_order": node.get("execution_order", 0),
             }
-            log_method(node_id, node_info, error_message, duration)
 
-        self.current_dag_node = None
+        # Log DAG node failure
+        if log_method := getattr(self, "log_dag_node_failed", None):
+            log_method(node_id, node_info, error_message, duration)
 
     def _log_operation_with_dag_context(
         self, op_name: str, op_idx: int, event_type: str, partition_id: int = 0, **kwargs

--- a/data_juicer/core/executor/pipeline_dag.py
+++ b/data_juicer/core/executor/pipeline_dag.py
@@ -11,6 +11,7 @@ Refactored to:
 """
 
 import json
+import threading
 import time
 from enum import Enum
 from pathlib import Path
@@ -64,6 +65,7 @@ class PipelineDAG:
         self.edges: List[Any] = []
         self.execution_plan: List[str] = []
         self.parallel_groups: List[List[str]] = []
+        self._state_lock = threading.RLock()
 
     def save_execution_plan(self, filename: str = "dag_execution_plan.json") -> str:
         """Save the execution plan to file.
@@ -150,34 +152,39 @@ class PipelineDAG:
 
     def mark_node_started(self, node_id: str) -> None:
         """Mark a node as started (running)."""
-        if node_id in self.nodes:
-            node = self.nodes[node_id]
-            node["status"] = DAGNodeStatus.RUNNING.value
-            node["start_time"] = time.time()
+        with self._state_lock:
+            if node_id in self.nodes:
+                node = self.nodes[node_id]
+                if node.get("status") == DAGNodeStatus.RUNNING.value:
+                    return
+                node["status"] = DAGNodeStatus.RUNNING.value
+                node["start_time"] = time.time()
 
     def mark_node_completed(self, node_id: str, duration: float = None) -> None:
         """Mark a node as completed."""
-        if node_id in self.nodes:
-            node = self.nodes[node_id]
-            current_time = time.time()
-            node["status"] = DAGNodeStatus.COMPLETED.value
-            node["end_time"] = current_time
-            if duration is not None:
-                node["actual_duration"] = duration
-            else:
-                start = node.get("start_time") or current_time
-                node["actual_duration"] = current_time - start
+        with self._state_lock:
+            if node_id in self.nodes:
+                node = self.nodes[node_id]
+                current_time = time.time()
+                node["status"] = DAGNodeStatus.COMPLETED.value
+                node["end_time"] = current_time
+                if duration is not None:
+                    node["actual_duration"] = duration
+                else:
+                    start = node.get("start_time") or current_time
+                    node["actual_duration"] = current_time - start
 
     def mark_node_failed(self, node_id: str, error_message: str) -> None:
         """Mark a node as failed."""
-        if node_id in self.nodes:
-            node = self.nodes[node_id]
-            current_time = time.time()
-            node["status"] = DAGNodeStatus.FAILED.value
-            node["end_time"] = current_time
-            node["error_message"] = error_message
-            start = node.get("start_time") or current_time
-            node["actual_duration"] = current_time - start
+        with self._state_lock:
+            if node_id in self.nodes:
+                node = self.nodes[node_id]
+                current_time = time.time()
+                node["status"] = DAGNodeStatus.FAILED.value
+                node["end_time"] = current_time
+                node["error_message"] = error_message
+                start = node.get("start_time") or current_time
+                node["actual_duration"] = current_time - start
 
     def get_node_status(self, node_id: str) -> DAGNodeStatus:
         """Get status of a node by ID.
@@ -188,45 +195,50 @@ class PipelineDAG:
         Returns:
             DAGNodeStatus of the node
         """
-        if node_id not in self.nodes:
-            return DAGNodeStatus.PENDING
-        status_str = self.nodes[node_id].get("status", "pending")
-        return DAGNodeStatus(status_str)
+        with self._state_lock:
+            if node_id not in self.nodes:
+                return DAGNodeStatus.PENDING
+            status_str = self.nodes[node_id].get("status", "pending")
+            return DAGNodeStatus(status_str)
 
     def get_ready_nodes(self) -> List[str]:
         """Get list of nodes ready to execute (all dependencies completed)."""
-        ready_nodes = []
-        for node_id, node in self.nodes.items():
-            if node.get("status", "pending") != DAGNodeStatus.PENDING.value:
-                continue
+        with self._state_lock:
+            ready_nodes = []
+            for node_id, node in self.nodes.items():
+                if node.get("status", "pending") != DAGNodeStatus.PENDING.value:
+                    continue
 
-            dependencies = node.get("dependencies", [])
-            all_deps_completed = all(self.get_node_status(dep_id) == DAGNodeStatus.COMPLETED for dep_id in dependencies)
-            if all_deps_completed:
-                ready_nodes.append(node_id)
+                dependencies = node.get("dependencies", [])
+                all_deps_completed = all(
+                    self.get_node_status(dep_id) == DAGNodeStatus.COMPLETED for dep_id in dependencies
+                )
+                if all_deps_completed:
+                    ready_nodes.append(node_id)
 
-        return ready_nodes
+            return ready_nodes
 
     def get_execution_summary(self) -> Dict[str, Any]:
         """Get execution summary statistics."""
-        total_nodes = len(self.nodes)
+        with self._state_lock:
+            total_nodes = len(self.nodes)
 
-        completed = sum(1 for n in self.nodes.values() if n.get("status") == DAGNodeStatus.COMPLETED.value)
-        failed = sum(1 for n in self.nodes.values() if n.get("status") == DAGNodeStatus.FAILED.value)
-        running = sum(1 for n in self.nodes.values() if n.get("status") == DAGNodeStatus.RUNNING.value)
-        pending = sum(1 for n in self.nodes.values() if n.get("status", "pending") == DAGNodeStatus.PENDING.value)
+            completed = sum(1 for n in self.nodes.values() if n.get("status") == DAGNodeStatus.COMPLETED.value)
+            failed = sum(1 for n in self.nodes.values() if n.get("status") == DAGNodeStatus.FAILED.value)
+            running = sum(1 for n in self.nodes.values() if n.get("status") == DAGNodeStatus.RUNNING.value)
+            pending = sum(1 for n in self.nodes.values() if n.get("status", "pending") == DAGNodeStatus.PENDING.value)
 
-        total_duration = sum(n.get("actual_duration") or 0 for n in self.nodes.values())
+            total_duration = sum(n.get("actual_duration") or 0 for n in self.nodes.values())
 
-        return {
-            "total_nodes": total_nodes,
-            "completed_nodes": completed,
-            "failed_nodes": failed,
-            "running_nodes": running,
-            "pending_nodes": pending,
-            "completion_percentage": (completed / total_nodes * 100) if total_nodes > 0 else 0,
-            "total_duration": total_duration,
-        }
+            return {
+                "total_nodes": total_nodes,
+                "completed_nodes": completed,
+                "failed_nodes": failed,
+                "running_nodes": running,
+                "pending_nodes": pending,
+                "completion_percentage": (completed / total_nodes * 100) if total_nodes > 0 else 0,
+                "total_duration": total_duration,
+            }
 
     def visualize(self) -> str:
         """Generate a string representation of the DAG for visualization."""

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -8,6 +8,7 @@ This module implements a streamlined partitioned execution strategy for Ray mode
 5. Supports convergence points for global operations (like deduplicators)
 """
 
+import copy
 import hashlib
 import json
 import math
@@ -556,24 +557,37 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         original_concurrency = self._scale_operator_parallelism(ops, max_workers)
 
         try:
-            with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ray-partition") as executor:
-                futures = {
-                    executor.submit(self._process_partition, partition, i, len(partitions), ops): i
-                    for i, partition in enumerate(partitions)
-                }
-                try:
-                    for future in as_completed(futures):
-                        partition_id, processed_data = future.result()
-                        processed_partitions[partition_id] = processed_data
-                except BaseException:
-                    # Running Ray Dataset executions cannot be forcefully
-                    # interrupted here, but queued driver work should not start
-                    # after the job has already failed.
-                    for future in futures:
-                        future.cancel()
-                    raise
+            # Capture the per-partition resource plan in an isolated template.
+            # Restore the original operators before any worker starts so later
+            # convergence stages never depend on thread-pool shutdown timing.
+            isolate_operators = max_workers > 1
+            partition_ops_template = self._clone_partition_operators(ops) if isolate_operators else ops
         finally:
             self._restore_operator_parallelism(original_concurrency)
+
+        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ray-partition") as executor:
+            futures = {
+                executor.submit(
+                    self._process_partition,
+                    partition,
+                    i,
+                    len(partitions),
+                    partition_ops_template,
+                    isolate_operators,
+                ): i
+                for i, partition in enumerate(partitions)
+            }
+            try:
+                for future in as_completed(futures):
+                    partition_id, processed_data = future.result()
+                    processed_partitions[partition_id] = processed_data
+            except BaseException:
+                # Running Ray Dataset executions cannot be forcefully
+                # interrupted here, but queued driver work should not start
+                # after the job has already failed.
+                for future in futures:
+                    future.cancel()
+                raise
 
         # Merge all processed partitions back into a single dataset
         logger.info("Merging processed partitions...")
@@ -588,7 +602,14 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         # Return as RayDataset wrapper
         return RayDataset(merged_dataset, cfg=self.cfg)
 
-    def _process_partition(self, partition, partition_id: int, total_partitions: int, ops: List):
+    def _process_partition(
+        self,
+        partition,
+        partition_id: int,
+        total_partitions: int,
+        ops: List,
+        isolate_operators: bool = True,
+    ):
         """Process one partition while preserving its position in the final union."""
         logger.info(f"Processing partition {partition_id + 1}/{total_partitions}")
 
@@ -599,8 +620,12 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         )
 
         try:
+            # RayDataset may temporarily mutate operator attributes while
+            # building an execution plan (for example runtime_env fallback and
+            # tracing). Give every concurrent partition its own instances.
+            partition_ops = self._clone_partition_operators(ops) if isolate_operators else ops
             partition_dataset = self._wrap_with_precomputed_parallelism(partition)
-            processed_partition = self._process_with_checkpointing(partition_dataset, partition_id, ops)
+            processed_partition = self._process_with_checkpointing(partition_dataset, partition_id, partition_ops)
         except Exception as error:
             self.log_partition_failed(partition_id, str(error), retry_count=0)
             raise
@@ -612,6 +637,17 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         )
 
         return partition_id, processed_partition.data
+
+    @staticmethod
+    def _clone_partition_operators(ops: List) -> List:
+        """Create an isolated operator graph for one partition."""
+        try:
+            return copy.deepcopy(ops)
+        except Exception as error:
+            raise RuntimeError(
+                "Failed to isolate operators for concurrent partition execution. "
+                "All partition operators must support deep copying."
+            ) from error
 
     def _configure_operator_parallelism(self, ops: List) -> None:
         """Plan global actor resources once before partition threads.

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -10,6 +10,7 @@ This module implements a streamlined partitioned execution strategy for Ray mode
 
 import hashlib
 import json
+import math
 import os
 import shutil
 import time
@@ -456,6 +457,14 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         if self.partition_mode == "auto":
             self._configure_auto_partitioning(dataset, ops)
 
+        # Calculate automatic Ray operator parallelism once on the driver.
+        # Every partition shares the same operator objects, so recalculating in
+        # concurrent partition threads would mutate their resource settings
+        # concurrently. Partition execution scales the resulting global actor
+        # pool sizes below, while Ray task pools can continue to use their
+        # resource-driven default when num_proc is None.
+        self._configure_auto_operator_parallelism(ops)
+
         # Initialize DAG execution planning with final partition count
         # Pass ops to avoid redundant loading
         self._initialize_dag_execution(self.cfg, ops=ops)
@@ -542,15 +551,27 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
             "driver threads and checkpointing support..."
         )
         processed_partitions = [None] * len(partitions)
+        original_auto_concurrency = self._scale_auto_operator_parallelism(ops, max_workers)
 
-        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ray-partition") as executor:
-            futures = {
-                executor.submit(self._process_partition, partition, i, len(partitions), ops): i
-                for i, partition in enumerate(partitions)
-            }
-            for future in as_completed(futures):
-                partition_id, processed_data = future.result()
-                processed_partitions[partition_id] = processed_data
+        try:
+            with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ray-partition") as executor:
+                futures = {
+                    executor.submit(self._process_partition, partition, i, len(partitions), ops): i
+                    for i, partition in enumerate(partitions)
+                }
+                try:
+                    for future in as_completed(futures):
+                        partition_id, processed_data = future.result()
+                        processed_partitions[partition_id] = processed_data
+                except BaseException:
+                    # Running Ray Dataset executions cannot be forcefully
+                    # interrupted here, but queued driver work should not start
+                    # after the job has already failed.
+                    for future in futures:
+                        future.cancel()
+                    raise
+        finally:
+            self._restore_auto_operator_parallelism(original_auto_concurrency)
 
         # Merge all processed partitions back into a single dataset
         logger.info("Merging processed partitions...")
@@ -576,7 +597,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         )
 
         try:
-            partition_dataset = RayDataset(partition, cfg=self.cfg)
+            partition_dataset = self._wrap_with_precomputed_parallelism(partition)
             processed_partition = self._process_with_checkpointing(partition_dataset, partition_id, ops)
         except Exception as error:
             self.log_partition_failed(partition_id, str(error), retry_count=0)
@@ -589,6 +610,70 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         )
 
         return partition_id, processed_partition.data
+
+    def _configure_auto_operator_parallelism(self, ops: List) -> None:
+        """Calculate automatic operator resources once before partition threads."""
+        self._auto_parallel_op_ids = set()
+        if not ConfigAccessor.get(self.cfg, "auto_op_parallelism", True):
+            return
+
+        auto_ops = [op for op in ops if op.use_auto_proc()]
+        if not auto_ops:
+            return
+
+        from data_juicer.utils.process_utils import calculate_ray_np
+
+        self._auto_parallel_op_ids = {id(op) for op in auto_ops}
+        calculate_ray_np(ops)
+
+    @staticmethod
+    def _scale_concurrency_for_partitions(concurrency, max_workers: int):
+        """Share a globally calculated actor pool size across partitions."""
+        if max_workers <= 1 or concurrency is None:
+            return concurrency
+
+        def _scale(value):
+            if value is None:
+                return None
+            return max(1, math.ceil(value / max_workers))
+
+        if isinstance(concurrency, (tuple, list)):
+            scaled = tuple(_scale(value) for value in concurrency)
+            if len(scaled) == 2 and scaled[0] > scaled[1]:
+                scaled = (scaled[1], scaled[1])
+            return scaled
+        if isinstance(concurrency, int) and concurrency > 0:
+            return _scale(concurrency)
+        return concurrency
+
+    def _scale_auto_operator_parallelism(self, ops: List, max_workers: int):
+        """Apply per-partition concurrency without changing explicit settings."""
+        original_concurrency = []
+        auto_parallel_op_ids = getattr(self, "_auto_parallel_op_ids", set())
+        for op in ops:
+            if id(op) not in auto_parallel_op_ids:
+                continue
+            original_concurrency.append((op, op.num_proc))
+            op.num_proc = self._scale_concurrency_for_partitions(op.num_proc, max_workers)
+            if op.num_proc != original_concurrency[-1][1]:
+                logger.info(
+                    f"Op[{op._name}] partition concurrency: "
+                    f"{original_concurrency[-1][1]} -> {op.num_proc} "
+                    f"across {max_workers} concurrent partitions"
+                )
+        return original_concurrency
+
+    @staticmethod
+    def _restore_auto_operator_parallelism(original_concurrency) -> None:
+        """Restore the global plan for convergence or later execution stages."""
+        for op, concurrency in original_concurrency:
+            op.num_proc = concurrency
+
+    def _wrap_with_precomputed_parallelism(self, dataset) -> RayDataset:
+        """Wrap data without recalculating shared operator resources."""
+        wrapped = RayDataset(dataset, cfg=self.cfg)
+        wrapped._auto_proc = False
+        return wrapped
 
     def _process_with_convergence(self, dataset: RayDataset, ops: List, convergence_points: List[int]):
         """
@@ -622,7 +707,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         # Process merged dataset with post-convergence operations
         if post_convergence_ops:
             logger.info("Processing merged dataset with global operations...")
-            merged_ray_dataset = RayDataset(merged_dataset, cfg=self.cfg)
+            merged_ray_dataset = self._wrap_with_precomputed_parallelism(merged_dataset)
 
             # Pre-execute DAG monitoring (log operation start events)
             if self.pipeline_dag:
@@ -712,6 +797,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
                         f"Partition {partition_id}: Will process {len(group_ops)} operations from beginning of group"
                     )
                 else:
+                    current_dataset._auto_proc = False
                     logger.info(
                         f"Partition {partition_id}: Successfully loaded checkpoint, resuming from operation {latest_checkpoint[0] + 1}"
                     )

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -38,6 +38,8 @@ from data_juicer.utils.lazy_loader import LazyLoader
 
 ray = LazyLoader("ray")
 
+_AUTO_CPU_PARTITION_CAP = 4
+
 
 class TempDirManager:
     """Context manager for temporary directory cleanup."""
@@ -285,7 +287,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         # Use ConfigAccessor to handle both dict and object configurations
         mode = ConfigAccessor.get(partition_cfg, "mode", "auto")
         num_of_partitions = ConfigAccessor.get(partition_cfg, "num_of_partitions", 4)
-        max_concurrent_partitions = ConfigAccessor.get(partition_cfg, "max_concurrent_partitions", 32)
+        max_concurrent_partitions = ConfigAccessor.get(partition_cfg, "max_concurrent_partitions", "auto")
         partition_size = ConfigAccessor.get(partition_cfg, "size", 5000)
         max_size_mb = ConfigAccessor.get(partition_cfg, "max_size_mb", 64)
 
@@ -457,13 +459,12 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         if self.partition_mode == "auto":
             self._configure_auto_partitioning(dataset, ops)
 
-        # Calculate automatic Ray operator parallelism once on the driver.
-        # Every partition shares the same operator objects, so recalculating in
-        # concurrent partition threads would mutate their resource settings
-        # concurrently. Partition execution scales the resulting global actor
-        # pool sizes below, while Ray task pools can continue to use their
-        # resource-driven default when num_proc is None.
-        self._configure_auto_operator_parallelism(ops)
+        # Record explicit actor-pool budgets and calculate automatic Ray
+        # operator parallelism once on the driver. Every partition shares the
+        # same operator objects, so resource planning must finish before the
+        # concurrent partition threads start.
+        self._configure_operator_parallelism(ops)
+        self._resolve_max_concurrent_partitions(ops)
 
         # Initialize DAG execution planning with final partition count
         # Pass ops to avoid redundant loading
@@ -545,13 +546,14 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
         # Process partitions concurrently. Each worker thread drives one Ray
         # Dataset execution; the actual data processing still runs on Ray.
-        max_workers = min(len(partitions), self.max_concurrent_partitions)
+        requested_max_workers = min(len(partitions), self.max_concurrent_partitions)
+        max_workers = self._limit_partition_workers_for_explicit_actors(ops, requested_max_workers)
         logger.info(
             f"Processing {len(partitions)} partitions with up to {max_workers} concurrent "
             "driver threads and checkpointing support..."
         )
         processed_partitions = [None] * len(partitions)
-        original_auto_concurrency = self._scale_auto_operator_parallelism(ops, max_workers)
+        original_concurrency = self._scale_operator_parallelism(ops, max_workers)
 
         try:
             with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ray-partition") as executor:
@@ -571,7 +573,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
                         future.cancel()
                     raise
         finally:
-            self._restore_auto_operator_parallelism(original_auto_concurrency)
+            self._restore_operator_parallelism(original_concurrency)
 
         # Merge all processed partitions back into a single dataset
         logger.info("Merging processed partitions...")
@@ -611,9 +613,18 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
         return partition_id, processed_partition.data
 
-    def _configure_auto_operator_parallelism(self, ops: List) -> None:
-        """Calculate automatic operator resources once before partition threads."""
+    def _configure_operator_parallelism(self, ops: List) -> None:
+        """Plan global actor resources once before partition threads.
+
+        A positive explicit actor ``num_proc`` is treated as a global job
+        budget, matching its meaning in the non-partitioned Ray executor. Auto
+        parallelism is also calculated globally here and divided later.
+        """
         self._auto_parallel_op_ids = set()
+        self._explicit_actor_op_ids = {
+            id(op) for op in ops if op.use_ray_actor() and self._actor_pool_capacity(op.num_proc) is not None
+        }
+
         if not ConfigAccessor.get(self.cfg, "auto_op_parallelism", True):
             return
 
@@ -626,48 +637,195 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         self._auto_parallel_op_ids = {id(op) for op in auto_ops}
         calculate_ray_np(ops)
 
+    def _configure_auto_operator_parallelism(self, ops: List) -> None:
+        """Compatibility wrapper for the former auto-only planner."""
+        self._configure_operator_parallelism(ops)
+
+    def _resolve_max_concurrent_partitions(self, ops: List) -> int:
+        """Resolve automatic driver concurrency after operator planning.
+
+        A GPU pipeline is bounded by the tightest per-worker CPU/GPU
+        requirement. CPU-only pipelines use a small outer-pipeline cap because
+        Ray Data can already parallelize work inside each partition.
+        """
+        raw_value = self.max_concurrent_partitions
+        if not (isinstance(raw_value, str) and raw_value.lower() == "auto"):
+            self.max_concurrent_partitions = max(1, int(raw_value))
+            return self.max_concurrent_partitions
+
+        try:
+            cluster_resources = ray.cluster_resources()
+            total_cpus = float(cluster_resources.get("CPU", 0))
+            total_gpus = float(cluster_resources.get("GPU", 0))
+        except Exception as error:
+            logger.warning(
+                "Could not inspect Ray cluster resources for automatic partition "
+                f"concurrency; falling back to 1. Error: {error}"
+            )
+            self.max_concurrent_partitions = 1
+            return self.max_concurrent_partitions
+
+        if total_cpus <= 0:
+            logger.warning(
+                "Ray cluster reports no CPU resources for automatic partition " "concurrency; falling back to 1."
+            )
+            self.max_concurrent_partitions = 1
+            return self.max_concurrent_partitions
+
+        capacities = []
+        gpu_operator_names = []
+        for op in ops:
+            num_cpus = getattr(op, "num_cpus", None)
+            cpu_per_worker = float(num_cpus) if num_cpus and float(num_cpus) > 0 else 1.0
+            capacity = math.floor(total_cpus / cpu_per_worker + 1e-9)
+
+            num_gpus = getattr(op, "num_gpus", None)
+            gpu_per_worker = float(num_gpus) if num_gpus and float(num_gpus) > 0 else None
+            if gpu_per_worker is None:
+                try:
+                    if op.use_cuda():
+                        gpu_per_worker = 1.0
+                except (AttributeError, RuntimeError):
+                    pass
+
+            if gpu_per_worker is not None:
+                gpu_operator_names.append(getattr(op, "_name", type(op).__name__))
+                gpu_capacity = math.floor(total_gpus / gpu_per_worker + 1e-9)
+                capacity = min(capacity, gpu_capacity)
+
+            capacities.append(capacity)
+
+        resource_capacity = min(capacities) if capacities else math.floor(total_cpus)
+        if resource_capacity < 1:
+            logger.warning(
+                "Ray cluster resources cannot host one worker for every operator "
+                "with the current resource requests; using one partition pipeline "
+                "so Ray can surface the underlying scheduling error."
+            )
+            resource_capacity = 1
+
+        if gpu_operator_names:
+            resolved = resource_capacity
+            workload = f"GPU operators: {', '.join(gpu_operator_names)}"
+        else:
+            resolved = min(resource_capacity, _AUTO_CPU_PARTITION_CAP)
+            workload = f"CPU-only pipeline cap: {_AUTO_CPU_PARTITION_CAP}"
+
+        self.max_concurrent_partitions = max(1, resolved)
+        logger.info(
+            "Auto-configured max_concurrent_partitions="
+            f"{self.max_concurrent_partitions} from Ray resources "
+            f"(CPU={total_cpus:g}, GPU={total_gpus:g}; {workload})"
+        )
+        return self.max_concurrent_partitions
+
     @staticmethod
-    def _scale_concurrency_for_partitions(concurrency, max_workers: int):
-        """Share a globally calculated actor pool size across partitions."""
+    def _actor_pool_capacity(concurrency) -> Optional[int]:
+        """Return the maximum size represented by an actor concurrency value."""
+        if isinstance(concurrency, bool):
+            return None
+        if isinstance(concurrency, int) and concurrency > 0:
+            return concurrency
+        if isinstance(concurrency, (tuple, list)) and len(concurrency) in (2, 3):
+            max_size = concurrency[1]
+            if isinstance(max_size, int) and not isinstance(max_size, bool) and max_size > 0:
+                return max_size
+        return None
+
+    def _limit_partition_workers_for_explicit_actors(self, ops: List, requested_max_workers: int) -> int:
+        """Keep concurrent partitions within every explicit actor-pool budget."""
+        explicit_actor_op_ids = getattr(self, "_explicit_actor_op_ids", set())
+        actor_budgets = [
+            (op._name, self._actor_pool_capacity(op.num_proc)) for op in ops if id(op) in explicit_actor_op_ids
+        ]
+        actor_budgets = [(name, budget) for name, budget in actor_budgets if budget is not None]
+        if not actor_budgets:
+            return requested_max_workers
+
+        explicit_limit = min(budget for _, budget in actor_budgets)
+        max_workers = max(1, min(requested_max_workers, explicit_limit))
+        if max_workers < requested_max_workers:
+            budget_summary = ", ".join(f"{name}={budget}" for name, budget in actor_budgets)
+            logger.warning(
+                f"Reducing concurrent partition workers from {requested_max_workers} to {max_workers} "
+                f"to honor explicit global actor num_proc budget(s): {budget_summary}"
+            )
+        return max_workers
+
+    @staticmethod
+    def _scale_concurrency_for_partitions(concurrency, max_workers: int, *, round_up: bool = True):
+        """Share a global actor pool size across concurrent partitions."""
         if max_workers <= 1 or concurrency is None:
             return concurrency
 
         def _scale(value):
             if value is None:
                 return None
-            return max(1, math.ceil(value / max_workers))
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                return value
+            if round_up:
+                return max(1, math.ceil(value / max_workers))
+            return max(1, value // max_workers)
 
         if isinstance(concurrency, (tuple, list)):
-            scaled = tuple(_scale(value) for value in concurrency)
-            if len(scaled) == 2 and scaled[0] > scaled[1]:
-                scaled = (scaled[1], scaled[1])
-            return scaled
+            scaled = [_scale(value) for value in concurrency]
+            if len(scaled) >= 2 and isinstance(scaled[0], int) and isinstance(scaled[1], int):
+                scaled[0] = min(scaled[0], scaled[1])
+            if (
+                len(scaled) == 3
+                and isinstance(scaled[0], int)
+                and isinstance(scaled[1], int)
+                and isinstance(scaled[2], int)
+            ):
+                scaled[2] = min(max(scaled[2], scaled[0]), scaled[1])
+            return tuple(scaled)
         if isinstance(concurrency, int) and concurrency > 0:
             return _scale(concurrency)
         return concurrency
 
-    def _scale_auto_operator_parallelism(self, ops: List, max_workers: int):
-        """Apply per-partition concurrency without changing explicit settings."""
+    def _scale_operator_parallelism(self, ops: List, max_workers: int):
+        """Convert global auto and explicit actor budgets to per-partition values."""
         original_concurrency = []
         auto_parallel_op_ids = getattr(self, "_auto_parallel_op_ids", set())
+        explicit_actor_op_ids = getattr(self, "_explicit_actor_op_ids", set())
         for op in ops:
-            if id(op) not in auto_parallel_op_ids:
+            if id(op) in auto_parallel_op_ids:
+                scaling_mode = "automatic"
+                round_up = True
+            elif id(op) in explicit_actor_op_ids:
+                scaling_mode = "explicit"
+                round_up = False
+            else:
                 continue
+
             original_concurrency.append((op, op.num_proc))
-            op.num_proc = self._scale_concurrency_for_partitions(op.num_proc, max_workers)
+            op.num_proc = self._scale_concurrency_for_partitions(
+                op.num_proc,
+                max_workers,
+                round_up=round_up,
+            )
             if op.num_proc != original_concurrency[-1][1]:
                 logger.info(
-                    f"Op[{op._name}] partition concurrency: "
+                    f"Op[{op._name}] {scaling_mode} global concurrency: "
                     f"{original_concurrency[-1][1]} -> {op.num_proc} "
                     f"across {max_workers} concurrent partitions"
                 )
         return original_concurrency
 
+    def _scale_auto_operator_parallelism(self, ops: List, max_workers: int):
+        """Compatibility wrapper for the former auto-only scaler."""
+        return self._scale_operator_parallelism(ops, max_workers)
+
     @staticmethod
-    def _restore_auto_operator_parallelism(original_concurrency) -> None:
+    def _restore_operator_parallelism(original_concurrency) -> None:
         """Restore the global plan for convergence or later execution stages."""
         for op, concurrency in original_concurrency:
             op.num_proc = concurrency
+
+    @staticmethod
+    def _restore_auto_operator_parallelism(original_concurrency) -> None:
+        """Compatibility wrapper for the former auto-only restorer."""
+        PartitionedRayExecutor._restore_operator_parallelism(original_concurrency)
 
     def _wrap_with_precomputed_parallelism(self, dataset) -> RayDataset:
         """Wrap data without recalculating shared operator resources."""

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -13,6 +13,7 @@ import json
 import os
 import shutil
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -531,35 +532,19 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
             f"{partitioning_info.total_rows} total rows"
         )
 
-        # Process each partition separately with checkpointing
-        logger.info("Processing partitions with checkpointing support...")
-        processed_partitions = []
+        # Process partitions concurrently. Each worker thread drives one Ray
+        # Dataset execution; the actual data processing still runs on Ray.
+        logger.info(f"Processing {len(partitions)} partitions in parallel with checkpointing support...")
+        processed_partitions = [None] * len(partitions)
 
-        for i, partition in enumerate(partitions):
-            logger.info(f"Processing partition {i+1}/{len(partitions)}")
-
-            # Log partition start event
-            self._log_event(
-                event_type=EventType.PARTITION_START,
-                message=f"Starting processing of partition {i+1}/{len(partitions)}",
-                partition_id=i,
-            )
-
-            # Create a RayDataset wrapper for this partition
-            partition_dataset = RayDataset(partition, cfg=self.cfg)
-
-            # Apply operations with checkpointing support and DAG monitoring
-            processed_partition = self._process_with_checkpointing(partition_dataset, i, ops)
-
-            # Store the processed partition's data
-            processed_partitions.append(processed_partition.data)
-
-            # Log partition completion event
-            self._log_event(
-                event_type=EventType.PARTITION_COMPLETE,
-                message=f"Completed processing of partition {i+1}/{len(partitions)}",
-                partition_id=i,
-            )
+        with ThreadPoolExecutor(max_workers=len(partitions), thread_name_prefix="ray-partition") as executor:
+            futures = {
+                executor.submit(self._process_partition, partition, i, len(partitions), ops): i
+                for i, partition in enumerate(partitions)
+            }
+            for future in as_completed(futures):
+                partition_id, processed_data = future.result()
+                processed_partitions[partition_id] = processed_data
 
         # Merge all processed partitions back into a single dataset
         logger.info("Merging processed partitions...")
@@ -573,6 +558,27 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
         # Return as RayDataset wrapper
         return RayDataset(merged_dataset, cfg=self.cfg)
+
+    def _process_partition(self, partition, partition_id: int, total_partitions: int, ops: List):
+        """Process one partition while preserving its position in the final union."""
+        logger.info(f"Processing partition {partition_id + 1}/{total_partitions}")
+
+        self._log_event(
+            event_type=EventType.PARTITION_START,
+            message=f"Starting processing of partition {partition_id + 1}/{total_partitions}",
+            partition_id=partition_id,
+        )
+
+        partition_dataset = RayDataset(partition, cfg=self.cfg)
+        processed_partition = self._process_with_checkpointing(partition_dataset, partition_id, ops)
+
+        self._log_event(
+            event_type=EventType.PARTITION_COMPLETE,
+            message=f"Completed processing of partition {partition_id + 1}/{total_partitions}",
+            partition_id=partition_id,
+        )
+
+        return partition_id, processed_partition.data
 
     def _process_with_convergence(self, dataset: RayDataset, ops: List, convergence_points: List[int]):
         """

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -284,6 +284,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         # Use ConfigAccessor to handle both dict and object configurations
         mode = ConfigAccessor.get(partition_cfg, "mode", "auto")
         num_of_partitions = ConfigAccessor.get(partition_cfg, "num_of_partitions", 4)
+        max_concurrent_partitions = ConfigAccessor.get(partition_cfg, "max_concurrent_partitions", 32)
         partition_size = ConfigAccessor.get(partition_cfg, "size", 5000)
         max_size_mb = ConfigAccessor.get(partition_cfg, "max_size_mb", 64)
 
@@ -303,6 +304,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
         self.partition_mode = mode
         self.num_partitions = num_of_partitions
+        self.max_concurrent_partitions = max_concurrent_partitions
         self.partition_size = partition_size
         self.max_size_mb = max_size_mb
 
@@ -534,10 +536,14 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
         # Process partitions concurrently. Each worker thread drives one Ray
         # Dataset execution; the actual data processing still runs on Ray.
-        logger.info(f"Processing {len(partitions)} partitions in parallel with checkpointing support...")
+        max_workers = min(len(partitions), self.max_concurrent_partitions)
+        logger.info(
+            f"Processing {len(partitions)} partitions with up to {max_workers} concurrent "
+            "driver threads and checkpointing support..."
+        )
         processed_partitions = [None] * len(partitions)
 
-        with ThreadPoolExecutor(max_workers=len(partitions), thread_name_prefix="ray-partition") as executor:
+        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ray-partition") as executor:
             futures = {
                 executor.submit(self._process_partition, partition, i, len(partitions), ops): i
                 for i, partition in enumerate(partitions)
@@ -569,8 +575,12 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
             partition_id=partition_id,
         )
 
-        partition_dataset = RayDataset(partition, cfg=self.cfg)
-        processed_partition = self._process_with_checkpointing(partition_dataset, partition_id, ops)
+        try:
+            partition_dataset = RayDataset(partition, cfg=self.cfg)
+            processed_partition = self._process_with_checkpointing(partition_dataset, partition_id, ops)
+        except Exception as error:
+            self.log_partition_failed(partition_id, str(error), retry_count=0)
+            raise
 
         self._log_event(
             event_type=EventType.PARTITION_COMPLETE,

--- a/docs/PartitionAndCheckpoint.md
+++ b/docs/PartitionAndCheckpoint.md
@@ -36,6 +36,7 @@ executor_type: ray_partitioned
 
 partition:
   mode: "auto"
+  max_concurrent_partitions: "auto"  # Resource-aware driver concurrency
   target_size_mb: 256    # Target partition size (128, 256, 512, or 1024)
   size: 5000             # Fallback if auto-analysis fails
   max_size_mb: 256       # Fallback max size
@@ -47,7 +48,15 @@ partition:
 partition:
   mode: "manual"
   num_of_partitions: 8
+  max_concurrent_partitions: "auto"
 ```
+
+`max_concurrent_partitions: "auto"` is the default. It is resolved after
+operator resource planning: GPU pipelines use the tightest CPU/GPU worker
+capacity reported by the Ray cluster, while CPU-only pipelines use a
+conservative outer-pipeline cap of 4. The actual concurrency is also bounded by
+the partition count and any explicit global actor `num_proc` budget. Set a
+positive integer to override the automatic limit.
 
 ### Checkpointing
 

--- a/docs/PartitionAndCheckpoint_ZH.md
+++ b/docs/PartitionAndCheckpoint_ZH.md
@@ -36,6 +36,7 @@ executor_type: ray_partitioned
 
 partition:
   mode: "auto"
+  max_concurrent_partitions: "auto"  # 资源感知的 Driver 并发上限
   target_size_mb: 256    # 目标分区大小（128、256、512 或 1024）
   size: 5000             # 自动分析失败时的回退值
   max_size_mb: 256       # 回退最大大小
@@ -47,7 +48,10 @@ partition:
 partition:
   mode: "manual"
   num_of_partitions: 8
+  max_concurrent_partitions: "auto"
 ```
+
+`max_concurrent_partitions: "auto"` 是默认值。该值会在 Operator 资源规划完成后解析：含 GPU Operator 的 pipeline 根据 Ray 集群可容纳的最小 CPU/GPU worker 数确定，纯 CPU pipeline 的外层并发保守限制为 4。实际并发还会受到 Partition 数量和显式全局 Actor `num_proc` 预算的限制。需要手动调优时，可将其设置为正整数来覆盖自动值。
 
 ### 检查点
 

--- a/tests/config/test_config_functions.py
+++ b/tests/config/test_config_functions.py
@@ -7,6 +7,7 @@ namespace_to_arg_list, build_base_parser, namespace_to_arg_list,
 save_cli_arguments, load_ops_with_stats_meta, prepare_cfgs_for_export,
 display_config.
 """
+
 import json
 import os
 import shutil
@@ -152,14 +153,18 @@ class SortOpByTypesAndNamesTest(DataJuicerTestCaseBase):
         ]
         result = sort_op_by_types_and_names(ops)
         names = [name for name, _ in result]
-        self.assertEqual(names, [
-            "a_mapper", "c_mapper",          # mappers first, sorted
-            "z_filter",                       # filters
-            "b_deduplicator",                 # deduplicators
-            "a_selector",                     # selectors
-            "b_grouper",                      # groupers
-            "a_aggregator",                   # aggregators
-        ])
+        self.assertEqual(
+            names,
+            [
+                "a_mapper",
+                "c_mapper",  # mappers first, sorted
+                "z_filter",  # filters
+                "b_deduplicator",  # deduplicators
+                "a_selector",  # selectors
+                "b_grouper",  # groupers
+                "a_aggregator",  # aggregators
+            ],
+        )
 
     def test_empty_list(self):
         result = sort_op_by_types_and_names([])
@@ -226,11 +231,14 @@ class ParseCliToConfigTest(DataJuicerTestCaseBase):
         self.assertEqual(result.get("items"), ["a", "b", "c"])
 
     def test_mixed_args(self):
-        result = _parse_cli_to_config([
-            "--name", "test",
-            "--count=10",
-            "--verbose",
-        ])
+        result = _parse_cli_to_config(
+            [
+                "--name",
+                "test",
+                "--count=10",
+                "--verbose",
+            ]
+        )
         self.assertEqual(result.get("name"), "test")
         self.assertEqual(result.get("count"), 10)
         self.assertEqual(result.get("verbose"), True)
@@ -338,9 +346,7 @@ class ValidateConfigForResumptionTest(DataJuicerTestCaseBase):
 
         cfg = Namespace(config=[cur_cfg])
         # Pass same CLI args as saved in cli.yaml
-        result = validate_config_for_resumption(
-            cfg, self.work_dir, original_args=["--np", "4"]
-        )
+        result = validate_config_for_resumption(cfg, self.work_dir, original_args=["--np", "4"])
         self.assertTrue(result)
         self.assertTrue(cfg._same_yaml_config)
 
@@ -392,9 +398,7 @@ class ValidateConfigForResumptionTest(DataJuicerTestCaseBase):
 
         cfg = Namespace(config=[cur_cfg])
         # Pass different CLI args
-        result = validate_config_for_resumption(
-            cfg, self.work_dir, original_args=["--np", "8"]
-        )
+        result = validate_config_for_resumption(cfg, self.work_dir, original_args=["--np", "8"])
         self.assertFalse(result)
 
 
@@ -511,16 +515,11 @@ class ResolveJobDirectoriesTest(DataJuicerTestCaseBase):
         )
         result = resolve_job_directories(cfg)
         self.assertTrue(result.work_dir.endswith("test_job_123"))
-        self.assertEqual(result.event_log_dir,
-                         os.path.join(result.work_dir, "logs"))
-        self.assertEqual(result.checkpoint_dir,
-                         os.path.join(result.work_dir, "checkpoints"))
-        self.assertEqual(result.partition_dir,
-                         os.path.join(result.work_dir, "partitions"))
-        self.assertEqual(result.metadata_dir,
-                         os.path.join(result.work_dir, "metadata"))
-        self.assertEqual(result.results_dir,
-                         os.path.join(result.work_dir, "results"))
+        self.assertEqual(result.event_log_dir, os.path.join(result.work_dir, "logs"))
+        self.assertEqual(result.checkpoint_dir, os.path.join(result.work_dir, "checkpoints"))
+        self.assertEqual(result.partition_dir, os.path.join(result.work_dir, "partitions"))
+        self.assertEqual(result.metadata_dir, os.path.join(result.work_dir, "metadata"))
+        self.assertEqual(result.results_dir, os.path.join(result.work_dir, "results"))
 
     def test_job_id_placeholder_substitution(self):
         cfg = Namespace(
@@ -607,18 +606,28 @@ class BuildBaseParserTest(DataJuicerTestCaseBase):
         parser = build_base_parser()
         self.assertIsNotNone(parser)
         action_dests = {a.dest for a in parser._actions}
-        self.assertIn('project_name', action_dests)
-        self.assertIn('executor_type', action_dests)
-        self.assertIn('dataset_path', action_dests)
+        self.assertIn("project_name", action_dests)
+        self.assertIn("executor_type", action_dests)
+        self.assertIn("dataset_path", action_dests)
 
     def test_executor_type_choices(self):
         parser = build_base_parser()
         for action in parser._actions:
-            if action.dest == 'executor_type':
-                self.assertIn('default', action.choices)
-                self.assertIn('ray', action.choices)
-                self.assertIn('ray_partitioned', action.choices)
+            if action.dest == "executor_type":
+                self.assertIn("default", action.choices)
+                self.assertIn("ray", action.choices)
+                self.assertIn("ray_partitioned", action.choices)
                 break
+
+    def test_partition_concurrency_defaults_to_auto(self):
+        parser = build_base_parser()
+        action = next(action for action in parser._actions if action.dest == "partition.max_concurrent_partitions")
+        self.assertEqual(action.default, "auto")
+
+    def test_partition_concurrency_accepts_explicit_positive_integer(self):
+        parser = build_base_parser()
+        cfg = parser.parse_args(["--auto", "--partition.max_concurrent_partitions=4"])
+        self.assertEqual(cfg.partition.max_concurrent_partitions, 4)
 
     def test_config_and_auto_mutually_exclusive(self):
         parser = build_base_parser()
@@ -629,56 +638,56 @@ class BuildBaseParserTest(DataJuicerTestCaseBase):
 class NamespaceToArgListTest(DataJuicerTestCaseBase):
 
     def test_flat_namespace(self):
-        ns = Namespace(a=1, b='hello')
+        ns = Namespace(a=1, b="hello")
         result = namespace_to_arg_list(ns)
-        self.assertIn('--a=1', result)
-        self.assertIn('--b=hello', result)
+        self.assertIn("--a=1", result)
+        self.assertIn("--b=hello", result)
 
     def test_skips_none_values(self):
         ns = Namespace(a=1, b=None)
         result = namespace_to_arg_list(ns)
-        self.assertIn('--a=1', result)
-        self.assertNotIn('--b=None', result)
+        self.assertIn("--a=1", result)
+        self.assertNotIn("--b=None", result)
 
     def test_excludes(self):
         ns = Namespace(a=1, b=2, c=3)
-        result = namespace_to_arg_list(ns, excludes=['b'])
-        keys = [r.split('=')[0] for r in result]
-        self.assertNotIn('--b', keys)
+        result = namespace_to_arg_list(ns, excludes=["b"])
+        keys = [r.split("=")[0] for r in result]
+        self.assertNotIn("--b", keys)
 
     def test_includes(self):
         ns = Namespace(a=1, b=2, c=3)
-        result = namespace_to_arg_list(ns, includes=['a', 'c'])
-        keys = [r.split('=')[0] for r in result]
-        self.assertIn('--a', keys)
-        self.assertIn('--c', keys)
-        self.assertNotIn('--b', keys)
+        result = namespace_to_arg_list(ns, includes=["a", "c"])
+        keys = [r.split("=")[0] for r in result]
+        self.assertIn("--a", keys)
+        self.assertIn("--c", keys)
+        self.assertNotIn("--b", keys)
 
     def test_exclude_prefixes(self):
         ns = Namespace(a=1, my_op=Namespace(x=10, y=20))
-        result = namespace_to_arg_list(ns, exclude_prefixes=('my_op',))
-        keys = [r.split('=')[0] for r in result]
-        self.assertIn('--a', keys)
-        self.assertNotIn('--my_op.x', keys)
-        self.assertNotIn('--my_op.y', keys)
+        result = namespace_to_arg_list(ns, exclude_prefixes=("my_op",))
+        keys = [r.split("=")[0] for r in result]
+        self.assertIn("--a", keys)
+        self.assertNotIn("--my_op.x", keys)
+        self.assertNotIn("--my_op.y", keys)
 
     def test_nested_namespace(self):
         ns = Namespace(top=Namespace(inner=42))
         result = namespace_to_arg_list(ns)
-        self.assertIn('--top.inner=42', result)
+        self.assertIn("--top.inner=42", result)
 
     def test_process_key_uses_json(self):
-        ns = Namespace(process=[{'op': {'k': 'v'}}])
+        ns = Namespace(process=[{"op": {"k": "v"}}])
         result = namespace_to_arg_list(ns)
         self.assertEqual(len(result), 1)
-        self.assertTrue(result[0].startswith('--process='))
-        parsed = json.loads(result[0].split('=', 1)[1])
-        self.assertEqual(parsed, [{'op': {'k': 'v'}}])
+        self.assertTrue(result[0].startswith("--process="))
+        parsed = json.loads(result[0].split("=", 1)[1])
+        self.assertEqual(parsed, [{"op": {"k": "v"}}])
 
     def test_prefix(self):
         ns = Namespace(x=5)
-        result = namespace_to_arg_list(ns, prefix='sub.')
-        self.assertIn('--sub.x=5', result)
+        result = namespace_to_arg_list(ns, prefix="sub.")
+        self.assertIn("--sub.x=5", result)
 
 
 class SaveCliArgumentsTest(DataJuicerTestCaseBase):
@@ -687,30 +696,29 @@ class SaveCliArgumentsTest(DataJuicerTestCaseBase):
         with tempfile.TemporaryDirectory() as tmpdir:
             cfg = Namespace(
                 work_dir=tmpdir,
-                _original_args=['--config', 'test.yaml', '--np', '4'],
+                _original_args=["--config", "test.yaml", "--np", "4"],
             )
             save_cli_arguments(cfg)
-            cli_path = os.path.join(tmpdir, 'cli.yaml')
+            cli_path = os.path.join(tmpdir, "cli.yaml")
             self.assertTrue(os.path.exists(cli_path))
             with open(cli_path) as f:
                 data = yaml.safe_load(f)
-            self.assertEqual(data['arguments'],
-                             ['--config', 'test.yaml', '--np', '4'])
+            self.assertEqual(data["arguments"], ["--config", "test.yaml", "--np", "4"])
 
     def test_no_work_dir_does_nothing(self):
-        cfg = Namespace(_original_args=['--x', '1'])
+        cfg = Namespace(_original_args=["--x", "1"])
         save_cli_arguments(cfg)
 
     def test_no_args_saves_sys_argv_fallback(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             cfg = Namespace(work_dir=tmpdir)
             save_cli_arguments(cfg)
-            cli_path = os.path.join(tmpdir, 'cli.yaml')
+            cli_path = os.path.join(tmpdir, "cli.yaml")
             self.assertTrue(os.path.exists(cli_path))
             with open(cli_path) as f:
                 data = yaml.safe_load(f)
-            self.assertIn('arguments', data)
-            self.assertIsInstance(data['arguments'], list)
+            self.assertIn("arguments", data)
+            self.assertIsInstance(data["arguments"], list)
 
 
 class LoadOpsWithStatsMetaTest(DataJuicerTestCaseBase):
@@ -721,12 +729,11 @@ class LoadOpsWithStatsMetaTest(DataJuicerTestCaseBase):
         self.assertGreater(len(result), 0)
         names = [list(d.keys())[0] for d in result]
         for expected in [
-            'alphanumeric_filter',
-            'audio_duration_filter',
-            'text_length_filter',
+            "alphanumeric_filter",
+            "audio_duration_filter",
+            "text_length_filter",
         ]:
-            self.assertIn(expected, names,
-                          f'{expected} should be in ops with stats meta')
+            self.assertIn(expected, names, f"{expected} should be in ops with stats meta")
 
     def test_each_item_is_single_key_dict(self):
         result = load_ops_with_stats_meta()
@@ -742,29 +749,32 @@ class PrepareCfgsForExportTest(DataJuicerTestCaseBase):
 
     def test_converts_config_paths_to_str(self):
         from pathlib import Path
-        cfg = {'config': [Path('/a/b.yaml')], 'process': []}
+
+        cfg = {"config": [Path("/a/b.yaml")], "process": []}
         result = prepare_cfgs_for_export(cfg)
-        self.assertEqual(result['config'], ['/a/b.yaml'])
+        self.assertEqual(result["config"], ["/a/b.yaml"])
 
     def test_removes_op_keys(self):
         from data_juicer.ops.base_op import OPERATORS
+
         some_op = next(iter(OPERATORS.modules.keys()))
         cfg = {
-            'process': [{'some_filter': {}}],
-            some_op: {'param': 'val'},
+            "process": [{"some_filter": {}}],
+            some_op: {"param": "val"},
         }
         result = prepare_cfgs_for_export(cfg)
         self.assertNotIn(some_op, result)
-        self.assertIn('process', result)
+        self.assertIn("process", result)
 
     def test_no_config_key(self):
-        cfg = {'process': [], 'other': 'val'}
+        cfg = {"process": [], "other": "val"}
         result = prepare_cfgs_for_export(cfg)
-        self.assertEqual(result['other'], 'val')
+        self.assertEqual(result["other"], "val")
 
     def test_mutates_in_place(self):
         from pathlib import Path
-        cfg = {'config': [Path('/a/b.yaml')], 'process': []}
+
+        cfg = {"config": [Path("/a/b.yaml")], "process": []}
         result = prepare_cfgs_for_export(cfg)
         self.assertIs(result, cfg)
 
@@ -773,11 +783,12 @@ class DisplayConfigTest(DataJuicerTestCaseBase):
 
     def test_output_contains_config_keys(self):
         cfg = Namespace(
-            project_name='test',
-            dataset_path='./data',
+            project_name="test",
+            dataset_path="./data",
             process=[],
         )
         import io
+
         old_stdout = sys.stdout
         sys.stdout = io.StringIO()
         try:
@@ -785,8 +796,8 @@ class DisplayConfigTest(DataJuicerTestCaseBase):
             output = sys.stdout.getvalue()
         finally:
             sys.stdout = old_stdout
-        self.assertIn('project_name', output)
-        self.assertIn('dataset_path', output)
+        self.assertIn("project_name", output)
+        self.assertIn("dataset_path", output)
 
 
 if __name__ == "__main__":

--- a/tests/core/executor/test_pipeline_dag.py
+++ b/tests/core/executor/test_pipeline_dag.py
@@ -468,6 +468,17 @@ class PipelineDAGCompletionTest(DataJuicerTestCaseBase):
         node = self.dag.nodes["n1"]
         self.assertGreater(node["actual_duration"], 0)
 
+    def test_repeated_start_does_not_overwrite_start_time(self):
+        import time
+
+        self.dag.nodes["n1"] = _make_node("n1")
+        self.dag.mark_node_started("n1")
+        original_start_time = self.dag.nodes["n1"]["start_time"]
+        time.sleep(0.02)
+        self.dag.mark_node_started("n1")
+
+        self.assertEqual(self.dag.nodes["n1"]["start_time"], original_start_time)
+
     def test_mark_completed_explicit_duration(self):
         self.dag.nodes["n1"] = _make_node("n1")
         self.dag.mark_node_started("n1")
@@ -508,4 +519,4 @@ class PipelineDAGCompletionTest(DataJuicerTestCaseBase):
 
 
 if __name__ == "__main__":
-    unittest.main() 
+    unittest.main()

--- a/tests/core/executor/test_ray_executor_partitioned_parallel.py
+++ b/tests/core/executor/test_ray_executor_partitioned_parallel.py
@@ -1,10 +1,14 @@
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 import threading
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 
+from data_juicer.core.executor.event_logging_mixin import EventType
 from data_juicer.core.executor.ray_executor_partitioned import PartitionedRayExecutor
+from data_juicer.utils.ckpt_utils import CheckpointStrategy, RayCheckpointManager
 
 
 class FakeData:
@@ -18,6 +22,16 @@ class FakeData:
 class FakeRayDataset:
     def __init__(self, data, cfg=None):
         self.data = data
+
+
+class FakeOp:
+    def __init__(self, name, num_proc, auto=True):
+        self._name = name
+        self.num_proc = num_proc
+        self._auto = auto
+
+    def use_auto_proc(self):
+        return self._auto
 
 
 def test_partitions_are_processed_in_parallel_and_merged_in_order():
@@ -52,6 +66,9 @@ def test_partitions_are_processed_in_parallel_and_merged_in_order():
 
     assert completion_order == [2, 1, 0]
     assert result.data.partition_ids == [0, 1, 2]
+    event_types = [call.kwargs["event_type"] for call in executor._log_event.call_args_list]
+    assert event_types.count(EventType.PARTITION_START) == len(partitions)
+    assert event_types.count(EventType.PARTITION_COMPLETE) == len(partitions)
 
 
 def test_partition_concurrency_is_bounded():
@@ -111,3 +128,135 @@ def test_partition_failure_is_logged_and_propagated():
         executor._process_with_simple_partitioning(FakeRayDataset(None), [])
 
     executor.log_partition_failed.assert_called_once_with(0, "partition failed", retry_count=0)
+    event_types = [call.kwargs["event_type"] for call in executor._log_event.call_args_list]
+    assert event_types == [EventType.PARTITION_START]
+
+
+def test_auto_operator_parallelism_is_calculated_once():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = {"auto_op_parallelism": True}
+    auto_op = FakeOp("auto", -1)
+    explicit_op = FakeOp("explicit", 3, auto=False)
+
+    def configure(ops):
+        ops[0].num_proc = (2, 8)
+        return ops
+
+    with patch("data_juicer.utils.process_utils.calculate_ray_np", side_effect=configure) as calculate:
+        executor._configure_auto_operator_parallelism([auto_op, explicit_op])
+
+    calculate.assert_called_once_with([auto_op, explicit_op])
+    assert executor._auto_parallel_op_ids == {id(auto_op)}
+    assert auto_op.num_proc == (2, 8)
+    assert explicit_op.num_proc == 3
+
+
+@pytest.mark.parametrize(
+    ("concurrency", "max_workers", "expected"),
+    [
+        (8, 4, 2),
+        ((2, 8), 4, (1, 2)),
+        ([1, 4], 2, (1, 2)),
+        (None, 4, None),
+        (4, 1, 4),
+    ],
+)
+def test_auto_operator_concurrency_is_scaled_per_partition(concurrency, max_workers, expected):
+    assert PartitionedRayExecutor._scale_concurrency_for_partitions(concurrency, max_workers) == expected
+
+
+def test_auto_operator_parallelism_is_restored_after_partition_processing():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = {}
+    executor.max_concurrent_partitions = 4
+    executor._log_event = Mock()
+    partitions = [FakeData([i]) for i in range(4)]
+    partitioning_info = SimpleNamespace(num_partitions=4, total_rows=4)
+    executor._split_dataset_deterministic = Mock(return_value=(partitions, partitioning_info))
+    auto_op = FakeOp("auto", 8)
+    explicit_op = FakeOp("explicit", 3, auto=False)
+    executor._auto_parallel_op_ids = {id(auto_op)}
+    observed_concurrency = []
+    start_barrier = threading.Barrier(len(partitions), timeout=2)
+
+    def process_with_checkpointing(dataset, partition_id, ops):
+        assert dataset._auto_proc is False
+        observed_concurrency.append((ops[0].num_proc, ops[1].num_proc))
+        start_barrier.wait()
+        return dataset
+
+    executor._process_with_checkpointing = process_with_checkpointing
+
+    with patch(
+        "data_juicer.core.executor.ray_executor_partitioned.RayDataset",
+        FakeRayDataset,
+    ):
+        result = executor._process_with_simple_partitioning(
+            FakeRayDataset(None),
+            [auto_op, explicit_op],
+        )
+
+    assert observed_concurrency == [(2, 3)] * len(partitions)
+    assert auto_op.num_proc == 8
+    assert explicit_op.num_proc == 3
+    assert result.data.partition_ids == [0, 1, 2, 3]
+
+
+def test_auto_operator_parallelism_is_restored_after_partition_failure():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = {}
+    executor.max_concurrent_partitions = 2
+    executor._log_event = Mock()
+    executor.log_partition_failed = Mock()
+    partitions = [FakeData([0]), FakeData([1])]
+    partitioning_info = SimpleNamespace(num_partitions=2, total_rows=2)
+    executor._split_dataset_deterministic = Mock(return_value=(partitions, partitioning_info))
+    auto_op = FakeOp("auto", 4)
+    executor._auto_parallel_op_ids = {id(auto_op)}
+    executor._process_with_checkpointing = Mock(side_effect=RuntimeError("partition failed"))
+
+    with (
+        patch(
+            "data_juicer.core.executor.ray_executor_partitioned.RayDataset",
+            FakeRayDataset,
+        ),
+        pytest.raises(RuntimeError, match="partition failed"),
+    ):
+        executor._process_with_simple_partitioning(FakeRayDataset(None), [auto_op])
+
+    assert auto_op.num_proc == 4
+
+
+def test_checkpoint_paths_remain_partition_scoped_under_concurrency(tmp_path):
+    manager = RayCheckpointManager(
+        ckpt_dir=str(tmp_path),
+        checkpoint_strategy=CheckpointStrategy.EVERY_OP,
+    )
+    write_barrier = threading.Barrier(4, timeout=2)
+
+    class ConcurrentCheckpointData:
+        def __init__(self, partition_id):
+            self.partition_id = partition_id
+
+        def write_parquet(self, checkpoint_path):
+            write_barrier.wait()
+            path = Path(checkpoint_path)
+            path.mkdir(parents=True, exist_ok=True)
+            (path / "partition.txt").write_text(str(self.partition_id))
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [
+            pool.submit(
+                manager.save_checkpoint,
+                ConcurrentCheckpointData(partition_id),
+                0,
+                "mapper",
+                partition_id,
+            )
+            for partition_id in range(4)
+        ]
+        checkpoint_paths = [future.result() for future in futures]
+
+    assert len(set(checkpoint_paths)) == 4
+    for partition_id, checkpoint_path in enumerate(checkpoint_paths):
+        assert Path(checkpoint_path, "partition.txt").read_text() == str(partition_id)

--- a/tests/core/executor/test_ray_executor_partitioned_parallel.py
+++ b/tests/core/executor/test_ray_executor_partitioned_parallel.py
@@ -25,13 +25,32 @@ class FakeRayDataset:
 
 
 class FakeOp:
-    def __init__(self, name, num_proc, auto=True):
+    def __init__(
+        self,
+        name,
+        num_proc,
+        auto=True,
+        actor=True,
+        num_cpus=None,
+        num_gpus=None,
+        cuda=False,
+    ):
         self._name = name
         self.num_proc = num_proc
         self._auto = auto
+        self._actor = actor
+        self.num_cpus = num_cpus
+        self.num_gpus = num_gpus
+        self._cuda = cuda
 
     def use_auto_proc(self):
         return self._auto
+
+    def use_ray_actor(self):
+        return self._actor
+
+    def use_cuda(self):
+        return self._cuda
 
 
 def test_partitions_are_processed_in_parallel_and_merged_in_order():
@@ -143,12 +162,82 @@ def test_auto_operator_parallelism_is_calculated_once():
         return ops
 
     with patch("data_juicer.utils.process_utils.calculate_ray_np", side_effect=configure) as calculate:
-        executor._configure_auto_operator_parallelism([auto_op, explicit_op])
+        executor._configure_operator_parallelism([auto_op, explicit_op])
 
     calculate.assert_called_once_with([auto_op, explicit_op])
     assert executor._auto_parallel_op_ids == {id(auto_op)}
+    assert executor._explicit_actor_op_ids == {id(explicit_op)}
     assert auto_op.num_proc == (2, 8)
     assert explicit_op.num_proc == 3
+
+
+@pytest.mark.parametrize(
+    ("resources", "ops", "expected"),
+    [
+        (
+            {"CPU": 32, "GPU": 4},
+            [FakeOp("gpu", 4, num_cpus=1, num_gpus=1, cuda=True)],
+            4,
+        ),
+        (
+            {"CPU": 32, "GPU": 4},
+            [FakeOp("two-gpu", 2, num_cpus=1, num_gpus=2, cuda=True)],
+            2,
+        ),
+        (
+            {"CPU": 16},
+            [FakeOp("cpu", None, actor=False, num_cpus=1)],
+            4,
+        ),
+        (
+            {"CPU": 16},
+            [FakeOp("cpu-heavy", None, actor=False, num_cpus=8)],
+            2,
+        ),
+        (
+            {"CPU": 32, "GPU": 4},
+            [
+                FakeOp("gpu", 4, num_cpus=1, num_gpus=1, cuda=True),
+                FakeOp("cpu-heavy", None, actor=False, num_cpus=16),
+            ],
+            2,
+        ),
+    ],
+)
+def test_auto_partition_concurrency_is_resource_aware(resources, ops, expected):
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.max_concurrent_partitions = "auto"
+
+    fake_ray = SimpleNamespace(cluster_resources=Mock(return_value=resources))
+    with patch("data_juicer.core.executor.ray_executor_partitioned.ray", fake_ray):
+        resolved = executor._resolve_max_concurrent_partitions(ops)
+
+    assert resolved == expected
+    assert executor.max_concurrent_partitions == expected
+
+
+def test_explicit_partition_concurrency_overrides_auto_detection():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.max_concurrent_partitions = 3
+    fake_ray = SimpleNamespace(cluster_resources=Mock())
+
+    with patch("data_juicer.core.executor.ray_executor_partitioned.ray", fake_ray):
+        resolved = executor._resolve_max_concurrent_partitions([])
+
+    assert resolved == 3
+    fake_ray.cluster_resources.assert_not_called()
+
+
+def test_auto_partition_concurrency_falls_back_to_one_when_ray_inspection_fails():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.max_concurrent_partitions = "auto"
+    fake_ray = SimpleNamespace(cluster_resources=Mock(side_effect=RuntimeError("Ray unavailable")))
+
+    with patch("data_juicer.core.executor.ray_executor_partitioned.ray", fake_ray):
+        resolved = executor._resolve_max_concurrent_partitions([])
+
+    assert resolved == 1
+    assert executor.max_concurrent_partitions == 1
 
 
 @pytest.mark.parametrize(
@@ -165,7 +254,28 @@ def test_auto_operator_concurrency_is_scaled_per_partition(concurrency, max_work
     assert PartitionedRayExecutor._scale_concurrency_for_partitions(concurrency, max_workers) == expected
 
 
-def test_auto_operator_parallelism_is_restored_after_partition_processing():
+@pytest.mark.parametrize(
+    ("concurrency", "max_workers", "expected"),
+    [
+        (8, 4, 2),
+        (5, 4, 1),
+        ((2, 8), 4, (1, 2)),
+        ([1, 5], 4, (1, 1)),
+        ((2, 8, 6), 4, (1, 2, 1)),
+    ],
+)
+def test_explicit_actor_concurrency_is_safely_scaled_per_partition(concurrency, max_workers, expected):
+    assert (
+        PartitionedRayExecutor._scale_concurrency_for_partitions(
+            concurrency,
+            max_workers,
+            round_up=False,
+        )
+        == expected
+    )
+
+
+def test_operator_parallelism_is_restored_after_partition_processing():
     executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
     executor.cfg = {}
     executor.max_concurrent_partitions = 4
@@ -174,8 +284,9 @@ def test_auto_operator_parallelism_is_restored_after_partition_processing():
     partitioning_info = SimpleNamespace(num_partitions=4, total_rows=4)
     executor._split_dataset_deterministic = Mock(return_value=(partitions, partitioning_info))
     auto_op = FakeOp("auto", 8)
-    explicit_op = FakeOp("explicit", 3, auto=False)
+    explicit_op = FakeOp("explicit", 4, auto=False)
     executor._auto_parallel_op_ids = {id(auto_op)}
+    executor._explicit_actor_op_ids = {id(explicit_op)}
     observed_concurrency = []
     start_barrier = threading.Barrier(len(partitions), timeout=2)
 
@@ -196,13 +307,13 @@ def test_auto_operator_parallelism_is_restored_after_partition_processing():
             [auto_op, explicit_op],
         )
 
-    assert observed_concurrency == [(2, 3)] * len(partitions)
+    assert observed_concurrency == [(2, 1)] * len(partitions)
     assert auto_op.num_proc == 8
-    assert explicit_op.num_proc == 3
+    assert explicit_op.num_proc == 4
     assert result.data.partition_ids == [0, 1, 2, 3]
 
 
-def test_auto_operator_parallelism_is_restored_after_partition_failure():
+def test_operator_parallelism_is_restored_after_partition_failure():
     executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
     executor.cfg = {}
     executor.max_concurrent_partitions = 2
@@ -225,6 +336,67 @@ def test_auto_operator_parallelism_is_restored_after_partition_failure():
         executor._process_with_simple_partitioning(FakeRayDataset(None), [auto_op])
 
     assert auto_op.num_proc == 4
+
+
+def test_explicit_actor_budget_limits_partition_concurrency():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = {}
+    executor.max_concurrent_partitions = 4
+    executor._log_event = Mock()
+    partitions = [FakeData([i]) for i in range(4)]
+    partitioning_info = SimpleNamespace(num_partitions=4, total_rows=4)
+    executor._split_dataset_deterministic = Mock(return_value=(partitions, partitioning_info))
+    explicit_op = FakeOp("explicit", 2, auto=False)
+    executor._auto_parallel_op_ids = set()
+    executor._explicit_actor_op_ids = {id(explicit_op)}
+
+    active_partitions = 0
+    max_active_partitions = 0
+    active_lock = threading.Lock()
+    pair_barrier = threading.Barrier(2, timeout=2)
+    observed_concurrency = []
+
+    def process_with_checkpointing(dataset, partition_id, ops):
+        nonlocal active_partitions, max_active_partitions
+        with active_lock:
+            active_partitions += 1
+            max_active_partitions = max(max_active_partitions, active_partitions)
+            observed_concurrency.append(ops[0].num_proc)
+        pair_barrier.wait()
+        with active_lock:
+            active_partitions -= 1
+        return dataset
+
+    executor._process_with_checkpointing = process_with_checkpointing
+
+    with patch(
+        "data_juicer.core.executor.ray_executor_partitioned.RayDataset",
+        FakeRayDataset,
+    ):
+        result = executor._process_with_simple_partitioning(
+            FakeRayDataset(None),
+            [explicit_op],
+        )
+
+    assert max_active_partitions == 2
+    assert observed_concurrency == [1] * len(partitions)
+    assert explicit_op.num_proc == 2
+    assert result.data.partition_ids == [0, 1, 2, 3]
+
+
+def test_explicit_task_concurrency_is_not_partition_scaled():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = {"auto_op_parallelism": False}
+    explicit_actor = FakeOp("actor", 4, auto=False)
+    explicit_task = FakeOp("task", 4, auto=False, actor=False)
+
+    executor._configure_operator_parallelism([explicit_actor, explicit_task])
+
+    assert executor._auto_parallel_op_ids == set()
+    assert executor._explicit_actor_op_ids == {id(explicit_actor)}
+    assert executor._limit_partition_workers_for_explicit_actors([explicit_task], 8) == 8
+    assert executor._scale_operator_parallelism([explicit_task], 8) == []
+    assert explicit_task.num_proc == 4
 
 
 def test_checkpoint_paths_remain_partition_scoped_under_concurrency(tmp_path):

--- a/tests/core/executor/test_ray_executor_partitioned_parallel.py
+++ b/tests/core/executor/test_ray_executor_partitioned_parallel.py
@@ -1,12 +1,14 @@
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-import threading
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 
+from data_juicer.core.executor.dag_execution_mixin import DAGExecutionMixin
 from data_juicer.core.executor.event_logging_mixin import EventType
+from data_juicer.core.executor.pipeline_dag import DAGNodeStatus, PipelineDAG
 from data_juicer.core.executor.ray_executor_partitioned import PartitionedRayExecutor
 from data_juicer.utils.ckpt_utils import CheckpointStrategy, RayCheckpointManager
 
@@ -124,6 +126,46 @@ def test_partition_concurrency_is_bounded():
 
     assert max_active_partitions == executor.max_concurrent_partitions
     assert result.data.partition_ids == [0, 1, 2, 3]
+
+
+def test_concurrent_partitions_use_isolated_operator_instances():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = {}
+    executor.max_concurrent_partitions = 3
+    executor._log_event = Mock()
+    partitions = [FakeData([i]) for i in range(3)]
+    partitioning_info = SimpleNamespace(num_partitions=3, total_rows=3)
+    executor._split_dataset_deterministic = Mock(return_value=(partitions, partitioning_info))
+    original_op = FakeOp("mutable", 1)
+    original_op.partition_marker = None
+
+    start_barrier = threading.Barrier(len(partitions), timeout=2)
+    observations = {}
+    observations_lock = threading.Lock()
+
+    def process_with_checkpointing(dataset, partition_id, ops):
+        partition_op = ops[0]
+        partition_op.partition_marker = partition_id
+        start_barrier.wait()
+        with observations_lock:
+            observations[partition_id] = (id(partition_op), partition_op.partition_marker)
+        return dataset
+
+    executor._process_with_checkpointing = process_with_checkpointing
+
+    with patch(
+        "data_juicer.core.executor.ray_executor_partitioned.RayDataset",
+        FakeRayDataset,
+    ):
+        executor._process_with_simple_partitioning(FakeRayDataset(None), [original_op])
+
+    operator_ids = {operator_id for operator_id, _ in observations.values()}
+    assert len(operator_ids) == len(partitions)
+    assert id(original_op) not in operator_ids
+    assert {partition_id: marker for partition_id, (_, marker) in observations.items()} == {
+        partition_id: partition_id for partition_id in range(len(partitions))
+    }
+    assert original_op.partition_marker is None
 
 
 def test_partition_failure_is_logged_and_propagated():
@@ -338,6 +380,49 @@ def test_operator_parallelism_is_restored_after_partition_failure():
     assert auto_op.num_proc == 4
 
 
+def test_partition_template_stays_scaled_after_sibling_failure():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = {}
+    executor.max_concurrent_partitions = 2
+    executor._log_event = Mock()
+    executor.log_partition_failed = Mock()
+    partitions = [FakeData([0]), FakeData([1])]
+    partitioning_info = SimpleNamespace(num_partitions=2, total_rows=2)
+    executor._split_dataset_deterministic = Mock(return_value=(partitions, partitioning_info))
+    auto_op = FakeOp("auto", 4)
+    executor._auto_parallel_op_ids = {id(auto_op)}
+
+    start_barrier = threading.Barrier(2, timeout=2)
+    failure_announced = threading.Event()
+    sibling_observation = []
+
+    def process_with_checkpointing(dataset, partition_id, ops):
+        start_barrier.wait()
+        if partition_id == 0:
+            failure_announced.set()
+            raise RuntimeError("partition failed")
+
+        assert failure_announced.wait(timeout=2)
+        sibling_observation.append((ops[0].num_proc, auto_op.num_proc))
+        return dataset
+
+    executor._process_with_checkpointing = process_with_checkpointing
+
+    with (
+        patch(
+            "data_juicer.core.executor.ray_executor_partitioned.RayDataset",
+            FakeRayDataset,
+        ),
+        pytest.raises(RuntimeError, match="partition failed"),
+    ):
+        executor._process_with_simple_partitioning(FakeRayDataset(None), [auto_op])
+
+    # The running partition keeps its scaled private plan while the shared
+    # operator has already been restored for later convergence stages.
+    assert sibling_observation == [(2, 4)]
+    assert auto_op.num_proc == 4
+
+
 def test_explicit_actor_budget_limits_partition_concurrency():
     executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
     executor.cfg = {}
@@ -432,3 +517,60 @@ def test_checkpoint_paths_remain_partition_scoped_under_concurrency(tmp_path):
     assert len(set(checkpoint_paths)) == 4
     for partition_id, checkpoint_path in enumerate(checkpoint_paths):
         assert Path(checkpoint_path, "partition.txt").read_text() == str(partition_id)
+
+
+def test_concurrent_dag_monitoring_tracks_current_node_per_partition(tmp_path):
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    DAGExecutionMixin.__init__(executor)
+    executor.pipeline_dag = PipelineDAG(str(tmp_path))
+    executor.log_dag_node_start = Mock()
+    executor.log_dag_node_complete = Mock()
+
+    num_partitions = 4
+    node_ids = [f"op_001_fake_partition_{partition_id}" for partition_id in range(num_partitions)]
+    executor.pipeline_dag.nodes = {
+        node_id: {
+            "node_id": node_id,
+            "operation_name": "fake",
+            "node_type": "partition_operation",
+            "partition_id": partition_id,
+            "execution_order": 1,
+            "dependencies": [],
+            "status": DAGNodeStatus.PENDING.value,
+            "start_time": None,
+            "end_time": None,
+            "actual_duration": None,
+            "error_message": None,
+        }
+        for partition_id, node_id in enumerate(node_ids)
+    }
+
+    started_barrier = threading.Barrier(num_partitions, timeout=2)
+    observed_barrier = threading.Barrier(num_partitions, timeout=2)
+    observed_current_nodes = {}
+    active_snapshot = {}
+
+    def monitor_partition(partition_id):
+        node_id = node_ids[partition_id]
+        executor._mark_dag_node_started(node_id)
+        started_barrier.wait()
+        observed_current_nodes[partition_id] = executor.current_dag_node
+        if partition_id == 0:
+            with executor._dag_state_lock:
+                active_snapshot.update(executor.current_dag_nodes)
+        observed_barrier.wait()
+        executor._mark_dag_node_completed(node_id, duration=partition_id + 0.5)
+
+    with ThreadPoolExecutor(max_workers=num_partitions) as pool:
+        futures = [pool.submit(monitor_partition, partition_id) for partition_id in range(num_partitions)]
+        for future in futures:
+            future.result()
+
+    assert observed_current_nodes == {partition_id: node_id for partition_id, node_id in enumerate(node_ids)}
+    assert active_snapshot == {partition_id: node_id for partition_id, node_id in enumerate(node_ids)}
+    assert executor.current_dag_nodes == {}
+    for partition_id, node_id in enumerate(node_ids):
+        node = executor.pipeline_dag.nodes[node_id]
+        assert node["status"] == DAGNodeStatus.COMPLETED.value
+        assert node["start_time"] is not None
+        assert node["actual_duration"] == partition_id + 0.5

--- a/tests/core/executor/test_ray_executor_partitioned_parallel.py
+++ b/tests/core/executor/test_ray_executor_partitioned_parallel.py
@@ -2,6 +2,8 @@ import threading
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pytest
+
 from data_juicer.core.executor.ray_executor_partitioned import PartitionedRayExecutor
 
 
@@ -22,15 +24,22 @@ def test_partitions_are_processed_in_parallel_and_merged_in_order():
     """Partition jobs should overlap without changing their union order."""
     executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
     executor.cfg = {}
+    executor.max_concurrent_partitions = 3
     executor._log_event = Mock()
     partitions = [FakeData([i]) for i in range(3)]
     partitioning_info = SimpleNamespace(num_partitions=3, total_rows=3)
     executor._split_dataset_deterministic = Mock(return_value=(partitions, partitioning_info))
 
     start_barrier = threading.Barrier(len(partitions), timeout=2)
+    partition_finished = [threading.Event() for _ in partitions]
+    completion_order = []
 
     def process_with_checkpointing(dataset, partition_id, ops):
         start_barrier.wait()
+        if partition_id < len(partitions) - 1:
+            assert partition_finished[partition_id + 1].wait(timeout=2)
+        completion_order.append(partition_id)
+        partition_finished[partition_id].set()
         return dataset
 
     executor._process_with_checkpointing = process_with_checkpointing
@@ -41,4 +50,64 @@ def test_partitions_are_processed_in_parallel_and_merged_in_order():
     ):
         result = executor._process_with_simple_partitioning(FakeRayDataset(None), [])
 
+    assert completion_order == [2, 1, 0]
     assert result.data.partition_ids == [0, 1, 2]
+
+
+def test_partition_concurrency_is_bounded():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = {}
+    executor.max_concurrent_partitions = 2
+    executor._log_event = Mock()
+    partitions = [FakeData([i]) for i in range(4)]
+    partitioning_info = SimpleNamespace(num_partitions=4, total_rows=4)
+    executor._split_dataset_deterministic = Mock(return_value=(partitions, partitioning_info))
+
+    active_partitions = 0
+    max_active_partitions = 0
+    active_lock = threading.Lock()
+    pair_barrier = threading.Barrier(executor.max_concurrent_partitions, timeout=2)
+
+    def process_with_checkpointing(dataset, partition_id, ops):
+        nonlocal active_partitions, max_active_partitions
+        with active_lock:
+            active_partitions += 1
+            max_active_partitions = max(max_active_partitions, active_partitions)
+        pair_barrier.wait()
+        with active_lock:
+            active_partitions -= 1
+        return dataset
+
+    executor._process_with_checkpointing = process_with_checkpointing
+
+    with patch(
+        "data_juicer.core.executor.ray_executor_partitioned.RayDataset",
+        FakeRayDataset,
+    ):
+        result = executor._process_with_simple_partitioning(FakeRayDataset(None), [])
+
+    assert max_active_partitions == executor.max_concurrent_partitions
+    assert result.data.partition_ids == [0, 1, 2, 3]
+
+
+def test_partition_failure_is_logged_and_propagated():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = {}
+    executor.max_concurrent_partitions = 1
+    executor._log_event = Mock()
+    executor.log_partition_failed = Mock()
+    partitions = [FakeData([0])]
+    partitioning_info = SimpleNamespace(num_partitions=1, total_rows=1)
+    executor._split_dataset_deterministic = Mock(return_value=(partitions, partitioning_info))
+    executor._process_with_checkpointing = Mock(side_effect=RuntimeError("partition failed"))
+
+    with (
+        patch(
+            "data_juicer.core.executor.ray_executor_partitioned.RayDataset",
+            FakeRayDataset,
+        ),
+        pytest.raises(RuntimeError, match="partition failed"),
+    ):
+        executor._process_with_simple_partitioning(FakeRayDataset(None), [])
+
+    executor.log_partition_failed.assert_called_once_with(0, "partition failed", retry_count=0)

--- a/tests/core/executor/test_ray_executor_partitioned_parallel.py
+++ b/tests/core/executor/test_ray_executor_partitioned_parallel.py
@@ -1,0 +1,44 @@
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from data_juicer.core.executor.ray_executor_partitioned import PartitionedRayExecutor
+
+
+class FakeData:
+    def __init__(self, partition_ids):
+        self.partition_ids = partition_ids
+
+    def union(self, other):
+        return FakeData(self.partition_ids + other.partition_ids)
+
+
+class FakeRayDataset:
+    def __init__(self, data, cfg=None):
+        self.data = data
+
+
+def test_partitions_are_processed_in_parallel_and_merged_in_order():
+    """Partition jobs should overlap without changing their union order."""
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = {}
+    executor._log_event = Mock()
+    partitions = [FakeData([i]) for i in range(3)]
+    partitioning_info = SimpleNamespace(num_partitions=3, total_rows=3)
+    executor._split_dataset_deterministic = Mock(return_value=(partitions, partitioning_info))
+
+    start_barrier = threading.Barrier(len(partitions), timeout=2)
+
+    def process_with_checkpointing(dataset, partition_id, ops):
+        start_barrier.wait()
+        return dataset
+
+    executor._process_with_checkpointing = process_with_checkpointing
+
+    with patch(
+        "data_juicer.core.executor.ray_executor_partitioned.RayDataset",
+        FakeRayDataset,
+    ):
+        result = executor._process_with_simple_partitioning(FakeRayDataset(None), [])
+
+    assert result.data.partition_ids == [0, 1, 2]


### PR DESCRIPTION
## Summary

This PR fixes serial partition execution and hardens resource planning in
`PartitionedRayExecutor`.

The executor previously split a Ray Dataset into multiple partitions but
processed them one at a time on the driver. Increasing
`partition.num_of_partitions` therefore added independent Ray Data job and
Actor startup overhead without creating partition-level concurrency.

This change:

- drives partition jobs concurrently with a driver-side `ThreadPoolExecutor`;
- keeps the actual data processing and resource scheduling in Ray;
- preserves the original partition order when the processed datasets are
  unioned;
- reuses the existing checkpointing and event-logging path for every
  partition;
- calculates automatic operator parallelism once as a global job plan and
  scales it across concurrent partitions;
- treats an explicit Actor `num_proc` as a global pool budget instead of
  repeating the full pool in every partition;
- changes the default `partition.max_concurrent_partitions` from `32` to
  resource-aware `"auto"`;
- adds regression coverage for execution overlap, ordering, resource scaling,
  explicit Actor budgets, automatic partition limits, and restoration after
  success or failure.

No operator API or output schema is changed. Existing positive integer values
for `partition.max_concurrent_partitions` remain valid and override automatic
detection.

## Motivation

Partitioning is expected to let independent dataset partitions make progress
at the same time when Ray has sufficient resources. The previous implementation
used the following effective execution order:

```text
partition 0: submit -> materialize -> finish
partition 1: submit -> materialize -> finish
partition 2: submit -> materialize -> finish
...
```

`_process_with_checkpointing()` materializes the processed Ray Dataset before
returning. Because `_process_with_simple_partitioning()` called it from a
regular Python `for` loop, the driver waited for each partition to finish
before submitting the next one.

As a result:

- partition-level concurrency was always 1;
- idle CPUs or GPUs could not be used by another partition;
- GPU Actors were repeatedly created and destroyed in series;
- a larger partition count could make the job substantially slower.

This behavior was especially visible with one-GPU model Actors. On a four-GPU
node, `partition=4` still processed every row on GPU 0 while the other three
GPUs remained unused.

## Root cause

Ray Data transformations are lazy, but every partition is explicitly
materialized inside the existing checkpointing path:

```python
processed_dataset = dataset.process(ops)
processed_dataset.data = processed_dataset.data.materialize()
```

The outer serial loop therefore became a synchronization boundary around each
partition. Ray could parallelize blocks within one partition, but it never saw
multiple independent partition jobs at the same time.

The issue is in Data-Juicer's driver-side orchestration rather than in Ray's
partition or scheduling implementation.

Enabling concurrent partition drivers also exposed two resource-planning
risks:

1. An automatic or explicit Actor pool size could be reused independently by
   every partition. For example, four concurrent partitions could each see
   `num_proc=4` and collectively request up to 16 Actors even though the
   non-partitioned meaning is a four-Actor job budget.
2. The fixed default `max_concurrent_partitions=32` could start many Ray Data
   execution plans, driver threads, model initializations, and checkpoint
   writes at once, even on a four-GPU node.

The final implementation therefore separates global operator planning from
per-partition execution and resolves a safe outer-pipeline limit before
starting driver threads.

## What does this PR change?

### Concurrent partition orchestration

Replace the serial partition loop with a bounded `ThreadPoolExecutor`:

```python
requested_max_workers = min(
    len(partitions),
    self.max_concurrent_partitions,
)
max_workers = self._limit_partition_workers_for_explicit_actors(
    ops,
    requested_max_workers,
)

with ThreadPoolExecutor(
    max_workers=max_workers,
    thread_name_prefix="ray-partition",
) as executor:
    futures = {
        executor.submit(
            self._process_partition,
            partition,
            partition_id,
            len(partitions),
            ops,
        ): partition_id
        for partition_id, partition in enumerate(partitions)
    }
```

The Python threads only drive independent Ray Dataset executions and wait for
their results. CPU/GPU data processing still runs in Ray tasks and Actors, so
Ray remains responsible for resource admission and placement.

### Plan operator resources globally

Operator resource planning now runs once on the driver before any partition
thread starts:

```python
self._configure_operator_parallelism(ops)
self._resolve_max_concurrent_partitions(ops)
```

This avoids concurrent mutation of the shared operator objects and preserves
the non-partitioned meaning of operator concurrency.

For automatically planned operators, the global concurrency is divided across
the number of concurrently driven partitions. Automatic values use ceiling
division so every partition retains usable concurrency. For example, on a
four-GPU node:

```text
global GPU num_proc=4

P=1 -> 1 partition worker  × num_proc=4
P=2 -> 2 partition workers × num_proc=2
P=4 -> 4 partition workers × num_proc=1
```

The original global values are restored in a `finally` block for later
convergence stages and for correct cleanup after partition failures.

### Treat explicit Actor num_proc as a global budget

A positive explicit Actor `num_proc` (including supported tuple/list forms) is
recorded as a global job budget. The executor:

- limits concurrent partition workers to the smallest explicit Actor budget;
- uses floor division to derive a safe per-partition Actor pool size;
- restores the configured value after partition processing.

For example, `num_proc=4` with four concurrent partitions becomes one Actor
per partition rather than four Actors per partition. If `num_proc=2` and four
partitions are requested, at most two partitions run concurrently, each with
one Actor.

Explicit Ray task concurrency is intentionally unchanged; this budget
handling applies to Actor pools whose instances and model memory would
otherwise be multiplied per partition.

### Resolve partition concurrency from Ray resources

`partition.max_concurrent_partitions` now defaults to `"auto"` and is resolved
after operator resource planning:

- GPU pipelines use the tightest CPU/GPU worker capacity reported by the Ray
  cluster;
- CPU-only pipelines use a conservative outer-pipeline cap of 4 because Ray
  Data already parallelizes blocks inside each partition;
- the result is bounded by the actual partition count and explicit Actor
  budgets;
- inability to inspect usable Ray resources falls back to one partition
  pipeline;
- a positive integer remains available as an explicit override.

This controls driver threads and the number of simultaneous Ray Data execution
plans. Ray still performs final CPU, GPU, memory, and object-store admission.

### Preserve deterministic union order

Concurrent partitions can finish in any order. The implementation therefore
preallocates the result list and stores every result by `partition_id`:

```python
processed_partitions = [None] * len(partitions)

for future in as_completed(futures):
    partition_id, processed_data = future.result()
    processed_partitions[partition_id] = processed_data
```

The existing union loop then consumes this list in the original partition
order. Completion order does not affect output partition ordering.

### Reuse the existing per-partition path

The original per-partition logic is moved into `_process_partition()`:

- emit `PARTITION_START`;
- wrap the Ray Dataset;
- call `_process_with_checkpointing()`;
- emit `PARTITION_COMPLETE`;
- return the partition ID and processed Ray Dataset.

The checkpoint strategy, materialization behavior, metrics, DAG monitoring,
and event types are not otherwise changed.

Calling `future.result()` also propagates a partition exception to the caller
instead of silently dropping a failed result.

### Regression coverage

Add
`tests/core/executor/test_ray_executor_partitioned_parallel.py`.

The test uses a `threading.Barrier` that can only pass when all three partition
jobs overlap. It also makes the partitions return in a concurrent execution
path and verifies that the final union order remains:

```text
[0, 1, 2]
```

The previous serial loop cannot pass the barrier and therefore fails this
test.

Additional tests cover:

- automatic planning exactly once on the driver;
- automatic and explicit Actor concurrency scaling;
- tuple/list Actor pool forms;
- global concurrency restoration after success and failure;
- explicit Actor budgets limiting partition workers;
- explicit Ray task concurrency remaining unchanged;
- automatic GPU, multi-GPU, CPU-only, and CPU-heavy partition limits;
- explicit `max_concurrent_partitions` overrides and safe fallback behavior;
- configuration parsing for the new `"auto"` default.

## Behavior before and after

```text
Before:

partition 0  [================]
partition 1                    [================]
partition 2                                      [================]
partition 3                                                        [================]

After:

partition 0  [================]
partition 1  [================]
partition 2  [================]
partition 3  [================]
```

The second timeline assumes sufficient Ray resources and no smaller explicit
Actor budget. Otherwise, the executor applies the resolved partition cap and
Ray queues tasks or Actors normally; the driver no longer adds an
unconditional serial barrier.

## Testing

The controlled benchmark harnesses and raw benchmark outputs are kept outside
the Data-Juicer repository and are not part of this PR's source diff.

### Unit test

Run:

```bash
python -m pytest -q \
  tests/core/executor/test_ray_executor_partitioned_parallel.py \
  tests/config/test_config_functions.py
```

Result:

```text
108 passed in 4.94s
```

The targeted tests cover:

- overlapping partition execution;
- result collection through completed futures;
- preservation of partition union order;
- global automatic operator planning;
- automatic and explicit Actor-pool scaling and restoration;
- resource-aware automatic partition limits and explicit overrides;
- the `max_concurrent_partitions: "auto"` configuration default.

### Controlled single-node CPU A/B benchmark

A controlled sleep Mapper was used to isolate partition-level concurrency:

- 4096 input rows;
- 4 Ray blocks;
- batch size 64;
- 100 ms of work per batch;
- one CPU worker inside each partition;
- checkpointing and automatic operator parallelism disabled;
- three repetitions per configuration.

All 18 runs completed with 4096 output rows and 4 output blocks.
The table reports median `processing_seconds`:

| Implementation | Partition | Processing time | Throughput | Speedup vs P=1 | Original / Fixed |
| --- | ---: | ---: | ---: | ---: | ---: |
| original | 1 | 11.145 s | 367.5 rows/s | 1.00x | 1.00x |
| original | 2 | 11.195 s | 365.9 rows/s | 1.00x | 1.41x |
| original | 4 | 11.398 s | 359.4 rows/s | 0.98x | 1.73x |
| fixed | 1 | 11.141 s | 367.6 rows/s | 1.00x | 1.00x |
| fixed | 2 | 7.926 s | 516.8 rows/s | 1.41x | 1.41x |
| fixed | 4 | 6.574 s | 623.1 rows/s | 1.69x | 1.73x |

P=1 changed by approximately 0.03%. At P=2 and P=4, the fix reduced
processing time by 29.20% and 42.32%, respectively.

### Initial isolated four-GPU H20 orchestration A/B benchmark

The GPU benchmark used:

- one node with 4 NVIDIA H20 GPUs;
- 100,000 input rows and 100 Ray blocks;
- batch size 1,000;
- one one-GPU Actor per partition;
- BF16 inference with a fixed token length of 64;
- local sentiment, topic-classification, and CLIP model weights;
- checkpointing, OP fusion, and automatic operator parallelism disabled;
- three repetitions per configuration.

The three model forwards were combined into one batched benchmark Mapper to
keep the 100,000-row test practical and isolate partition scheduling. Every
run produced 100,000 rows, 100 output blocks, and 100 recorded GPU batches.
All 18 runs succeeded.

Median results:

| Implementation | Partition | Processing time | Throughput | Speedup vs P=1 | Peak concurrent GPU batches |
| --- | ---: | ---: | ---: | ---: | ---: |
| original | 1 | 68.576 s | 1458.2 rows/s | 1.00x | 1 |
| original | 2 | 77.573 s | 1289.1 rows/s | 0.88x | 1 |
| original | 4 | 95.317 s | 1049.1 rows/s | 0.72x | 1 |
| fixed | 1 | 68.654 s | 1456.6 rows/s | 1.00x | 1 |
| fixed | 2 | 39.144 s | 2554.7 rows/s | 1.75x | 2 |
| fixed | 4 | 25.516 s | 3919.1 rows/s | 2.69x | 4 |

Observed GPU placement:

| Implementation | Partition | Processed rows per GPU |
| --- | ---: | --- |
| original | 2 | GPU 0: 100,000 |
| original | 4 | GPU 0: 100,000 |
| fixed | 2 | GPU 0/1: 50,000 each |
| fixed | 4 | GPU 0/1/2/3: 25,000 each |

At P=2, the fix reduced processing time by 49.54%. At P=4, it reduced
processing time by 73.23% and was 3.74x faster than the original P=4 path.

The GPU traces also show the orchestration change directly:

- original P=4 started each partition only after the previous one completed;
- fixed P=4 started all four partitions within approximately 2 ms;
- fixed P=4 partition completion times were within approximately 0.55 s;
- the four concurrent Actors were placed on four different H20 GPUs.

P=4 does not reach a full 4x speedup because the critical path still contains
approximately 10 seconds of fixed Actor creation, local model loading, CUDA
warm-up, Ray scheduling, and partition bookkeeping. The measured model-batch
work decreases from approximately 58.7 seconds at P=1 to 15.0 seconds at P=4,
while that fixed cost does not decrease.

This isolated A/B benchmark was produced while validating the core
orchestration change. Its one-Actor-per-partition setup intentionally models
per-partition placement. The final global Actor-budget and automatic
operator-planning behavior is validated separately by the end-to-end
benchmark below.

Because the final implementation interprets an explicit Actor `num_proc=1`
as a global one-Actor budget, this exact harness is retained as evidence for
the original serial barrier rather than as a performance claim for the final
explicit-Actor policy.

### Final four-GPU auto-num-proc end-to-end benchmark

The final resource-planning implementation was tested with the standard
`demos/elastic_sharding/configs/gpu_demo.yaml` operator chain:

- one node with 4 NVIDIA H20 GPUs and 8 Ray CPUs;
- Ray 2.55.1;
- 100,000 input rows and 100 Ray blocks;
- P=1, P=2, and P=4, one long run per configuration;
- separate sentiment-classification, topic-classification, and CLIP
  text-pair-similarity GPU operators;
- the original GPU batch size of 4;
- local model weights;
- every explicit operator `num_proc` removed at runtime;
- `auto_op_parallelism: true`;
- `partition.max_concurrent_partitions: "auto"`;
- checkpointing, cache, and Data-Juicer OP fusion disabled.

Every run produced and exported 100,000 rows with 100 output blocks. Runtime
instrumentation captured the global plan, the per-partition scaled plan, and
the restored plan.

Resource-plan validation:

| Partition | Global GPU num_proc | Partition workers | Per-partition GPU num_proc | Effective budget | Resolved auto limit | Trace valid |
| ---: | ---: | ---: | ---: | ---: | ---: | --- |
| 1 | 4 | 1 | 4 | 4 | 4 | yes |
| 2 | 4 | 2 | 2 | 4 | 4 | yes |
| 4 | 4 | 4 | 1 | 4 | 4 | yes |

All checks passed:

- global planning, scaling, and restoration each ran exactly once;
- all three GPU operators received the global automatic value 4;
- the automatic partition limit resolved to the four-GPU capacity;
- P=1/2/4 scaled to 4/2/1 without multiplying the global budget;
- the global values were restored after partition processing.

Performance results:

| Partition | Recipe time | Throughput | Speedup vs P=1 | Average active GPUs | Peak active GPUs |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 1698.673 s | 58.9 rows/s | 1.00x | 1.00 | 2 |
| 2 | 1258.476 s | 79.5 rows/s | 1.35x | 1.35 | 3 |
| 4 | 831.512 s | 120.3 rows/s | 2.04x | 2.07 | 4 |

P=4 reduced recipe time by 51.05% and increased throughput by 104.29%
relative to P=1. It was also 33.93% faster than P=2.

The telemetry clarifies why P=4 still helps even though every configuration
has the same logical four-GPU budget:

- P=1 primarily used GPUs 0 and 1. GPU 2 was active in only 7 of 1,568
  samples, and GPU 3 remained unused.
- P=2 used three GPUs, but GPU 3 remained unused. Its two equal 50,000-row
  partitions completed in 851.49 s and 1249.02 s, leaving a long scheduling
  tail.
- P=4 used all four GPUs evenly. Per-GPU average utilization was
  11.70%-11.75%, and its four equal partitions completed within 2.48 s of
  each other.

In the P=1 log, Ray Data commonly reported only two active GPUs out of four
requested:

```text
Active & requested resources: 2/8 CPU, 2/4 GPU
```

The execution logs also contain `ResourceBudget` backpressure. This indicates
that `num_proc=4` is an upper bound, not a guarantee that one Ray Data
execution plan will continuously occupy four GPUs. Multiple eligible stages
inside the plan share Ray Data's resource budget. Four independent
one-GPU partition pipelines used the physical cluster more consistently.

This behavior is not a recurrence of the partition resource-multiplication
bug: the captured logical plan is correct in all three cases. It is a
remaining Ray Data scheduling and pipeline-utilization characteristic. The
low absolute GPU utilization is also consistent with batch size 4, CPU
tokenization/stats/filter stages, task scheduling, and sequential model
operators.

Because this production-style benchmark is expensive and each configuration
was run once, its exact timing is less statistically robust than the
three-repeat controlled A/B benchmarks. The 51% P=4 reduction and the
per-GPU placement evidence nevertheless show a clear trend.

## Compatibility

- No configuration field is removed.
- `partition.max_concurrent_partitions` now accepts either a positive integer
  or `"auto"` and defaults to `"auto"` instead of `32`. Existing positive
  integer configurations preserve their explicit limit.
- No operator API or dataset schema is changed.
- P=1 follows the same data-processing path through a one-worker thread pool;
  CPU and GPU median benchmarks show no measurable P=1 regression.
- Processed partitions are still unioned in their original partition order.
- Existing checkpoint and event-logging functions remain the implementation
  used by every partition.
- Explicit Actor `num_proc` is now interpreted as a global job budget in the
  partitioned executor. This deliberately prevents the configured Actor pool
  from being repeated per partition.
- Explicit Ray task `num_proc` behavior is unchanged.
- Actual driver concurrency is bounded by the partition count, the resolved or
  configured partition limit, and explicit Actor budgets. Ray continues to
  enforce physical CPU, GPU, memory, and object-store resources.

## Requirements and limitations

- Automatic partition concurrency uses advertised CPU/GPU resources and
  per-worker requests. It does not predict model memory, object-store traffic,
  input skew, or Ray Data's internal per-operator resource reservation.
- A manual positive `max_concurrent_partitions` can still create many driver
  threads and Ray Data execution plans. Large overrides should be selected
  with driver, object-store, checkpoint-I/O, and model-initialization capacity
  in mind.
- Concurrent GPU partitions instantiate multiple model Actors at the same
  time up to the global Actor and partition limits. GPU memory usage therefore
  scales with the number of simultaneously admitted Actors.
- Speedup depends on partition balance, available Ray resources, operator
  cost, batch size, model-loading overhead, Ray Data backpressure, and
  object-store pressure.
- `num_proc` is a Ray Data concurrency ceiling. Internal resource reservation
  and backpressure may keep actual CPU/GPU activity below the planned value,
  as observed in the final P=1 GPU run.
- Ray 2.55.1 warns that specifying both `num_cpus` and `num_gpus` for map tasks
  is experimental. The final end-to-end recipe retains both values from the
  source recipe so each task receives a CUDA device and one CPU.
- The controlled benchmarks disable checkpointing and convergence operations
  to isolate the simple-partition execution path. The PR does not change their
  internal logic, but a large end-to-end checkpoint/resume stress test was not
  part of this validation.
- The GPU benchmark combines three model forwards in a benchmark-only Mapper;
  it validates partition scheduling and GPU placement rather than exact
  end-to-end performance of the three separate production operators.
- The final auto-num-proc benchmark does use the three separate production
  operators, but it has one repetition per partition count.
- The full repository test suite was not run.

## Validation status

- [x] Targeted executor and configuration tests, 108/108 passed
- [x] Controlled CPU A/B benchmark, 18/18 successful runs
- [x] Initial isolated 4×H20 orchestration A/B benchmark, 18/18 successful runs
- [x] Final standard-recipe 4×H20 auto-num-proc benchmark, 3/3 successful runs
- [x] Global/per-partition/restored resource-plan validation
- [x] Output row, block, and batch-count validation
- [x] GPU placement and batch-overlap validation
