### PR TITLE
Use public Ray compute strategies

### DIFF
--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -8,7 +8,7 @@ import pyarrow
 import ray
 from jsonargparse import Namespace
 from loguru import logger
-from ray.data._internal.util import get_compute_strategy
+from ray.data import ActorPoolStrategy, TaskPoolStrategy
 
 from data_juicer.core.data import DJDataset
 from data_juicer.core.data.schema import Schema
@@ -233,7 +233,7 @@ class RayDataset(DJDataset):
 
                 try:
                     if op.use_ray_actor():
-                        compute = get_compute_strategy(op.__class__, concurrency=op.num_proc)
+                        compute = ActorPoolStrategy(size=op.num_proc)
                         self.data = self.data.map_batches(
                             op.__class__,
                             fn_args=None,
@@ -248,7 +248,7 @@ class RayDataset(DJDataset):
                             runtime_env=op.runtime_env,
                         )
                     else:
-                        compute = get_compute_strategy(op.process, concurrency=op.num_proc)
+                        compute = TaskPoolStrategy(size=op.num_proc)
                         self.data = self.data.map_batches(
                             op.process,
                             batch_size=batch_size,
@@ -283,7 +283,7 @@ class RayDataset(DJDataset):
                         f"to preserve shared dedup state across workers"
                     )
                 if op.use_ray_actor() and not use_instance_for_ray_tasks:
-                    compute = get_compute_strategy(op.__class__, concurrency=op.num_proc)
+                    compute = ActorPoolStrategy(size=op.num_proc)
                     self.data = self.data.map_batches(
                         op.__class__,
                         fn_args=None,
@@ -298,7 +298,7 @@ class RayDataset(DJDataset):
                         runtime_env=op.runtime_env,
                     )
                 else:
-                    compute = get_compute_strategy(op.compute_stats, concurrency=op.num_proc)
+                    compute = TaskPoolStrategy(size=op.num_proc)
                     self.data = self.data.map_batches(
                         op.compute_stats,
                         batch_size=batch_size,

--- a/tests/core/data/test_ray_dataset.py
+++ b/tests/core/data/test_ray_dataset.py
@@ -1,6 +1,8 @@
 import json
 import unittest
 import os
+from unittest.mock import MagicMock
+
 from data_juicer.utils.unittest_utils import TEST_TAG, DataJuicerTestCaseBase
 
 
@@ -371,6 +373,45 @@ class TestRayDataset(DataJuicerTestCaseBase):
         self.assertIsInstance(row, dict)
         self.assertIsInstance(row["text"], str)
         self.assertIsInstance(row["score"], int)
+
+
+class RayComputeStrategyTest(DataJuicerTestCaseBase):
+    def _get_compute_strategy(self, op):
+        from data_juicer.core.data.ray_dataset import RayDataset
+
+        ray_data = MagicMock()
+        ray_data.map_batches.return_value = ray_data
+        dataset = RayDataset.__new__(RayDataset)
+        dataset.data = ray_data
+
+        dataset._run_single_op(op, {"text"})
+
+        compute_strategies = [
+            call.kwargs["compute"] for call in ray_data.map_batches.call_args_list if "compute" in call.kwargs
+        ]
+        self.assertEqual(len(compute_strategies), 1)
+        return compute_strategies[0]
+
+    @TEST_TAG("ray")
+    def test_public_compute_strategies(self):
+        from ray.data import ActorPoolStrategy, TaskPoolStrategy
+
+        from data_juicer.ops.filter.text_length_filter import TextLengthFilter
+        from data_juicer.ops.mapper.python_lambda_mapper import PythonLambdaMapper
+
+        for op_class in [PythonLambdaMapper, TextLengthFilter]:
+            with self.subTest(op=op_class.__name__, mode="task"):
+                op = op_class(auto_op_parallelism=False, num_proc=2, ray_execution_mode="task")
+                compute = self._get_compute_strategy(op)
+                self.assertIsInstance(compute, TaskPoolStrategy)
+                self.assertEqual(compute.size, 2)
+
+            with self.subTest(op=op_class.__name__, mode="actor"):
+                op = op_class(auto_op_parallelism=False, num_proc=2, ray_execution_mode="actor")
+                compute = self._get_compute_strategy(op)
+                self.assertIsInstance(compute, ActorPoolStrategy)
+                self.assertEqual(compute.min_size, 2)
+                self.assertEqual(compute.max_size, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Replace Ray’s private `get_compute_strategy` helper with the public `TaskPoolStrategy` and `ActorPoolStrategy` APIs.

## Changes

- Use `ActorPoolStrategy(size=op.num_proc)` for actor-based Mapper and Filter operations.
- Use `TaskPoolStrategy(size=op.num_proc)` for task-based operations.
- Add regression coverage for Mapper/Filter × task/actor combinations.

## Motivation

The previous implementation imported `get_compute_strategy` from `ray.data._internal`, which is not a stable public API. It also passed the deprecated `concurrency` argument internally.

The new implementation follows Ray’s public API while preserving the existing fixed worker-count behavior.

## Validation

- 20 related tests passed.
- Verified end-to-end execution with Ray 2.52.0.
- Confirmed task mode uses `TaskPoolMapOperator`.
- Confirmed actor mode uses `ActorPoolMapOperator`.
- All pre-commit checks passed.