### PR TITLE
feat(ops): support external operator plugins via entry points

### DIFF
--- a/data_juicer/ops/__init__.py
+++ b/data_juicer/ops/__init__.py
@@ -1,5 +1,6 @@
 import time
 from contextlib import contextmanager
+from importlib.metadata import entry_points
 
 from loguru import logger
 
@@ -39,8 +40,60 @@ with timing_context('Importing operator modules'):
         op_requirements_to_op_env_spec,
     )
 
+# Entry-point group name that external operator plugin packages must declare
+# under [project.entry-points] in their pyproject.toml to be auto-discovered.
+OP_PLUGIN_ENTRY_POINT_GROUP = 'data_juicer.ops'
+
+
+def load_op_plugins(group: str = OP_PLUGIN_ENTRY_POINT_GROUP):
+    """Discover and import external operator plugin packages.
+
+    Any installed distribution that declares an entry point under ``group``
+    (default ``data_juicer.ops``) is imported here, which triggers the module
+    level ``OPERATORS.register_module(...)`` calls in those packages so that
+    their operators become visible in the global ``OPERATORS`` registry just
+    like the built-in ones.
+
+    A failing plugin (e.g. broken import, missing dependency) only emits a
+    warning and is skipped, so a single bad plugin never breaks the whole
+    pipeline.
+
+    :param group: the entry point group to scan.
+    :return: the list of successfully loaded plugin entry point names.
+    """
+    loaded = []
+    # importlib.metadata.entry_points has two API shapes across Python
+    # versions: 3.10+ supports the ``group=`` selection keyword, while older
+    # ones return a dict keyed by group name.
+    try:
+        eps = entry_points(group=group)
+    except TypeError:  # pragma: no cover - only on very old importlib
+        eps = entry_points().get(group, [])
+
+    for ep in eps:
+        try:
+            ep.load()
+            loaded.append(ep.name)
+            logger.debug(f'Loaded operator plugin [{ep.name}] from entry point group [{group}].')
+        except Exception as e:  # noqa: BLE001 - a bad plugin must not crash dj
+            logger.warning(
+                f'Failed to load operator plugin [{ep.name}] from entry point '
+                f'group [{group}]: {e}. This plugin will be skipped.'
+            )
+    if loaded:
+        logger.info(f'Discovered {len(loaded)} operator plugin(s) via entry points: {loaded}')
+    return loaded
+
+
+# eagerly discover external operator plugins at import time so that the
+# registry is fully populated before init_configs() reads OPERATORS.modules.
+with timing_context('Discovering operator plugins'):
+    load_op_plugins()
+
 __all__ = [
     'load_ops',
+    'load_op_plugins',
+    'OP_PLUGIN_ENTRY_POINT_GROUP',
     'Filter',
     'Mapper',
     'Deduplicator',

--- a/data_juicer/ops/__init__.py
+++ b/data_juicer/ops/__init__.py
@@ -78,7 +78,10 @@ def load_op_plugins(group: str = OP_PLUGIN_ENTRY_POINT_GROUP):
         except Exception as e:  # noqa: BLE001 - a bad plugin must not crash dj
             logger.warning(
                 f'Failed to load operator plugin [{ep.name}] from entry point '
-                f'group [{group}]: {e}. This plugin will be skipped.'
+                f'group [{group}]: {e}. '
+                f'Operators registered by this plugin before the error '
+                f'remain available, but any operators defined after the '
+                f'failing one in the same module will not be loaded.'
             )
     if loaded:
         logger.info(f'Discovered {len(loaded)} operator plugin(s) via entry points: {loaded}')

--- a/docs/OperatorPlugins.md
+++ b/docs/OperatorPlugins.md
@@ -1,58 +1,46 @@
 # Operator Plugins
 
-Data-Juicer can discover and load operators that live **outside** the core
-`data_juicer` package. This lets you ship, version and install operators as
-independent Python packages (e.g. on PyPI or a private index) and have them
-show up in the global `OPERATORS` registry exactly like the built-in ones —
-usable in any recipe by name, with no code change to Data-Juicer.
-
 - English | [中文](OperatorPlugins_ZH.md)
 
-## How it works
+## Overview
 
-At `import data_juicer.ops` time, Data-Juicer calls `load_op_plugins()`, which
-scans all installed distributions for entry points under the
-`data_juicer.ops` group and imports the referenced modules. Importing a plugin
-module runs its module-level `@OPERATORS.register_module(...)` decorators, so
-its operators become available before `init_configs()` reads the registry.
+Data-Juicer supports discovering and loading operators from external Python packages via the standard [entry points](https://packaging.python.org/en/latest/specifications/entry-points/) mechanism. This allows operators to be distributed, versioned, and installed independently (e.g. on PyPI or a private index) while still appearing in the global `OPERATORS` registry and being usable in any recipe by name.
+
+## How It Works
+
+When `data_juicer.ops` is imported, `load_op_plugins()` scans all installed distributions for entry points declared under the `data_juicer.ops` group and imports the referenced modules. Importing a plugin module executes its module-level `@OPERATORS.register_module(...)` decorators, registering operators into the global registry before `init_configs()` reads it.
 
 Key properties:
 
-- **Zero-config discovery**: once a plugin package is `pip install`ed, its
-  operators are available automatically; no path needs to be configured.
-- **Fault isolation**: if a plugin fails to import (e.g. a missing dependency),
-  it is skipped with a warning and never breaks the rest of the pipeline.
-- **Backward compatible**: when no plugin is installed, behavior is unchanged.
+- **Automatic discovery** — once a plugin package is installed, its operators become available without additional configuration.
+- **Fault isolation** — if a plugin fails to import (e.g. due to a missing dependency), it is skipped with a warning and does not affect the rest of the pipeline.
+- **Backward compatibility** — when no plugin is installed, behavior remains unchanged.
 
 ## Plugins vs. `custom_operator_paths`
 
-Data-Juicer offers two ways to use out-of-tree operators; they are
-complementary:
+Data-Juicer offers two complementary ways to use out-of-tree operators:
 
-| | Operator plugins (entry points) | `custom_operator_paths` |
+| | Operator Plugins (entry points) | `custom_operator_paths` |
 |---|---|---|
 | Distribution | Installable package (PyPI / private index) | Local `.py` file or package directory |
 | Discovery | Automatic on `pip install` | Explicit path in CLI / YAML |
-| Best for | Reusable, versioned, shared operators | Quick local / one-off operators |
-| Config | none | `--custom-operator-paths` or `custom_operator_paths:` in YAML |
+| Best for | Reusable, versioned, shared operators | Quick local or one-off operators |
+| Configuration | None required | `--custom-operator-paths` or `custom_operator_paths:` in YAML |
 
-## Writing an operator plugin
+## Writing an Operator Plugin
 
-### 1. Package layout
+### 1. Package Layout
 
 ```
 my-dj-ops/
 ├── pyproject.toml
 └── my_dj_ops/
-    └── __init__.py        # defines & registers your operators
+    └── __init__.py        # defines & registers operators
 ```
 
-### 2. Implement & register operators
+### 2. Implement and Register Operators
 
-Operators are written exactly as built-in ones: inherit from a base class
-(`Mapper`, `Filter`, `Deduplicator`, ...) and register with the
-`@OPERATORS.register_module(<op_name>)` decorator. Heavy dependencies should be
-loaded lazily via `LazyLoader` (never imported at module import time).
+Operators follow the same conventions as built-in ones: inherit from a base class (`Mapper`, `Filter`, `Deduplicator`, etc.) and register with `@OPERATORS.register_module(<op_name>)`. Heavy dependencies should be loaded lazily via `LazyLoader` rather than imported at module level.
 
 ```python
 # my_dj_ops/__init__.py
@@ -70,12 +58,9 @@ class MyUpperMapper(Mapper):
         return samples
 ```
 
-### 3. Declare the entry point
+### 3. Declare the Entry Point
 
-In `pyproject.toml`, expose the module under the `data_juicer.ops` group. The
-entry point **value** must point at a module (or object) whose import triggers
-your `@OPERATORS.register_module` calls — pointing at the package `__init__`
-is the simplest choice.
+In `pyproject.toml`, expose the module under the `data_juicer.ops` group. The entry point value must reference a module (or object) whose import triggers the `@OPERATORS.register_module` calls — pointing to the package `__init__` is the simplest approach.
 
 ```toml
 [project]
@@ -87,29 +72,22 @@ dependencies = ["py-data-juicer"]
 my_dj_ops = "my_dj_ops"
 ```
 
-### 4. Install & use
+### 4. Install and Use
 
 ```bash
 pip install -e .        # or: pip install my-dj-ops
 ```
 
-Then reference the operator by name in any recipe, in both the default and Ray
-executors:
+Then reference the operator by name in any recipe. Both the default and Ray executors are supported:
 
 ```yaml
 process:
   - my_upper_mapper: {}
 ```
 
-## Notes & best practices
+## Notes and Best Practices
 
-- **Operator name uniqueness**: the registered op name (e.g. `my_upper_mapper`)
-  must not collide with a built-in operator or another plugin.
-- **Depend on `py-data-juicer`**: list it in your plugin's `dependencies` so the
-  base classes and registry are available.
-- **Keep heavy deps lazy**: declare heavy ML libraries in your plugin's
-  `dependencies`, but load them at runtime via `LazyLoader`, matching the core
-  operator convention.
-- **GPU / unforkable operators** work as plugins too: set `_accelerator =
-  "cuda"` / `use_cuda()` as usual; the executor handles the multiprocessing
-  context based on these attributes.
+- **Operator name uniqueness**: the registered name (e.g. `my_upper_mapper`) must not collide with a built-in operator or another plugin.
+- **Depend on `py-data-juicer`**: list it in your plugin's `dependencies` so that base classes and the registry are available.
+- **Keep heavy dependencies lazy**: declare heavy ML libraries in your plugin's `dependencies`, but load them at runtime via `LazyLoader`, following the same convention used by core operators.
+- **GPU and unforkable operators**: plugins can use `_accelerator = "cuda"` or `use_cuda()` as usual; the executor selects the appropriate multiprocessing context based on these attributes.

--- a/docs/OperatorPlugins.md
+++ b/docs/OperatorPlugins.md
@@ -1,0 +1,115 @@
+# Operator Plugins
+
+Data-Juicer can discover and load operators that live **outside** the core
+`data_juicer` package. This lets you ship, version and install operators as
+independent Python packages (e.g. on PyPI or a private index) and have them
+show up in the global `OPERATORS` registry exactly like the built-in ones —
+usable in any recipe by name, with no code change to Data-Juicer.
+
+- English | [中文](OperatorPlugins_ZH.md)
+
+## How it works
+
+At `import data_juicer.ops` time, Data-Juicer calls `load_op_plugins()`, which
+scans all installed distributions for entry points under the
+`data_juicer.ops` group and imports the referenced modules. Importing a plugin
+module runs its module-level `@OPERATORS.register_module(...)` decorators, so
+its operators become available before `init_configs()` reads the registry.
+
+Key properties:
+
+- **Zero-config discovery**: once a plugin package is `pip install`ed, its
+  operators are available automatically; no path needs to be configured.
+- **Fault isolation**: if a plugin fails to import (e.g. a missing dependency),
+  it is skipped with a warning and never breaks the rest of the pipeline.
+- **Backward compatible**: when no plugin is installed, behavior is unchanged.
+
+## Plugins vs. `custom_operator_paths`
+
+Data-Juicer offers two ways to use out-of-tree operators; they are
+complementary:
+
+| | Operator plugins (entry points) | `custom_operator_paths` |
+|---|---|---|
+| Distribution | Installable package (PyPI / private index) | Local `.py` file or package directory |
+| Discovery | Automatic on `pip install` | Explicit path in CLI / YAML |
+| Best for | Reusable, versioned, shared operators | Quick local / one-off operators |
+| Config | none | `--custom-operator-paths` or `custom_operator_paths:` in YAML |
+
+## Writing an operator plugin
+
+### 1. Package layout
+
+```
+my-dj-ops/
+├── pyproject.toml
+└── my_dj_ops/
+    └── __init__.py        # defines & registers your operators
+```
+
+### 2. Implement & register operators
+
+Operators are written exactly as built-in ones: inherit from a base class
+(`Mapper`, `Filter`, `Deduplicator`, ...) and register with the
+`@OPERATORS.register_module(<op_name>)` decorator. Heavy dependencies should be
+loaded lazily via `LazyLoader` (never imported at module import time).
+
+```python
+# my_dj_ops/__init__.py
+from data_juicer.ops.base_op import OPERATORS, Mapper
+
+
+@OPERATORS.register_module("my_upper_mapper")
+class MyUpperMapper(Mapper):
+    """Uppercases the text of each sample."""
+
+    _batched_op = True
+
+    def process_batched(self, samples):
+        samples[self.text_key] = [t.upper() for t in samples[self.text_key]]
+        return samples
+```
+
+### 3. Declare the entry point
+
+In `pyproject.toml`, expose the module under the `data_juicer.ops` group. The
+entry point **value** must point at a module (or object) whose import triggers
+your `@OPERATORS.register_module` calls — pointing at the package `__init__`
+is the simplest choice.
+
+```toml
+[project]
+name = "my-dj-ops"
+version = "0.1.0"
+dependencies = ["py-data-juicer"]
+
+[project.entry-points."data_juicer.ops"]
+my_dj_ops = "my_dj_ops"
+```
+
+### 4. Install & use
+
+```bash
+pip install -e .        # or: pip install my-dj-ops
+```
+
+Then reference the operator by name in any recipe, in both the default and Ray
+executors:
+
+```yaml
+process:
+  - my_upper_mapper: {}
+```
+
+## Notes & best practices
+
+- **Operator name uniqueness**: the registered op name (e.g. `my_upper_mapper`)
+  must not collide with a built-in operator or another plugin.
+- **Depend on `py-data-juicer`**: list it in your plugin's `dependencies` so the
+  base classes and registry are available.
+- **Keep heavy deps lazy**: declare heavy ML libraries in your plugin's
+  `dependencies`, but load them at runtime via `LazyLoader`, matching the core
+  operator convention.
+- **GPU / unforkable operators** work as plugins too: set `_accelerator =
+  "cuda"` / `use_cuda()` as usual; the executor handles the multiprocessing
+  context based on these attributes.

--- a/docs/OperatorPlugins_ZH.md
+++ b/docs/OperatorPlugins_ZH.md
@@ -1,31 +1,33 @@
 # 算子插件
 
-Data-Juicer 可以发现并加载位于核心 `data_juicer` 包**之外**的算子。借此你可以把算子作为独立的 Python 包来发布、版本化和安装（例如发到 PyPI 或私有索引），它们会像内置算子一样出现在全局 `OPERATORS` 注册表中——在任意 recipe 中直接按名字引用，无需改动 Data-Juicer 本身。
-
 - [English](OperatorPlugins.md) | 中文
+
+## 概述
+
+Data-Juicer 支持通过 Python 标准的 [entry points](https://packaging.python.org/en/latest/specifications/entry-points/) 机制发现并加载来自外部包的算子。这使得算子可以作为独立的 Python 包进行分发、版本管理和安装（例如发布到 PyPI 或私有索引），同时仍然注册到全局 `OPERATORS` 注册表中，并可在任意 recipe 中通过名称引用。
 
 ## 工作原理
 
-在 `import data_juicer.ops` 时，Data-Juicer 会调用 `load_op_plugins()`，扫描所有已安装发行包中声明在 `data_juicer.ops` 分组下的 entry points，并导入其指向的模块。导入插件模块会执行其模块级的 `@OPERATORS.register_module(...)` 装饰器，因此这些算子在 `init_configs()` 读取注册表之前就已就绪。
+在 `import data_juicer.ops` 时，`load_op_plugins()` 会扫描所有已安装发行包中声明在 `data_juicer.ops` 分组下的 entry points，并导入其指向的模块。导入插件模块会执行其模块级的 `@OPERATORS.register_module(...)` 装饰器，在 `init_configs()` 读取注册表之前完成算子注册。
 
 关键特性：
 
-- **零配置发现**：插件包一经 `pip install`，其算子即自动可用，无需配置任何路径。
-- **故障隔离**：若某个插件导入失败（例如缺少依赖），只会记录 warning 并跳过，绝不影响其余流程。
-- **向后兼容**：未安装任何插件时，行为与原来完全一致。
+- **自动发现**：插件包安装后，其算子即可使用，无需额外配置。
+- **故障隔离**：若某个插件导入失败（例如缺少依赖），仅记录警告并跳过，不影响其余流程的执行。
+- **向后兼容**：未安装任何插件时，行为保持不变。
 
 ## 插件 vs. `custom_operator_paths`
 
-Data-Juicer 提供两种使用库外算子的方式，二者互补：
+Data-Juicer 提供两种互补的方式来使用库外算子：
 
 | | 算子插件（entry points） | `custom_operator_paths` |
 |---|---|---|
 | 分发方式 | 可安装的包（PyPI / 私有索引） | 本地 `.py` 文件或包目录 |
-| 发现方式 | `pip install` 后自动 | 在 CLI / YAML 中显式指定路径 |
-| 适用场景 | 可复用、可版本化、共享的算子 | 快速的本地 / 一次性算子 |
-| 配置 | 无 | `--custom-operator-paths` 或 YAML 中的 `custom_operator_paths:` |
+| 发现方式 | 安装后自动发现 | 在 CLI / YAML 中显式指定路径 |
+| 适用场景 | 可复用、可版本化、需要共享的算子 | 快速的本地或一次性算子 |
+| 配置 | 无需额外配置 | `--custom-operator-paths` 或 YAML 中的 `custom_operator_paths:` |
 
-## 开发一个算子插件
+## 开发算子插件
 
 ### 1. 包结构
 
@@ -33,12 +35,12 @@ Data-Juicer 提供两种使用库外算子的方式，二者互补：
 my-dj-ops/
 ├── pyproject.toml
 └── my_dj_ops/
-    └── __init__.py        # 定义并注册你的算子
+    └── __init__.py        # 定义并注册算子
 ```
 
 ### 2. 实现并注册算子
 
-算子的写法与内置算子完全一致：继承基类（`Mapper`、`Filter`、`Deduplicator` 等），并用 `@OPERATORS.register_module(<op_name>)` 装饰器注册。重型依赖应通过 `LazyLoader` 延迟加载（切勿在模块导入时直接 import）。
+算子的编写方式与内置算子一致：继承基类（`Mapper`、`Filter`、`Deduplicator` 等），并使用 `@OPERATORS.register_module(<op_name>)` 装饰器注册。重型依赖应通过 `LazyLoader` 延迟加载，避免在模块导入时直接引入。
 
 ```python
 # my_dj_ops/__init__.py
@@ -56,9 +58,9 @@ class MyUpperMapper(Mapper):
         return samples
 ```
 
-### 3. 声明 entry point
+### 3. 声明 Entry Point
 
-在 `pyproject.toml` 中，将模块暴露到 `data_juicer.ops` 分组下。entry point 的**取值**必须指向一个模块（或对象），其导入会触发你的 `@OPERATORS.register_module` 调用——指向包的 `__init__` 是最简单的做法。
+在 `pyproject.toml` 中，将模块暴露到 `data_juicer.ops` 分组下。entry point 的取值需指向一个模块（或对象），其导入会触发 `@OPERATORS.register_module` 调用——指向包的 `__init__` 是最简单的做法。
 
 ```toml
 [project]
@@ -76,7 +78,7 @@ my_dj_ops = "my_dj_ops"
 pip install -e .        # 或：pip install my-dj-ops
 ```
 
-然后即可在任意 recipe 中按名字引用该算子，在 default 和 Ray 两种执行器下均可用：
+然后即可在任意 recipe 中按名称引用该算子，default 和 Ray 执行器均支持：
 
 ```yaml
 process:
@@ -85,7 +87,7 @@ process:
 
 ## 注意事项与最佳实践
 
-- **算子名唯一性**：注册的算子名（如 `my_upper_mapper`）不得与内置算子或其他插件冲突。
-- **依赖 `py-data-juicer`**：在插件的 `dependencies` 中声明它，以便获得基类与注册表。
-- **重型依赖保持懒加载**：将重型 ML 库写入插件的 `dependencies`，但在运行时通过 `LazyLoader` 加载，与核心算子的约定保持一致。
-- **GPU / 不可 fork 算子**同样可作为插件：照常设置 `_accelerator = "cuda"` / `use_cuda()`，执行器会据此选择多进程上下文。
+- **算子名称唯一性**：注册的算子名（如 `my_upper_mapper`）不得与内置算子或其他插件冲突。
+- **声明 `py-data-juicer` 依赖**：在插件的 `dependencies` 中列出，以确保基类与注册表可用。
+- **重型依赖保持延迟加载**：将重型 ML 库写入插件的 `dependencies`，但在运行时通过 `LazyLoader` 加载，与核心算子保持相同的约定。
+- **GPU 与不可 fork 算子**：插件中可照常使用 `_accelerator = "cuda"` 或 `use_cuda()`，执行器会根据这些属性选择相应的多进程上下文。

--- a/docs/OperatorPlugins_ZH.md
+++ b/docs/OperatorPlugins_ZH.md
@@ -1,0 +1,91 @@
+# 算子插件
+
+Data-Juicer 可以发现并加载位于核心 `data_juicer` 包**之外**的算子。借此你可以把算子作为独立的 Python 包来发布、版本化和安装（例如发到 PyPI 或私有索引），它们会像内置算子一样出现在全局 `OPERATORS` 注册表中——在任意 recipe 中直接按名字引用，无需改动 Data-Juicer 本身。
+
+- [English](OperatorPlugins.md) | 中文
+
+## 工作原理
+
+在 `import data_juicer.ops` 时，Data-Juicer 会调用 `load_op_plugins()`，扫描所有已安装发行包中声明在 `data_juicer.ops` 分组下的 entry points，并导入其指向的模块。导入插件模块会执行其模块级的 `@OPERATORS.register_module(...)` 装饰器，因此这些算子在 `init_configs()` 读取注册表之前就已就绪。
+
+关键特性：
+
+- **零配置发现**：插件包一经 `pip install`，其算子即自动可用，无需配置任何路径。
+- **故障隔离**：若某个插件导入失败（例如缺少依赖），只会记录 warning 并跳过，绝不影响其余流程。
+- **向后兼容**：未安装任何插件时，行为与原来完全一致。
+
+## 插件 vs. `custom_operator_paths`
+
+Data-Juicer 提供两种使用库外算子的方式，二者互补：
+
+| | 算子插件（entry points） | `custom_operator_paths` |
+|---|---|---|
+| 分发方式 | 可安装的包（PyPI / 私有索引） | 本地 `.py` 文件或包目录 |
+| 发现方式 | `pip install` 后自动 | 在 CLI / YAML 中显式指定路径 |
+| 适用场景 | 可复用、可版本化、共享的算子 | 快速的本地 / 一次性算子 |
+| 配置 | 无 | `--custom-operator-paths` 或 YAML 中的 `custom_operator_paths:` |
+
+## 开发一个算子插件
+
+### 1. 包结构
+
+```
+my-dj-ops/
+├── pyproject.toml
+└── my_dj_ops/
+    └── __init__.py        # 定义并注册你的算子
+```
+
+### 2. 实现并注册算子
+
+算子的写法与内置算子完全一致：继承基类（`Mapper`、`Filter`、`Deduplicator` 等），并用 `@OPERATORS.register_module(<op_name>)` 装饰器注册。重型依赖应通过 `LazyLoader` 延迟加载（切勿在模块导入时直接 import）。
+
+```python
+# my_dj_ops/__init__.py
+from data_juicer.ops.base_op import OPERATORS, Mapper
+
+
+@OPERATORS.register_module("my_upper_mapper")
+class MyUpperMapper(Mapper):
+    """将每个样本的文本转为大写。"""
+
+    _batched_op = True
+
+    def process_batched(self, samples):
+        samples[self.text_key] = [t.upper() for t in samples[self.text_key]]
+        return samples
+```
+
+### 3. 声明 entry point
+
+在 `pyproject.toml` 中，将模块暴露到 `data_juicer.ops` 分组下。entry point 的**取值**必须指向一个模块（或对象），其导入会触发你的 `@OPERATORS.register_module` 调用——指向包的 `__init__` 是最简单的做法。
+
+```toml
+[project]
+name = "my-dj-ops"
+version = "0.1.0"
+dependencies = ["py-data-juicer"]
+
+[project.entry-points."data_juicer.ops"]
+my_dj_ops = "my_dj_ops"
+```
+
+### 4. 安装并使用
+
+```bash
+pip install -e .        # 或：pip install my-dj-ops
+```
+
+然后即可在任意 recipe 中按名字引用该算子，在 default 和 Ray 两种执行器下均可用：
+
+```yaml
+process:
+  - my_upper_mapper: {}
+```
+
+## 注意事项与最佳实践
+
+- **算子名唯一性**：注册的算子名（如 `my_upper_mapper`）不得与内置算子或其他插件冲突。
+- **依赖 `py-data-juicer`**：在插件的 `dependencies` 中声明它，以便获得基类与注册表。
+- **重型依赖保持懒加载**：将重型 ML 库写入插件的 `dependencies`，但在运行时通过 `LazyLoader` 加载，与核心算子的约定保持一致。
+- **GPU / 不可 fork 算子**同样可作为插件：照常设置 `_accelerator = "cuda"` / `use_cuda()`，执行器会据此选择多进程上下文。

--- a/tests/ops/test_load_op_plugins.py
+++ b/tests/ops/test_load_op_plugins.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest import mock
+
+from data_juicer.ops import (
+    OP_PLUGIN_ENTRY_POINT_GROUP,
+    load_op_plugins,
+)
+from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
+
+
+def _make_ep(name, load_side_effect=None):
+    """Build a fake importlib.metadata EntryPoint-like object."""
+    ep = mock.Mock()
+    ep.name = name
+    if load_side_effect is not None:
+        ep.load.side_effect = load_side_effect
+    else:
+        ep.load.return_value = mock.Mock()
+    return ep
+
+
+class LoadOpPluginsTest(DataJuicerTestCaseBase):
+    """Test load_op_plugins: entry-point based external operator discovery."""
+
+    def test_default_group_name(self):
+        # the entry point group external plugin packages must declare
+        self.assertEqual(OP_PLUGIN_ENTRY_POINT_GROUP, "data_juicer.ops")
+
+    def test_discovers_and_loads_plugins(self):
+        eps = [_make_ep("textclean"), _make_ep("llmgen")]
+        with mock.patch("data_juicer.ops.entry_points", return_value=eps):
+            loaded = load_op_plugins(group="data_juicer.ops")
+        # both plugins loaded (ep.load() called -> triggers registration)
+        self.assertEqual(sorted(loaded), ["llmgen", "textclean"])
+        for ep in eps:
+            ep.load.assert_called_once()
+
+    def test_no_plugins_is_noop(self):
+        with mock.patch("data_juicer.ops.entry_points", return_value=[]):
+            loaded = load_op_plugins(group="data_juicer.ops")
+        self.assertEqual(loaded, [])
+
+    def test_broken_plugin_is_skipped_not_crash(self):
+        # a broken plugin (load raises) must not crash the whole pipeline;
+        # good plugins alongside it must still be loaded.
+        good = _make_ep("good_plugin")
+        bad = _make_ep("bad_plugin", load_side_effect=ImportError("boom"))
+        with mock.patch("data_juicer.ops.entry_points", return_value=[bad, good]):
+            loaded = load_op_plugins(group="data_juicer.ops")
+        # bad one skipped, good one still loaded
+        self.assertEqual(loaded, ["good_plugin"])
+        bad.load.assert_called_once()
+        good.load.assert_called_once()
+
+    def test_legacy_entry_points_dict_api(self):
+        # older importlib.metadata returns a dict keyed by group and does not
+        # accept the group= kwarg; load_op_plugins must fall back gracefully.
+        eps = [_make_ep("textclean")]
+
+        def _dict_api(*args, **kwargs):
+            if kwargs.get("group"):
+                raise TypeError("entry_points() got an unexpected keyword")
+            return {"data_juicer.ops": eps}
+
+        with mock.patch("data_juicer.ops.entry_points", side_effect=_dict_api):
+            loaded = load_op_plugins(group="data_juicer.ops")
+        self.assertEqual(loaded, ["textclean"])
+
+    def test_real_call_does_not_crash(self):
+        # regression: calling against the real environment (no external
+        # plugins installed in CI) must return a list and never raise.
+        loaded = load_op_plugins()
+        self.assertIsInstance(loaded, list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This PR introduces a plugin mechanism based on Python entry points, providing a third option: ship operators as independent pip packages — install and use, zero configuration required.

## Changes

- **`data_juicer/ops/__init__.py`**: Add `load_op_plugins()` which, at `import data_juicer.ops` time, automatically scans the `data_juicer.ops` entry point group for installed plugin packages and loads them into the global `OPERATORS` registry.
- **`docs/OperatorPlugins.md`** / **`docs/OperatorPlugins_ZH.md`**: Bilingual documentation covering how it works, comparison with `custom_operator_paths`, and a complete plugin authoring example.
- **`tests/ops/test_load_op_plugins.py`**: Unit tests covering normal discovery, empty plugins, broken-plugin skip, legacy `entry_points()` dict API compatibility, and a real-environment regression test.

## Design

| Concern | Behavior |
|---|---|
| Discovery | Automatic after `pip install`, zero config |
| Fault isolation | A failing plugin emits a warning and is skipped; the rest of the pipeline is unaffected |
| Name conflict | The Registry defaults to `force=False` — a duplicate name raises `KeyError`, which is caught and logged as a warning. Operators already registered by the same plugin before the conflict remain available, but any operators defined after the conflicting one in the same module will not be loaded |
| Plugin overriding built-ins | Plugins can explicitly override a built-in operator via `@OPERATORS.register_module("name", force=True)` |
| Load order | Built-in operators load first, plugins load after — ensuring correct override semantics |
| Backward compatibility | No behavior change when no plugin is installed |

## Usage

A plugin package declares its entry point in `pyproject.toml`:

```toml
[project.entry-points."data_juicer.ops"]
my_dj_ops = "my_dj_ops"
```

Once installed, operators are available in any recipe by name:

```yaml
process:
  - my_upper_mapper: {}
```
