### PR TITLE
perf: Reduce eager Ray dataset actions

### DIFF
--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -112,10 +112,14 @@ class RayDataset(DJDataset):
         Returns:
             Schema: Dataset schema containing column names and types
         """
-        if self.data is None or self.data.columns() is None:
+        if self.data is None:
             raise ValueError("Dataset is empty or not initialized")
 
-        return Schema.from_ray_schema(self.data.schema())
+        ray_schema = self.data.schema()
+        if ray_schema is None:
+            raise ValueError("Dataset is empty or not initialized")
+
+        return Schema.from_ray_schema(ray_schema)
 
     def get(self, k: int) -> List[Dict[str, Any]]:
         """Get k rows from the dataset."""
@@ -125,8 +129,7 @@ class RayDataset(DJDataset):
         if k == 0:
             return []
 
-        k = min(k, self.data.count())
-        return list(self.data.limit(k).take())
+        return list(self.data.take(k))
 
     def get_column(self, column: str, k: Optional[int] = None) -> List[Any]:
         """Get column values from Ray dataset.
@@ -142,7 +145,11 @@ class RayDataset(DJDataset):
             KeyError: If column doesn't exist
             ValueError: If k is negative
         """
-        if self.data is None or self.data.columns() is None or column not in self.data.columns():
+        if self.data is None:
+            raise KeyError(f"Column '{column}' not found in dataset")
+
+        columns = self.data.columns()
+        if columns is None or column not in columns:
             raise KeyError(f"Column '{column}' not found in dataset")
 
         if k is not None:
@@ -150,10 +157,9 @@ class RayDataset(DJDataset):
                 raise ValueError(f"k must be non-negative, got {k}")
             if k == 0:
                 return []
-            k = min(k, self.data.count())
-            return [row[column] for row in self.data.limit(k).take()]
+            return [row[column] for row in self.data.take(k)]
 
-        return [row[column] for row in self.data.take()]
+        return [row[column] for row in self.data.take_all()]
 
     def process(self, operators, *, exporter=None, checkpointer=None, tracer=None) -> DJDataset:
         if operators is None:
@@ -165,17 +171,6 @@ class RayDataset(DJDataset):
 
         if self._auto_proc:
             calculate_ray_np(operators)
-
-        # Check if dataset is empty - Ray returns None for columns() on empty datasets
-        # with unknown schema. If empty, skip processing as there's nothing to process.
-        try:
-            row_count = self.data.count()
-        except Exception:
-            row_count = 0
-
-        if row_count == 0:
-            logger.warning("Dataset is empty (0 rows), skipping operator processing")
-            return self
 
         # Cache columns once at start to avoid breaking pipeline with repeated columns() calls
         # Ray's columns() internally does limit(1) which forces execution and breaks streaming

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -122,7 +122,13 @@ class RayDataset(DJDataset):
         return Schema.from_ray_schema(ray_schema)
 
     def get(self, k: int) -> List[Dict[str, Any]]:
-        """Get k rows from the dataset."""
+        """Get k rows from the dataset.
+
+        Note:
+            The requested rows are moved to the caller's machine. A ``k``
+            larger than the dataset size returns all rows and may cause an
+            OutOfMemory error on the caller.
+        """
         if k < 0:
             raise ValueError(f"k must be non-negative, got {k}")
 
@@ -144,6 +150,12 @@ class RayDataset(DJDataset):
         Raises:
             KeyError: If column doesn't exist
             ValueError: If k is negative
+
+        Note:
+            The requested rows are moved to the caller's machine. A ``k``
+            larger than the dataset size returns all rows, and ``k=None``
+            returns every row; either may cause an OutOfMemory error on the
+            caller for large datasets.
         """
         if self.data is None:
             raise KeyError(f"Column '{column}' not found in dataset")
@@ -175,9 +187,10 @@ class RayDataset(DJDataset):
         # Cache columns once at start to avoid breaking pipeline with repeated columns() calls
         # Ray's columns() internally does limit(1) which forces execution and breaks streaming
         columns_result = self.data.columns()
-        # Handle empty dataset case where columns() returns None
-        if columns_result is None:
-            logger.warning("Dataset has unknown schema (likely empty), skipping operator processing")
+        # Handle empty dataset: columns() returns None when the schema is unknown
+        # (lazy/empty datasets) and [] for datasets with a known schema but 0 rows
+        if not columns_result:
+            logger.warning("Dataset is empty (0 rows or unknown schema), skipping operator processing")
             return self
         cached_columns = set(columns_result)
 

--- a/tests/core/data/test_ray_dataset.py
+++ b/tests/core/data/test_ray_dataset.py
@@ -403,6 +403,27 @@ class TestRayDataset(DataJuicerTestCaseBase):
 
         self.assertIs(result, dataset)
         ray_data.count.assert_not_called()
+        ray_data.columns.assert_called_once()
+
+    @TEST_TAG("ray")
+    def test_process_skips_empty_dataset_with_known_schema(self):
+        """Empty datasets with a known schema (columns() returns []) must be
+        skipped instead of running operators on zero rows."""
+        import pyarrow
+        import ray
+        from data_juicer.core.data.ray_dataset import RayDataset
+        from data_juicer.ops.mapper.punctuation_normalization_mapper import (
+            PunctuationNormalizationMapper,
+        )
+
+        empty_data = pyarrow.table({"text": []})
+        dataset = RayDataset(ray.data.from_arrow(empty_data))
+        self.assertEqual(dataset.data.columns(), ["text"])
+        self.assertEqual(dataset.data.count(), 0)
+
+        result = dataset.process([PunctuationNormalizationMapper()])
+
+        self.assertIs(result, dataset)
 
 
 if __name__ == "__main__":

--- a/tests/core/data/test_ray_dataset.py
+++ b/tests/core/data/test_ray_dataset.py
@@ -1,6 +1,8 @@
 import json
 import unittest
 import os
+from unittest.mock import MagicMock
+
 from data_juicer.utils.unittest_utils import TEST_TAG, DataJuicerTestCaseBase
 
 
@@ -274,6 +276,16 @@ class TestRayDataset(DataJuicerTestCaseBase):
         texts = self.dataset.get_column("text", k=1)
         self.assertEqual(texts, ["Hello"])
 
+        # Ray's take() defaults to 20 rows, so explicitly requesting or
+        # retrieving all rows must not truncate larger datasets.
+        import ray
+        from data_juicer.core.data.ray_dataset import RayDataset
+
+        large_data = [{"text": str(i)} for i in range(25)]
+        large_dataset = RayDataset(ray.data.from_items(large_data))
+        self.assertEqual(large_dataset.get_column("text", k=25), [str(i) for i in range(25)])
+        self.assertEqual(large_dataset.get_column("text"), [str(i) for i in range(25)])
+
     @TEST_TAG("ray")
     def test_get_column_errors(self):
         """Test error handling"""
@@ -371,6 +383,26 @@ class TestRayDataset(DataJuicerTestCaseBase):
         self.assertIsInstance(row, dict)
         self.assertIsInstance(row["text"], str)
         self.assertIsInstance(row["score"], int)
+
+        large_data = [{"text": str(i)} for i in range(25)]
+        large_dataset = RayDataset(ray.data.from_items(large_data))
+        self.assertEqual(large_dataset.get(25), large_data)
+
+    @TEST_TAG("ray")
+    def test_process_does_not_count_before_building_plan(self):
+        from data_juicer.core.data.ray_dataset import RayDataset
+
+        ray_data = MagicMock()
+        ray_data.columns.return_value = ["text"]
+        dataset = RayDataset.__new__(RayDataset)
+        dataset.data = ray_data
+        dataset._auto_proc = False
+        dataset._run_single_op = MagicMock(return_value={"text"})
+
+        result = dataset.process(MagicMock())
+
+        self.assertIs(result, dataset)
+        ray_data.count.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Reduce unnecessary eager Ray Dataset actions and fix row retrieval truncation.

## Changes

- Remove the full `count()` call before building an operator pipeline.
- Use `take(k)` directly instead of `count()`, `limit(k)`, and `take()`.
- Use `take_all()` when `get_column()` is expected to return every row.
- Avoid repeated `columns()` and `schema()` calls.
- Add regression coverage with datasets containing more than 20 rows.

## Motivation

Ray Datasets are lazily evaluated, but `count()` triggers execution. Calling it before constructing every processing pipeline adds unnecessary work, especially when the partitioned executor invokes `process()` for each partition or checkpoint group.

Additionally, Ray’s `take()` defaults to 20 rows. The previous implementation could therefore silently truncate results from `get()` and `get_column()` even when more rows were requested.

## Validation

- 20 related tests passed.
- Verified that 25 requested rows are returned without truncation.
- Verified that `process()` no longer calls `count()` before building the execution plan.
- All pre-commit checks passed.

## Note

`get_column(k=None)` now follows its documented behavior and returns all rows using `take_all()`. As before, callers should avoid using it with datasets too large to fit in driver memory.