### PR TITLE
fix(ray): preserve elastic actor pool concurrency

### DIFF
--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from functools import partial
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import pyarrow
 import ray
@@ -18,6 +18,16 @@ from data_juicer.ops.base_op import DEFAULT_BATCH_SIZE, TAGGING_OPS
 from data_juicer.utils.constant import Fields
 from data_juicer.utils.file_utils import is_remote_path
 from data_juicer.utils.webdataset_utils import _custom_default_decoder
+
+
+def _build_actor_pool_strategy(num_proc: Union[int, Tuple[int, int], List[int]]) -> ActorPoolStrategy:
+    """Build a Ray ActorPool strategy for fixed or elastic concurrency."""
+    if isinstance(num_proc, (tuple, list)):
+        if len(num_proc) != 2:
+            raise ValueError(f"Invalid ActorPool concurrency range: {num_proc}")
+        min_size, max_size = num_proc
+        return ActorPoolStrategy(min_size=min_size, max_size=max_size)
+    return ActorPoolStrategy(size=num_proc)
 
 
 def get_abs_path(path, dataset_dir):
@@ -241,7 +251,7 @@ class RayDataset(DJDataset):
 
                 try:
                     if op.use_ray_actor():
-                        compute = ActorPoolStrategy(size=op.num_proc)
+                        compute = _build_actor_pool_strategy(op.num_proc)
                         self.data = self.data.map_batches(
                             op.__class__,
                             fn_args=None,
@@ -291,7 +301,7 @@ class RayDataset(DJDataset):
                         f"to preserve shared dedup state across workers"
                     )
                 if op.use_ray_actor() and not use_instance_for_ray_tasks:
-                    compute = ActorPoolStrategy(size=op.num_proc)
+                    compute = _build_actor_pool_strategy(op.num_proc)
                     self.data = self.data.map_batches(
                         op.__class__,
                         fn_args=None,

--- a/tests/core/data/test_ray_dataset.py
+++ b/tests/core/data/test_ray_dataset.py
@@ -464,6 +464,13 @@ class RayComputeStrategyTest(DataJuicerTestCaseBase):
                 self.assertEqual(compute.min_size, 2)
                 self.assertEqual(compute.max_size, 2)
 
+            with self.subTest(op=op_class.__name__, mode="actor", concurrency="elastic"):
+                op = op_class(auto_op_parallelism=False, num_proc=(1, 3), ray_execution_mode="actor")
+                compute = self._get_compute_strategy(op)
+                self.assertIsInstance(compute, ActorPoolStrategy)
+                self.assertEqual(compute.min_size, 1)
+                self.assertEqual(compute.max_size, 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add a shared `_build_actor_pool_strategy()` helper for Ray Actor operators.
- Preserve elastic concurrency ranges by converting `(min_proc, max_proc)` to:
  `ActorPoolStrategy(min_size=min_proc, max_size=max_proc)`.
- Keep fixed integer concurrency unchanged with `ActorPoolStrategy(size=num_proc)`.
- Apply the conversion in both RayDataset Actor paths:
  - Mapper execution
  - Filter statistics execution
- Add regression coverage for elastic ActorPool concurrency.

## Root Cause

`calculate_ray_np()` may assign Ray Actor operators an elastic concurrency range such as `(1, 30)`. Previously, `RayDataset` passed this tuple directly to:

```python
ActorPoolStrategy(size=op.num_proc)
```

Ray expects `size` to be an integer, so this caused:

```text
TypeError: '<' not supported between instances of 'tuple' and 'int'
```

before any Actor, model, or GPU workload was started.

## Fix

The new helper preserves the planner’s intended semantics:

```python
# Fixed concurrency
ActorPoolStrategy(size=4)

# Elastic concurrency
ActorPoolStrategy(min_size=1, max_size=30)
```

This prevents the tuple type error without collapsing elastic ActorPool concurrency into a fixed maximum-sized pool.

## Validation

Passed:

- `tests/core/data/test_ray_dataset.py`: 17 passed
- `tests/core/executor/test_ray_executor.py`: 6 passed
- `tests/core/executor/test_ray_executor_partitioned.py`: 24 passed
- `tests/core/executor/test_ray_executor_partitioned_parallel.py`: 29 passed
- `tests/core/executor/test_partitioned_integration.py`: 13 passed, 1 skipped

`test_ray_exporter.py` has a pre-existing failure in `test_lance_keep_hashes`: it also reproduces on the unmodified base commit (`753debf`) and is caused by the current Lance 7.0.0 / Ray Data exporter compatibility issue.