### PR TITLE
fix: Pin pandas for supported Ray Data versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ audio = [
 # Distributed Computing
 distributed = [
     "ray[default]>=2.51.0",  # distributed computing
+    "pandas<3",  # Ray Data versions supported by Data-Juicer are not compatible with pandas 3
     "uvloop==0.21.0",  # avoid async error before it's fixed in uvloop
     "pyspark==3.5.5",  # distributed data processing
     "s3fs",  # S3 filesystem support for cloud storage


### PR DESCRIPTION
## Summary

Pin `pandas<3` in the `distributed` optional dependencies.

## Motivation

Ray Data 2.51–2.54 is incompatible with pandas 3 during JSON export. Ray accesses `pd.errors.SettingWithCopyWarning`, which was removed in pandas 3, causing an `AttributeError` in Ray workers.

This constraint only affects distributed/Ray installations and keeps the base package’s pandas dependency unchanged.

## Validation

- Verified the failure with Ray 2.52.0 and pandas 3.0.3.
- Verified successful JSON export with Ray 2.52.0, pandas 2.2.3, and PyArrow 24.0.0.
- Ran pre-commit checks successfully.