### PR TITLE
fix(deps): remove numpy<2.0 upper bound for Python 3.13+ compatibility

### DIFF
--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -32,7 +32,7 @@ from .cache_utils import DATA_JUICER_MODELS_CACHE as DJMC
 torch = LazyLoader("torch")
 transformers = LazyLoader("transformers")
 nn = LazyLoader("torch.nn")
-fasttext = LazyLoader("fasttext", "fasttext-wheel")
+fasttext = LazyLoader("fasttext", "fasttext-predict")
 sentencepiece = LazyLoader("sentencepiece")
 kenlm = LazyLoader("kenlm")
 nltk = LazyLoader("nltk")

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -601,7 +601,7 @@ sp = LazyLoader('sentencepiece')
 
 class PerplexityFilter(Filter):
     # set the additional requirements for this OP explicitly
-    _requirements = ['kenlm', 'sentencepiece', 'fasttext-wheel']
+    _requirements = ['kenlm', 'sentencepiece', 'fasttext-predict']
 
     def __init__(self,
                 # ... (OP parameters)
@@ -609,7 +609,7 @@ class PerplexityFilter(Filter):
                 **kwargs):
         # auto install before init
         super().__init__(*args, **kwargs)
-        LazyLoader.check_packages(['fasttext-wheel'])
+        LazyLoader.check_packages(['fasttext-predict'])
         # ... (some codes)
 
     def process_single(self, sample):

--- a/docs/DeveloperGuide_ZH.md
+++ b/docs/DeveloperGuide_ZH.md
@@ -578,7 +578,7 @@ nltk = LazyLoader('nltk')
 
 class PerplexityFilter(Filter):
     # 显式为 OP 设置额外的依赖
-    _requirements = ['kenlm', 'sentencepiece', 'fasttext-wheel']
+    _requirements = ['kenlm', 'sentencepiece', 'fasttext-predict']
 
     def __init__(self,
                 # ... (OP parameters)
@@ -586,7 +586,7 @@ class PerplexityFilter(Filter):
                 **kwargs):
         # 在初始化前自动安装所需依赖库
         super().__init__(*args, **kwargs)
-        LazyLoader.check_packages(['fasttext-wheel'])
+        LazyLoader.check_packages(['fasttext-predict'])
         # ... (some codes)
 
     def process_single(self, sample):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.10"
+requires-python = ">=3.10,<4"
 urls = {repository = "https://github.com/datajuicer/data-juicer"}
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
@@ -20,7 +20,7 @@ dependencies = [
     "datasets>=4.7.0", # core data loading
     "fsspec==2023.5.0", # file system operations
     "pandas", # data manipulation
-    "numpy>=1.26.4,<2.0.0", # numerical operations
+    "numpy>=1.26.4", # numerical operations
     "loguru", # logging
     "tqdm", # progress bars
     "jsonargparse[signatures]", # configuration
@@ -68,7 +68,7 @@ vision = [
     "imagededup",  # Image deduplication
     "diffusers>=0.33.0",  # Diffusion models
     "simple-aesthetics-predictor",  # Image aesthetics
-    "scenedetect[opencv]",  # Scene detection
+    "scenedetect",  # Scene detection
     "ultralytics",  # YOLO models
     "rembg",  # Background removal
     "decord; (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'win32' and platform_machine == 'AMD64')", # video/audio handling (no aarch64/macOS py3.10+ wheel)
@@ -160,7 +160,7 @@ dev = [
 ai_services = [
     "dashscope",  # Alibaba Cloud AI
     "openai",  # OpenAI API
-    "label-studio==1.17.0",  # Data labeling
+    "label-studio>=1.23.0",  # Data labeling
 ]
 
 # tools, including analysis, mcp, ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ vision = [
 nlp = [
     "nltk==3.9.1",  # NLP toolkit
     "easyocr==1.7.1",  # OCR
-    "fasttext-wheel",  # FastText
+    "fasttext-predict",  # FastText (no numpy dependency, numpy 2.x safe)
     "kenlm",  # Language modeling
     "sentencepiece",  # Tokenization
     "ftfy",  # Text fixing

--- a/tests/utils/test_lazy_loader.py
+++ b/tests/utils/test_lazy_loader.py
@@ -189,7 +189,7 @@ nlp = [
     "transformers>=4.30.0",
     "sentencepiece",
     "kenlm",
-    "fasttext-wheel"
+    "fasttext-predict"
 ]
 audio = [
     "librosa>=0.10",

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -360,13 +360,13 @@ class ModelUtilsTest(DataJuicerTestCaseBase):
             
             labels, scores = predictions
             self.assertIsInstance(labels, tuple, "Labels should be a tuple")
-            self.assertIsInstance(scores, np.ndarray, "Scores should be a numpy array")
+            self.assertIsInstance(scores, (tuple, list), "Scores should be a sequence")
             self.assertEqual(len(labels), len(scores), "Number of labels should match number of scores")
             
             # Check first prediction
             self.assertTrue(labels[0].startswith('__label__'), 
                           "Label should start with __label__")
-            self.assertIsInstance(scores[0], (float, np.floating), "Score should be a float")
+            self.assertIsInstance(scores[0], float, "Score should be a float")
 
     def test_prepare_fasttext_model_invalid(self):
         """Test FastText model with invalid model file."""


### PR DESCRIPTION
The `numpy>=1.26.4,<2.0.0` constraint causes an unsatisfiable dependency resolution on Python ≥3.13, where `tf-keras==2.21.0` transitively requires `numpy>=2.1.0` via `ml-dtypes`.

Changes:
- Remove `numpy<2.0.0` upper bound — all current dependencies support numpy 2.x
- Upgrade `label-studio` from `==1.17.0` to `>=1.23.0` (1.17.0 internally pins `numpy<2.0.0`; SDK 2.x maintains full backward compatibility via `_legacy` module)
- Remove obsolete `[opencv]` extra from `scenedetect` (included by default since 0.7.x)
- Add `requires-python = ">=3.10,<4"` to prevent resolver from attempting impossible Python 4.x splits

Verified:
- `uv pip compile --extra all --universal` resolves successfully (numpy 2.2.6)
- `label_studio_sdk 2.0.18` retains all APIs used by this project (`Client`, `get_project`, `create_project`, `import_tasks`, `get_tasks`, `get_task`)