### PR TITLE
[Bugfix]: Preserve partition checkpoints across Ray block-layout changes

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -522,6 +522,16 @@ def build_base_parser() -> ArgumentParser:
         help="Custom job ID for resumption and tracking. If not provided, a unique ID will be auto-generated.",
     )
     parser.add_argument(
+        "--resume",
+        type=str,
+        default=None,
+        help=(
+            "Resume a ray_partitioned job using the job ID printed by its "
+            "original run. The saved partition boundaries and content hashes "
+            "are used to reconstruct and validate the original partitions."
+        ),
+    )
+    parser.add_argument(
         "--temp_dir",
         type=str,
         default=None,
@@ -1460,7 +1470,15 @@ def validate_config_for_resumption(cfg: Namespace, work_dir: str, original_args:
         # Compare CLI arguments per key
         cli_differences = []
         all_cli_keys = set(cli_config.keys()) | set(current_cli_config.keys())
-        excluded_keys = {"config", "_original_args", "backed_up_config_path", "_same_yaml_config", "job_id", "work_dir"}
+        excluded_keys = {
+            "config",
+            "_original_args",
+            "backed_up_config_path",
+            "_same_yaml_config",
+            "job_id",
+            "resume",
+            "work_dir",
+        }
 
         for key in all_cli_keys:
             if key in excluded_keys:
@@ -1876,6 +1894,19 @@ def prepare_cfgs_for_export(cfg):
 def resolve_job_id(cfg):
     """Resolve or auto-generate job_id and set it on cfg."""
     job_id = getattr(cfg, "job_id", None)
+    resume_id = getattr(cfg, "resume", None)
+
+    if resume_id is not None:
+        if job_id is not None and job_id != resume_id:
+            raise ValueError("--resume and --job_id must refer to the same job when both are provided.")
+        if getattr(cfg, "executor_type", "ray_partitioned") != "ray_partitioned":
+            raise ValueError("--resume is only supported by the ray_partitioned executor.")
+        setattr(cfg, "job_id", resume_id)
+        setattr(cfg, "_user_provided_job_id", True)
+        setattr(cfg, "_resume_requested", True)
+        return cfg
+
+    setattr(cfg, "_resume_requested", False)
 
     # Track whether job_id was user-provided
     if job_id is not None:

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -40,8 +40,9 @@ from data_juicer.utils.lazy_loader import LazyLoader
 ray = LazyLoader("ray")
 
 _AUTO_CPU_PARTITION_CAP = 4
-_PARTITION_CONTENT_HASH_ALGORITHM = "sha256-multiset-v1"
+_PARTITION_CONTENT_HASH_ALGORITHM = "sha256-sequence-v1"
 _PARTITION_CONTENT_HASH_MODULUS = 1 << 256
+_PARTITION_CONTENT_HASH_BASE = int.from_bytes(hashlib.sha256(b"data-juicer-partition-sequence-v1").digest(), "big") | 1
 
 
 def _canonical_row_bytes(row: Dict) -> bytes:
@@ -54,37 +55,36 @@ def _canonical_row_bytes(row: Dict) -> bytes:
 
 
 def _hash_partition_batch(batch):
-    """Return an order-independent hash accumulator for one Arrow batch."""
+    """Return an order-sensitive rolling hash for one Arrow batch."""
     import pyarrow
 
-    digest_sum = 0
-    digest_xor = 0
+    sequence_hash = 0
     rows = batch.to_pylist()
     for row in rows:
         digest = int.from_bytes(hashlib.sha256(_canonical_row_bytes(row)).digest(), "big")
-        digest_sum = (digest_sum + digest) % _PARTITION_CONTENT_HASH_MODULUS
-        digest_xor ^= digest
+        sequence_hash = (sequence_hash * _PARTITION_CONTENT_HASH_BASE + digest) % _PARTITION_CONTENT_HASH_MODULUS
 
     return pyarrow.table(
         {
             "row_count": [len(rows)],
-            "digest_sum": [f"{digest_sum:064x}"],
-            "digest_xor": [f"{digest_xor:064x}"],
+            "sequence_hash": [f"{sequence_hash:064x}"],
         }
     )
 
 
 def _combine_partition_hash_partials(partials: List[Dict]) -> tuple:
-    """Combine batch accumulators into a stable partition content hash."""
+    """Combine ordered batch hashes without depending on batch boundaries."""
     row_count = 0
-    digest_sum = 0
-    digest_xor = 0
+    sequence_hash = 0
     for partial in partials:
-        row_count += int(partial["row_count"])
-        digest_sum = (digest_sum + int(partial["digest_sum"], 16)) % _PARTITION_CONTENT_HASH_MODULUS
-        digest_xor ^= int(partial["digest_xor"], 16)
+        partial_count = int(partial["row_count"])
+        sequence_hash = (
+            sequence_hash * pow(_PARTITION_CONTENT_HASH_BASE, partial_count, _PARTITION_CONTENT_HASH_MODULUS)
+            + int(partial["sequence_hash"], 16)
+        ) % _PARTITION_CONTENT_HASH_MODULUS
+        row_count += partial_count
 
-    payload = f"{_PARTITION_CONTENT_HASH_ALGORITHM}:" f"{row_count}:{digest_sum:064x}:{digest_xor:064x}"
+    payload = f"{_PARTITION_CONTENT_HASH_ALGORITHM}:{row_count}:{sequence_hash:064x}"
     return hashlib.sha256(payload.encode("ascii")).hexdigest(), row_count
 
 
@@ -1277,9 +1277,10 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
     ) -> PartitionMetadata:
         """Collect metadata from a partition for validation on resume.
 
-        The complete content hash is independent of Ray block boundaries and
-        row order within the partition. It is used for strict explicit resume
-        validation; the first-row hash remains for backward compatibility.
+        The complete content hash is independent of Ray block boundaries but
+        sensitive to row order within the partition. It is used for strict
+        explicit resume validation; the first-row hash remains for backward
+        compatibility.
         """
         if compute_content_hash:
             content_hash, row_count = self._compute_partition_content_hash(partition)
@@ -1308,7 +1309,9 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         )
 
     def _compute_partition_content_hash(self, partition) -> tuple:
-        """Compute a block-boundary-independent hash of a partition."""
+        """Compute an order-sensitive, block-boundary-independent hash."""
+        # preserve_order is enabled before the source Dataset is created, so
+        # take_all() returns these one-row partials in partition row order.
         partials = partition.map_batches(_hash_partition_batch, batch_format="pyarrow").take_all()
         return _combine_partition_hash_partials(partials)
 
@@ -1397,9 +1400,6 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
                 f"expected={saved_info.num_partitions}, actual={len(saved_info.partitions)}"
             )
 
-        if saved_info.num_partitions == 1:
-            return [dataset.data.materialize()]
-
         split_indices = []
         expected_start = 0
         for partition_id, meta in enumerate(saved_info.partitions):
@@ -1420,6 +1420,9 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
                 "Saved row boundaries do not cover the saved total row count: "
                 f"boundaries_end={expected_start}, total_rows={saved_info.total_rows}"
             )
+
+        if saved_info.num_partitions == 1:
+            return [dataset.data.materialize()]
 
         logger.info(f"Recreating partitions at saved row boundaries: {split_indices}")
         return dataset.data.split_at_indices(split_indices)

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -40,6 +40,52 @@ from data_juicer.utils.lazy_loader import LazyLoader
 ray = LazyLoader("ray")
 
 _AUTO_CPU_PARTITION_CAP = 4
+_PARTITION_CONTENT_HASH_ALGORITHM = "sha256-multiset-v1"
+_PARTITION_CONTENT_HASH_MODULUS = 1 << 256
+
+
+def _canonical_row_bytes(row: Dict) -> bytes:
+    """Serialize one row consistently for partition content hashing."""
+    try:
+        serialized = json.dumps(row, sort_keys=True, default=str, separators=(",", ":"), ensure_ascii=False)
+    except Exception:
+        serialized = str(row)
+    return serialized.encode("utf-8")
+
+
+def _hash_partition_batch(batch):
+    """Return an order-independent hash accumulator for one Arrow batch."""
+    import pyarrow
+
+    digest_sum = 0
+    digest_xor = 0
+    rows = batch.to_pylist()
+    for row in rows:
+        digest = int.from_bytes(hashlib.sha256(_canonical_row_bytes(row)).digest(), "big")
+        digest_sum = (digest_sum + digest) % _PARTITION_CONTENT_HASH_MODULUS
+        digest_xor ^= digest
+
+    return pyarrow.table(
+        {
+            "row_count": [len(rows)],
+            "digest_sum": [f"{digest_sum:064x}"],
+            "digest_xor": [f"{digest_xor:064x}"],
+        }
+    )
+
+
+def _combine_partition_hash_partials(partials: List[Dict]) -> tuple:
+    """Combine batch accumulators into a stable partition content hash."""
+    row_count = 0
+    digest_sum = 0
+    digest_xor = 0
+    for partial in partials:
+        row_count += int(partial["row_count"])
+        digest_sum = (digest_sum + int(partial["digest_sum"], 16)) % _PARTITION_CONTENT_HASH_MODULUS
+        digest_xor ^= int(partial["digest_xor"], 16)
+
+    payload = f"{_PARTITION_CONTENT_HASH_ALGORITHM}:" f"{row_count}:{digest_sum:064x}:{digest_xor:064x}"
+    return hashlib.sha256(payload.encode("ascii")).hexdigest(), row_count
 
 
 class TempDirManager:
@@ -91,6 +137,9 @@ class PartitionMetadata:
     row_count: int
     first_row_hash: str  # Hash of first row for validation
     last_row_hash: str  # Hash of last row for validation
+    content_hash: str = ""  # Stable hash of the complete partition contents
+    start_row: Optional[int] = None  # Inclusive row offset in the ordered input
+    end_row: Optional[int] = None  # Exclusive row offset in the ordered input
 
     def to_dict(self) -> Dict:
         return asdict(self)
@@ -112,12 +161,14 @@ class PartitioningInfo:
     total_rows: int
     partitions: List[PartitionMetadata] = field(default_factory=list)
     deterministic: bool = True  # Whether deterministic splitting was used
+    hash_algorithm: str = _PARTITION_CONTENT_HASH_ALGORITHM
 
     def to_dict(self) -> Dict:
         return {
             "num_partitions": self.num_partitions,
             "total_rows": self.total_rows,
             "deterministic": self.deterministic,
+            "hash_algorithm": self.hash_algorithm,
             "partitions": [p.to_dict() for p in self.partitions],
         }
 
@@ -128,6 +179,7 @@ class PartitioningInfo:
             num_partitions=data["num_partitions"],
             total_rows=data["total_rows"],
             deterministic=data.get("deterministic", True),
+            hash_algorithm=data.get("hash_algorithm", _PARTITION_CONTENT_HASH_ALGORITHM),
             partitions=partitions,
         )
 
@@ -400,6 +452,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
         # Check if user provided a job_id (indicating resumption attempt)
         user_provided_job_id = getattr(self.cfg, "_user_provided_job_id", False)
+        resume_requested = getattr(self.cfg, "_resume_requested", False)
 
         if user_provided_job_id and self.job_id:
             logger.info(f"🔄 User provided job_id: {self.job_id} - attempting to resume job")
@@ -411,6 +464,10 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
                 logger.info("✅ Job resumption successful - will use existing checkpoints")
                 is_resuming = True
             else:  # resume_result == "failed"
+                if resume_requested:
+                    raise RuntimeError(
+                        f"Unable to resume job {self.job_id}. " "The existing checkpoints were left unchanged."
+                    )
                 logger.info("❌ Job resumption failed - starting fresh")
                 is_resuming = False
         else:
@@ -419,6 +476,11 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
             else:
                 logger.info("🚀 Starting new job")
             is_resuming = False
+            if self.job_id and self.ckpt_manager.checkpoint_enabled:
+                logger.info(
+                    f"Resume token: {self.job_id}. "
+                    f"Rerun the original command with --resume {self.job_id} to resume this job."
+                )
 
         if not is_resuming:
             logger.info("🚀 Starting simplified partitioned processing...")
@@ -439,6 +501,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
                 "is_resuming": is_resuming,
                 "job_id": self.job_id,
                 "user_provided_job_id": user_provided_job_id,
+                "resume_requested": resume_requested,
             },
         )
 
@@ -447,6 +510,10 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         # Load the full dataset using a single DatasetBuilder
         logger.info("Loading dataset with single DatasetBuilder...")
 
+        # Ray Dataset captures a copy of DataContext when it is created. This
+        # must therefore happen before DatasetBuilder.load_dataset() so saved
+        # row boundaries have the same meaning when a job is resumed.
+        self._enable_deterministic_execution()
         override_num_blocks = getattr(self.cfg, "override_num_blocks", None)
         dataset = self.datasetbuilder.load_dataset(num_proc=load_data_np, override_num_blocks=override_num_blocks)
         columns = dataset.schema().columns
@@ -455,9 +522,21 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         logger.info("Preparing operations...")
         ops = self._prepare_operators()
 
+        # A resumed job must reuse the saved partition count before DAG
+        # initialization. Auto mode can otherwise choose a different count if
+        # the Ray cluster resources changed between runs.
+        if resume_requested:
+            saved_info = self._load_partitioning_info()
+            if saved_info is None:
+                raise RuntimeError(
+                    "Explicit resume requires saved partitioning_info.json; "
+                    "existing checkpoints were left unchanged."
+                )
+            self.num_partitions = saved_info.num_partitions
+            logger.info(f"Using saved partition count for resume: {self.num_partitions}")
         # Handle auto partition mode BEFORE initializing DAG
         # (DAG needs final partition count)
-        if self.partition_mode == "auto":
+        elif self.partition_mode == "auto":
             self._configure_auto_partitioning(dataset, ops)
 
         # Record explicit actor-pool budgets and calculate automatic Ray
@@ -1166,8 +1245,8 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
     def _enable_deterministic_execution(self) -> None:
         """Enable deterministic execution order in Ray Data.
 
-        This ensures that split() produces the same partitions on re-runs,
-        which is critical for checkpoint resumption.
+        This keeps the global row order stable so saved row boundaries can be
+        reapplied with split_at_indices() during explicit resume.
         """
         try:
             ctx = ray.data.DataContext.get_current()
@@ -1189,14 +1268,24 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
             # Fallback for non-serializable rows
             return hashlib.md5(str(row).encode()).hexdigest()[:16]
 
-    def _collect_partition_metadata(self, partition, partition_id: int) -> PartitionMetadata:
+    def _collect_partition_metadata(
+        self,
+        partition,
+        partition_id: int,
+        start_row: Optional[int] = None,
+        compute_content_hash: bool = True,
+    ) -> PartitionMetadata:
         """Collect metadata from a partition for validation on resume.
 
-        Only collects first_row_hash (not last_row_hash) for efficiency.
-        Getting the last row requires take(all_rows) which is expensive.
-        First row hash + row count is sufficient for detecting most mismatches.
+        The complete content hash is independent of Ray block boundaries and
+        row order within the partition. It is used for strict explicit resume
+        validation; the first-row hash remains for backward compatibility.
         """
-        row_count = partition.count()
+        if compute_content_hash:
+            content_hash, row_count = self._compute_partition_content_hash(partition)
+        else:
+            content_hash = ""
+            row_count = partition.count()
 
         # Get first row for hashing (cheap operation)
         first_row_hash = ""
@@ -1213,7 +1302,15 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
             row_count=row_count,
             first_row_hash=first_row_hash,
             last_row_hash="",  # Skip last_row_hash for efficiency
+            content_hash=content_hash,
+            start_row=start_row,
+            end_row=start_row + row_count if start_row is not None else None,
         )
+
+    def _compute_partition_content_hash(self, partition) -> tuple:
+        """Compute a block-boundary-independent hash of a partition."""
+        partials = partition.map_batches(_hash_partition_batch, batch_format="pyarrow").take_all()
+        return _combine_partition_hash_partials(partials)
 
     def _get_partitioning_info_path(self) -> str:
         """Get the path to the partitioning info file."""
@@ -1237,23 +1334,35 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         Validation checks:
         1. Partition count matches
         2. Row count per partition matches
-        3. First row hash matches (efficient validation)
+        3. Complete partition content hash matches when available
+        4. First row hash matches for backward compatibility
         """
         if len(partitions) != saved_info.num_partitions:
             logger.error(f"Partition count mismatch: current={len(partitions)}, " f"saved={saved_info.num_partitions}")
             return False
 
         for i, partition in enumerate(partitions):
-            current_count = partition.count()
             saved_meta = saved_info.partitions[i] if i < len(saved_info.partitions) else None
 
             if saved_meta is None:
-                logger.warning(f"No saved metadata for partition {i}")
-                continue
+                logger.error(f"No saved metadata for partition {i}")
+                return False
+
+            if saved_meta.content_hash:
+                current_hash, current_count = self._compute_partition_content_hash(partition)
+            else:
+                current_hash = ""
+                current_count = partition.count()
 
             if current_count != saved_meta.row_count:
                 logger.error(
                     f"Partition {i} row count mismatch: current={current_count}, " f"saved={saved_meta.row_count}"
+                )
+                return False
+
+            if saved_meta.content_hash and current_hash != saved_meta.content_hash:
+                logger.error(
+                    f"Partition {i} content hash mismatch: " f"current={current_hash}, saved={saved_meta.content_hash}"
                 )
                 return False
 
@@ -1275,6 +1384,46 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         logger.info("Partition validation passed - safe to use checkpoints")
         return True
 
+    def _split_at_saved_boundaries(self, dataset: RayDataset, saved_info: PartitioningInfo) -> List:
+        """Recreate partitions using row boundaries saved by the first run."""
+        if saved_info.num_partitions != self.num_partitions:
+            raise RuntimeError(
+                "Cannot resume with a different partition count: "
+                f"current={self.num_partitions}, saved={saved_info.num_partitions}"
+            )
+        if len(saved_info.partitions) != saved_info.num_partitions:
+            raise RuntimeError(
+                "Saved partition metadata is incomplete: "
+                f"expected={saved_info.num_partitions}, actual={len(saved_info.partitions)}"
+            )
+
+        if saved_info.num_partitions == 1:
+            return [dataset.data.materialize()]
+
+        split_indices = []
+        expected_start = 0
+        for partition_id, meta in enumerate(saved_info.partitions):
+            start_row = meta.start_row if meta.start_row is not None else expected_start
+            end_row = meta.end_row if meta.end_row is not None else start_row + meta.row_count
+            if start_row != expected_start or end_row - start_row != meta.row_count:
+                raise RuntimeError(
+                    f"Saved row boundaries are invalid for partition {partition_id}: "
+                    f"start={start_row}, end={end_row}, rows={meta.row_count}, "
+                    f"expected_start={expected_start}"
+                )
+            expected_start = end_row
+            if partition_id < saved_info.num_partitions - 1:
+                split_indices.append(end_row)
+
+        if expected_start != saved_info.total_rows:
+            raise RuntimeError(
+                "Saved row boundaries do not cover the saved total row count: "
+                f"boundaries_end={expected_start}, total_rows={saved_info.total_rows}"
+            )
+
+        logger.info(f"Recreating partitions at saved row boundaries: {split_indices}")
+        return dataset.data.split_at_indices(split_indices)
+
     def _split_dataset_deterministic(self, dataset: RayDataset) -> tuple:
         """Split dataset deterministically and collect metadata.
 
@@ -1286,6 +1435,40 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
         # Check for existing partitioning info (resumption case)
         saved_info = self._load_partitioning_info()
+        resume_requested = getattr(self.cfg, "_resume_requested", False)
+
+        if resume_requested:
+            if saved_info is None:
+                raise RuntimeError(
+                    "Explicit resume requires saved partitioning_info.json; "
+                    "existing checkpoints were left unchanged."
+                )
+            if saved_info.hash_algorithm != _PARTITION_CONTENT_HASH_ALGORITHM:
+                raise RuntimeError(
+                    "Explicit resume cannot validate the saved partition hash algorithm: "
+                    f"saved={saved_info.hash_algorithm}, "
+                    f"supported={_PARTITION_CONTENT_HASH_ALGORITHM}. "
+                    "Existing checkpoints were left unchanged."
+                )
+            if any(
+                not meta.content_hash or meta.start_row is None or meta.end_row is None
+                for meta in saved_info.partitions
+            ):
+                raise RuntimeError(
+                    "Explicit resume requires content hashes and row boundaries "
+                    "created by this version. Existing checkpoints were left unchanged."
+                )
+
+            logger.info("Explicit resume requested; recreating saved partition row boundaries...")
+            partitions = self._split_at_saved_boundaries(dataset, saved_info)
+            logger.info(f"Recreated {len(partitions)} partitions from saved boundaries")
+            if not self._validate_partitions(partitions, saved_info):
+                raise RuntimeError(
+                    "Saved partition content hashes do not match the current input. "
+                    "Refusing to resume; existing checkpoints were left unchanged."
+                )
+            logger.info("Saved partition hashes validated successfully - resuming checkpoints")
+            return partitions, saved_info
 
         # Split the dataset
         logger.info(f"Splitting dataset into {self.num_partitions} partitions (deterministic mode)...")
@@ -1309,13 +1492,22 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
         # Collect metadata for new partitions
         logger.info("Collecting partition metadata for checkpoint validation...")
-        total_rows = sum(p.count() for p in partitions)
         partition_metadata = []
+        next_start_row = 0
+        compute_content_hash = self.ckpt_manager.checkpoint_enabled
 
         for i, partition in enumerate(partitions):
-            meta = self._collect_partition_metadata(partition, i)
+            meta = self._collect_partition_metadata(
+                partition,
+                i,
+                start_row=next_start_row,
+                compute_content_hash=compute_content_hash,
+            )
             partition_metadata.append(meta)
+            next_start_row = meta.end_row
             logger.debug(f"Partition {i}: {meta.row_count} rows, hash={meta.first_row_hash[:8]}...")
+
+        total_rows = sum(meta.row_count for meta in partition_metadata)
 
         partitioning_info = PartitioningInfo(
             num_partitions=self.num_partitions,

--- a/docs/PartitionAndCheckpoint.md
+++ b/docs/PartitionAndCheckpoint.md
@@ -83,8 +83,8 @@ records:
 
 These values allow an explicit resume to recreate the original logical
 partitions even when Ray produces a different physical block layout in the new
-process. Complete partition hashes are independent of Ray batch boundaries and
-are validated before any checkpoint is reused.
+process. Complete partition hashes are sensitive to row order, independent of
+Ray batch boundaries, and validated before any checkpoint is reused.
 
 ### Intermediate Storage
 

--- a/docs/PartitionAndCheckpoint.md
+++ b/docs/PartitionAndCheckpoint.md
@@ -20,6 +20,8 @@ The `ray_partitioned` executor splits datasets into partitions and processes the
 ├── events_{timestamp}.jsonl      # Machine-readable event log
 ├── dag_execution_plan.json       # DAG execution plan
 ├── checkpoints/                  # Checkpoint data
+│   ├── partitioning_info.json    # Saved row boundaries and partition hashes
+│   └── checkpoint_op_*.parquet/  # Per-operation partition checkpoints
 ├── partitions/                   # Input partitions
 ├── logs/                         # Human-readable logs
 └── metadata/                     # Job metadata
@@ -70,6 +72,20 @@ checkpoint:
     - embedding_mapper
 ```
 
+When checkpointing is enabled, the initial run saves
+`checkpoints/partitioning_info.json`. For every logical partition, this file
+records:
+
+- `start_row` (inclusive) and `end_row` (exclusive) in the ordered input;
+- the partition row count;
+- a stable hash of the complete partition contents;
+- the partition hash algorithm used by the writer.
+
+These values allow an explicit resume to recreate the original logical
+partitions even when Ray produces a different physical block layout in the new
+process. Complete partition hashes are independent of Ray batch boundaries and
+are validated before any checkpoint is reused.
+
 ### Intermediate Storage
 
 ```yaml
@@ -91,14 +107,56 @@ dj-process --config config.yaml --partition.mode auto
 # Manual partition mode
 dj-process --config config.yaml --partition.mode manual --partition.num_of_partitions 4
 
-# With custom job ID
+# Optional: start a new job with a custom job ID
 dj-process --config config.yaml --job_id my_experiment_001
+```
+
+When checkpointing is enabled, a new `ray_partitioned` job prints a resume
+token:
+
+```text
+Resume token: 20260805_115141_81270d. Rerun the original command with
+--resume 20260805_115141_81270d to resume this job.
 ```
 
 ### Resuming Jobs
 
 ```bash
-dj-process --config config.yaml --job_id my_experiment_001
+# Use the token printed by the initial run. Keep the input and recipe unchanged.
+dj-process --config config.yaml --resume 20260805_115141_81270d
+
+# A custom ID from the initial run can be used in the same way.
+dj-process --config config.yaml --resume my_experiment_001
+```
+
+`--resume` is supported only by the `ray_partitioned` executor. It performs a
+strict resume in the following order:
+
+1. locate the original work and checkpoint directories;
+2. verify that the current configuration matches the original run;
+3. load the saved partition count, row boundaries, and content hashes;
+4. recreate the original partitions with the saved row boundaries;
+5. validate every complete partition hash;
+6. load completed checkpoints and process only the unfinished work.
+
+If metadata is missing, row boundaries are invalid, the input has changed, or
+a content hash does not match, explicit resume stops with an error and leaves
+the existing checkpoints unchanged.
+
+`--job_id` remains available for custom job naming and backward compatibility.
+For fault-tolerant continuation, prefer `--resume`: the legacy `--job_id`
+resumption path keeps its previous behavior and may clear mismatched
+checkpoints before starting fresh. Metadata created by an older Data-Juicer
+version can still be read, but it does not contain the row boundaries and full
+content hashes required by explicit resume; `--resume` therefore rejects it
+without deleting its checkpoints.
+
+If both arguments are supplied, their values must be identical:
+
+```bash
+dj-process --config config.yaml \
+  --job_id my_experiment_001 \
+  --resume my_experiment_001
 ```
 
 ### Checkpoint Strategies
@@ -273,7 +331,13 @@ disabled         | 0s        | Re-run everything
 ```bash
 ls -la ./outputs/{work_dir}/{job_id}/job_summary.json
 ls -la ./outputs/{work_dir}/{job_id}/checkpoints/
+cat ./outputs/{work_dir}/{job_id}/checkpoints/partitioning_info.json
 ```
+
+Use the resume token printed by the original run and rerun the same recipe with
+`--resume`. Check the error log for configuration mismatch, missing partition
+metadata, invalid row boundaries, or partition content hash mismatch. Explicit
+resume does not delete checkpoints when validation fails.
 
 **Check Ray status:**
 ```bash

--- a/docs/PartitionAndCheckpoint_ZH.md
+++ b/docs/PartitionAndCheckpoint_ZH.md
@@ -20,6 +20,8 @@
 ├── events_{timestamp}.jsonl      # 机器可读事件日志
 ├── dag_execution_plan.json       # DAG 执行计划
 ├── checkpoints/                  # 检查点数据
+│   ├── partitioning_info.json    # 保存的行号边界和分区内容 hash
+│   └── checkpoint_op_*.parquet/  # 各操作、各分区的检查点
 ├── partitions/                   # 输入分区
 ├── logs/                         # 人类可读日志
 └── metadata/                     # 作业元数据
@@ -65,6 +67,16 @@ checkpoint:
     - embedding_mapper
 ```
 
+启用检查点后，首次运行会保存
+`checkpoints/partitioning_info.json`。该文件为每个逻辑分区记录：
+
+- 输入数据中的 `start_row`（包含）和 `end_row`（不包含）；
+- 分区样本行数；
+- 覆盖完整分区内容的稳定 hash；
+- 写入 metadata 时使用的分区 hash 算法。
+
+即使新进程中的 Ray 物理 block 布局发生变化，显式续跑也可以用这些信息重建首次运行的逻辑分区。完整分区 hash 不依赖 Ray batch 边界，并且会在复用任何 checkpoint 前完成校验。
+
 ### 中间存储
 
 ```yaml
@@ -86,14 +98,46 @@ dj-process --config config.yaml --partition.mode auto
 # 手动分区模式
 dj-process --config config.yaml --partition.mode manual --partition.num_of_partitions 4
 
-# 自定义作业 ID
+# 可选：使用自定义作业 ID 启动新任务
 dj-process --config config.yaml --job_id my_experiment_001
+```
+
+启用检查点后，新建的 `ray_partitioned` 作业会打印 resume token：
+
+```text
+Resume token: 20260805_115141_81270d. Rerun the original command with
+--resume 20260805_115141_81270d to resume this job.
 ```
 
 ### 恢复作业
 
 ```bash
-dj-process --config config.yaml --job_id my_experiment_001
+# 使用首次运行打印的 token，并保持输入数据和 recipe 不变
+dj-process --config config.yaml --resume 20260805_115141_81270d
+
+# 首次运行使用的自定义 ID 也可以作为 resume token
+dj-process --config config.yaml --resume my_experiment_001
+```
+
+`--resume` 仅支持 `ray_partitioned` 执行器。它会依次执行严格续跑流程：
+
+1. 定位原任务的工作目录和检查点目录；
+2. 确认当前配置与首次运行配置一致；
+3. 读取保存的分区数、行号边界和内容 hash；
+4. 使用保存的行号边界重建首次运行的逻辑分区；
+5. 校验所有分区的完整内容 hash；
+6. 加载已完成的 checkpoint，仅处理尚未完成的部分。
+
+如果 metadata 缺失、行号边界非法、输入内容发生变化或内容 hash 不一致，显式续跑会报错停止，并保留已有 checkpoint，不会将其删除。
+
+`--job_id` 仍可用于自定义任务名称和向后兼容。需要进行容错续跑时，应优先使用 `--resume`：旧的 `--job_id` 续跑路径保持原有行为，在分区不匹配时可能清除 checkpoint 并重新开始。旧版 Data-Juicer 创建的 metadata 仍可读取，但其中没有显式续跑所需的行号边界和完整内容 hash；因此，`--resume` 会拒绝使用这种旧 metadata，同时保留已有 checkpoint。
+
+如果同时提供两个参数，它们的值必须相同：
+
+```bash
+dj-process --config config.yaml \
+  --job_id my_experiment_001 \
+  --resume my_experiment_001
 ```
 
 ### 检查点策略
@@ -268,7 +312,10 @@ disabled          | 0秒     | 重新执行全部
 ```bash
 ls -la ./outputs/{work_dir}/{job_id}/job_summary.json
 ls -la ./outputs/{work_dir}/{job_id}/checkpoints/
+cat ./outputs/{work_dir}/{job_id}/checkpoints/partitioning_info.json
 ```
+
+请使用首次运行打印的 resume token，并通过 `--resume` 重新执行相同的 recipe。可以在错误日志中检查配置不一致、分区 metadata 缺失、行号边界非法或分区内容 hash 不匹配。显式续跑校验失败时不会删除已有 checkpoint。
 
 **检查 Ray 状态：**
 ```bash

--- a/docs/PartitionAndCheckpoint_ZH.md
+++ b/docs/PartitionAndCheckpoint_ZH.md
@@ -75,7 +75,7 @@ checkpoint:
 - 覆盖完整分区内容的稳定 hash；
 - 写入 metadata 时使用的分区 hash 算法。
 
-即使新进程中的 Ray 物理 block 布局发生变化，显式续跑也可以用这些信息重建首次运行的逻辑分区。完整分区 hash 不依赖 Ray batch 边界，并且会在复用任何 checkpoint 前完成校验。
+即使新进程中的 Ray 物理 block 布局发生变化，显式续跑也可以用这些信息重建首次运行的逻辑分区。完整分区 hash 对样本顺序敏感、不依赖 Ray batch 边界，并且会在复用任何 checkpoint 前完成校验。
 
 ### 中间存储
 

--- a/tests/config/test_config_functions.py
+++ b/tests/config/test_config_functions.py
@@ -472,6 +472,23 @@ class ResolveJobIdTest(DataJuicerTestCaseBase):
         resolve_job_id(cfg2)
         self.assertNotEqual(cfg1.job_id, cfg2.job_id)
 
+    def test_resume_uses_resume_id_as_job_id(self):
+        cfg = Namespace(executor_type="ray_partitioned", job_id=None, resume="resume_token")
+        result = resolve_job_id(cfg)
+        self.assertEqual(result.job_id, "resume_token")
+        self.assertTrue(result._user_provided_job_id)
+        self.assertTrue(result._resume_requested)
+
+    def test_resume_rejects_conflicting_job_id(self):
+        cfg = Namespace(executor_type="ray_partitioned", job_id="job_a", resume="job_b")
+        with self.assertRaisesRegex(ValueError, "must refer to the same job"):
+            resolve_job_id(cfg)
+
+    def test_resume_rejects_non_partitioned_executor(self):
+        cfg = Namespace(executor_type="ray", job_id=None, resume="resume_token")
+        with self.assertRaisesRegex(ValueError, "only supported by the ray_partitioned executor"):
+            resolve_job_id(cfg)
+
 
 class ValidateWorkDirConfigTest(DataJuicerTestCaseBase):
     """Test validate_work_dir_config: ensures {job_id} is at end of path."""
@@ -609,6 +626,7 @@ class BuildBaseParserTest(DataJuicerTestCaseBase):
         self.assertIn("project_name", action_dests)
         self.assertIn("executor_type", action_dests)
         self.assertIn("dataset_path", action_dests)
+        self.assertIn("resume", action_dests)
 
     def test_executor_type_choices(self):
         parser = build_base_parser()

--- a/tests/core/executor/test_ray_partition_resume.py
+++ b/tests/core/executor/test_ray_partition_resume.py
@@ -23,7 +23,7 @@ def _metadata(partition_id, row_count, content_hash="hash"):
     )
 
 
-def test_partition_content_hash_is_independent_of_batch_boundaries_and_order():
+def test_partition_content_hash_is_independent_of_batch_boundaries():
     rows = [{"id": 1, "text": "a"}, {"id": 2, "text": "b"}, {"id": 3, "text": "c"}]
     one_batch = [_hash_partition_batch(pyarrow.Table.from_pylist(rows)).to_pylist()[0]]
     split_batches = [
@@ -32,10 +32,24 @@ def test_partition_content_hash_is_independent_of_batch_boundaries_and_order():
     ]
 
     one_hash, one_count = _combine_partition_hash_partials(one_batch)
-    split_hash, split_count = _combine_partition_hash_partials(list(reversed(split_batches)))
+    split_hash, split_count = _combine_partition_hash_partials(split_batches)
 
     assert one_count == split_count == 3
     assert one_hash == split_hash
+
+
+def test_partition_content_hash_detects_reordered_rows():
+    original = [{"id": "A"}, {"id": "B"}, {"id": "C"}]
+    reordered = [{"id": "A"}, {"id": "C"}, {"id": "B"}]
+
+    original_hash, _ = _combine_partition_hash_partials(
+        _hash_partition_batch(pyarrow.Table.from_pylist(original)).to_pylist()
+    )
+    reordered_hash, _ = _combine_partition_hash_partials(
+        _hash_partition_batch(pyarrow.Table.from_pylist(reordered)).to_pylist()
+    )
+
+    assert original_hash != reordered_hash
 
 
 def test_partition_content_hash_detects_changed_content():
@@ -134,6 +148,44 @@ def test_split_at_saved_boundaries_rejects_invalid_row_offsets():
 
     with pytest.raises(RuntimeError, match="Saved row boundaries are invalid"):
         executor._split_at_saved_boundaries(SimpleNamespace(data=Mock()), info)
+
+
+def test_split_at_saved_boundaries_materializes_valid_single_partition():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.num_partitions = 1
+    data = Mock()
+    data.materialize.return_value = "p0"
+    first = _metadata(0, 4)
+    first.start_row = 0
+    first.end_row = 4
+    info = PartitioningInfo(num_partitions=1, total_rows=4, partitions=[first])
+
+    partitions = executor._split_at_saved_boundaries(SimpleNamespace(data=data), info)
+
+    assert partitions == ["p0"]
+    data.materialize.assert_called_once_with()
+    data.split_at_indices.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [("start_row", 1), ("end_row", 5), ("total_rows", 5)],
+)
+def test_split_at_saved_boundaries_rejects_invalid_single_partition_metadata(field, invalid_value):
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.num_partitions = 1
+    data = Mock()
+    first = _metadata(0, 4)
+    first.start_row = 0
+    first.end_row = 4
+    info = PartitioningInfo(num_partitions=1, total_rows=4, partitions=[first])
+    target = first if field in {"start_row", "end_row"} else info
+    setattr(target, field, invalid_value)
+
+    with pytest.raises(RuntimeError, match="Saved row boundaries"):
+        executor._split_at_saved_boundaries(SimpleNamespace(data=data), info)
+
+    data.materialize.assert_not_called()
 
 
 def test_explicit_resume_hash_mismatch_keeps_checkpoints():

--- a/tests/core/executor/test_ray_partition_resume.py
+++ b/tests/core/executor/test_ray_partition_resume.py
@@ -1,0 +1,179 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pyarrow
+import pytest
+
+from data_juicer.core.executor.ray_executor_partitioned import (
+    PartitionMetadata,
+    PartitionedRayExecutor,
+    PartitioningInfo,
+    _combine_partition_hash_partials,
+    _hash_partition_batch,
+)
+
+
+def _metadata(partition_id, row_count, content_hash="hash"):
+    return PartitionMetadata(
+        partition_id=partition_id,
+        row_count=row_count,
+        first_row_hash="first",
+        last_row_hash="",
+        content_hash=content_hash,
+    )
+
+
+def test_partition_content_hash_is_independent_of_batch_boundaries_and_order():
+    rows = [{"id": 1, "text": "a"}, {"id": 2, "text": "b"}, {"id": 3, "text": "c"}]
+    one_batch = [_hash_partition_batch(pyarrow.Table.from_pylist(rows)).to_pylist()[0]]
+    split_batches = [
+        _hash_partition_batch(pyarrow.Table.from_pylist(rows[:1])).to_pylist()[0],
+        _hash_partition_batch(pyarrow.Table.from_pylist(rows[1:])).to_pylist()[0],
+    ]
+
+    one_hash, one_count = _combine_partition_hash_partials(one_batch)
+    split_hash, split_count = _combine_partition_hash_partials(list(reversed(split_batches)))
+
+    assert one_count == split_count == 3
+    assert one_hash == split_hash
+
+
+def test_partition_content_hash_detects_changed_content():
+    original = _hash_partition_batch(pyarrow.Table.from_pylist([{"id": 1}])).to_pylist()
+    changed = _hash_partition_batch(pyarrow.Table.from_pylist([{"id": 2}])).to_pylist()
+
+    original_hash, _ = _combine_partition_hash_partials(original)
+    changed_hash, _ = _combine_partition_hash_partials(changed)
+
+    assert original_hash != changed_hash
+
+
+def test_partitioning_info_loads_legacy_metadata_without_content_hash():
+    info = PartitioningInfo.from_dict(
+        {
+            "num_partitions": 1,
+            "total_rows": 2,
+            "partitions": [
+                {
+                    "partition_id": 0,
+                    "row_count": 2,
+                    "first_row_hash": "first",
+                    "last_row_hash": "",
+                }
+            ],
+        }
+    )
+
+    assert info.partitions[0].content_hash == ""
+
+
+def test_partitioning_info_persists_row_offsets_and_content_hash(tmp_path):
+    first = _metadata(0, 4, content_hash="partition-hash")
+    first.start_row = 0
+    first.end_row = 4
+    info = PartitioningInfo(num_partitions=1, total_rows=4, partitions=[first])
+    path = tmp_path / "partitioning_info.json"
+
+    info.save(str(path))
+    restored = PartitioningInfo.load(str(path))
+
+    assert restored is not None
+    assert restored.partitions[0].start_row == 0
+    assert restored.partitions[0].end_row == 4
+    assert restored.partitions[0].content_hash == "partition-hash"
+
+
+def test_split_at_saved_boundaries_uses_saved_row_counts():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.num_partitions = 3
+    data = Mock()
+    data.split_at_indices.return_value = ["p0", "p1", "p2"]
+    dataset = SimpleNamespace(data=data)
+    info = PartitioningInfo(
+        num_partitions=3,
+        total_rows=10,
+        partitions=[_metadata(0, 2), _metadata(1, 3), _metadata(2, 5)],
+    )
+
+    partitions = executor._split_at_saved_boundaries(dataset, info)
+
+    assert partitions == ["p0", "p1", "p2"]
+    data.split_at_indices.assert_called_once_with([2, 5])
+
+
+def test_split_at_saved_boundaries_uses_explicit_row_offsets():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.num_partitions = 2
+    data = Mock()
+    data.split_at_indices.return_value = ["p0", "p1"]
+    dataset = SimpleNamespace(data=data)
+    first = _metadata(0, 4)
+    first.start_row = 0
+    first.end_row = 4
+    second = _metadata(1, 6)
+    second.start_row = 4
+    second.end_row = 10
+    info = PartitioningInfo(num_partitions=2, total_rows=10, partitions=[first, second])
+
+    executor._split_at_saved_boundaries(dataset, info)
+
+    data.split_at_indices.assert_called_once_with([4])
+
+
+def test_split_at_saved_boundaries_rejects_invalid_row_offsets():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.num_partitions = 2
+    first = _metadata(0, 4)
+    first.start_row = 1
+    first.end_row = 5
+    info = PartitioningInfo(
+        num_partitions=2,
+        total_rows=10,
+        partitions=[first, _metadata(1, 6)],
+    )
+
+    with pytest.raises(RuntimeError, match="Saved row boundaries are invalid"):
+        executor._split_at_saved_boundaries(SimpleNamespace(data=Mock()), info)
+
+
+def test_explicit_resume_hash_mismatch_keeps_checkpoints():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = SimpleNamespace(_resume_requested=True)
+    executor.num_partitions = 2
+    executor._enable_deterministic_execution = Mock()
+    executor._clear_invalid_checkpoints = Mock()
+    first = _metadata(0, 1)
+    first.start_row = 0
+    first.end_row = 1
+    second = _metadata(1, 1)
+    second.start_row = 1
+    second.end_row = 2
+    info = PartitioningInfo(num_partitions=2, total_rows=2, partitions=[first, second])
+    executor._load_partitioning_info = Mock(return_value=info)
+    executor._split_at_saved_boundaries = Mock(return_value=["p0", "p1"])
+    executor._validate_partitions = Mock(return_value=False)
+
+    with pytest.raises(RuntimeError, match="Refusing to resume"):
+        executor._split_dataset_deterministic(SimpleNamespace(data=Mock()))
+
+    executor._clear_invalid_checkpoints.assert_not_called()
+
+
+def test_explicit_resume_rejects_legacy_metadata_without_hashes_or_boundaries():
+    executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
+    executor.cfg = SimpleNamespace(_resume_requested=True)
+    executor.num_partitions = 1
+    executor._enable_deterministic_execution = Mock()
+    executor._clear_invalid_checkpoints = Mock()
+    executor._load_partitioning_info = Mock(
+        return_value=PartitioningInfo(
+            num_partitions=1,
+            total_rows=1,
+            partitions=[_metadata(0, 1, content_hash="")],
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="requires content hashes and row boundaries"):
+        executor._split_dataset_deterministic(SimpleNamespace(data=Mock()))
+
+    executor._clear_invalid_checkpoints.assert_not_called()


### PR DESCRIPTION
## Summary

This PR makes `ray_partitioned` jobs explicitly resumable even when Ray produces a different physical block layout between two otherwise identical runs.

It introduces:

- a new `--resume <job_id>` CLI option for `ray_partitioned` jobs;
- persisted inclusive/exclusive row offsets for every logical partition;
- a stable full-content hash for every partition;
- reconstruction of the original logical partitions with `split_at_indices()`;
- fail-safe validation before any existing checkpoint is reused;
- a printed resume token for new checkpoint-enabled partitioned jobs.

Example:

```bash
# Initial run. The log prints: "Resume token: <job_id>"
dj-process --config recipe.yaml

# Resume the same job without changing the recipe
dj-process --config recipe.yaml --resume <job_id>
```

## Motivation

`Dataset.split(n)` depends on the physical Ray block layout. A job can therefore produce different logical partitions after a restart even when both the input data and recipe are unchanged.

For example, the regression tests force the same input to be read as 64 blocks on the first run and 65 blocks on the second run:

```text
first run:  partition 0 = 256 rows
second run: partition 0 = 380 rows
```

The existing resume path detects this row-count mismatch, deletes all partition checkpoints, and restarts the whole job. This makes checkpointing ineffective for long-running partitioned pipelines whose Ray block layout changes across processes or cluster states.

## How it works

### Persist stable partition metadata

After the initial split, `partitioning_info.json` now stores the following for each partition:

```json
{
  "partition_id": 0,
  "row_count": 256,
  "start_row": 0,
  "end_row": 256,
  "content_hash": "..."
}
```

The file also records the hash algorithm identifier:

```text
sha256-multiset-v1
```

The content hash is built from canonical per-row SHA-256 digests and combined with order- and Ray-batch-boundary-independent accumulators. This allows the same logical partition to validate even when Ray changes its internal physical blocks.

### Recreate the original logical partitions

When `--resume <job_id>` is provided, the executor:

1. locates the original work and checkpoint directories;
2. validates that the current configuration matches the original run;
3. loads `partitioning_info.json`;
4. reuses the saved partition count, including when partition mode is `auto`;
5. enables ordered Ray execution before loading the dataset;
6. recreates the original partitions from the saved row offsets with `split_at_indices()`;
7. recomputes and validates every partition content hash;
8. reuses existing checkpoints only after all validation succeeds.

### Fail closed without deleting checkpoints

Explicit resume fails with an actionable error and leaves existing checkpoints untouched when:

- the job or work directory cannot be located;
- `partitioning_info.json` is missing;
- the saved partition metadata is incomplete;
- the hash algorithm is unsupported;
- row boundaries are invalid;
- the current input content does not match the saved hashes.

This differs intentionally from the legacy `--job_id` behavior, which is retained for backward compatibility and may clear mismatched checkpoints before starting fresh.

## CLI behavior and compatibility

- `--resume` is supported only by the `ray_partitioned` executor.
- `--resume ID --job_id ID` is accepted when both IDs are identical.
- Conflicting `--resume` and `--job_id` values are rejected.
- The resume-only CLI argument is excluded from configuration equality checks, so the original recipe remains unchanged.
- Existing metadata can still be deserialized with empty default values for the new fields.
- Metadata created by older versions does not contain the full content hashes and row offsets required for safe explicit resume. In that case, `--resume` refuses to continue and preserves the existing checkpoint files.
- Existing non-explicit `--job_id` behavior remains available.

## Scope

The change is limited to partition checkpoint resumption:

- no recipe changes are required;
- the normal initial partitioning algorithm remains unchanged;
- legacy `--job_id` behavior remains unchanged;
- complete partition hashes are collected only when checkpointing is enabled;
- no unrelated operator or export behavior is modified.

## Testing

### Unit tests

```bash
NUMBA_DISABLE_JIT=1 PYTHONDONTWRITEBYTECODE=1 \
python -m pytest -q -p no:cacheprovider \
  tests/core/executor/test_ray_partition_resume.py \
  tests/config/test_config_functions.py::ResolveJobIdTest \
  tests/config/test_config_functions.py::BuildBaseParserTest::test_has_required_args
```

Result:

```text
17 passed in 3.63s
```

The tests cover:

- `--resume` ID resolution and CLI validation;
- conflicting `--resume`/`--job_id` values;
- rejection on non-partitioned executors;
- content-hash stability across Arrow batch boundaries and batch order;
- detection of changed partition content;
- persistence of row offsets and content hashes;
- reconstruction with saved row counts and explicit offsets;
- invalid boundary rejection;
- preservation of checkpoints after explicit-resume hash mismatch;
- safe rejection of legacy metadata without hashes or boundaries.

### CPU end-to-end regression

Configuration:

- 8,192 deterministic rows;
- 32 partitions;
- `text_length_filter`;
- first run: 64 Ray blocks, interrupted at partition 12;
- resume run: 65 Ray blocks with the same input and recipe.

Legacy behavior reproduced:

```text
Partition 0 row count mismatch: current=380, saved=256
Clearing invalid checkpoints
```

Fixed behavior with `--resume`:

- recreated all 32 partitions at the original 256-row boundaries;
- validated all 32 content hashes;
- reused all 11 completed checkpoints without changing their mtimes;
- preserved the original `partitioning_info.json` SHA-256;
- produced exactly 8,192 unique IDs with no missing or duplicated rows.

### Four-GPU end-to-end regression

Configuration:

- 4×NVIDIA H20;
- 512 deterministic rows;
- 32 partitions with 4 concurrent partition pipelines;
- `llm_perplexity_filter` with `Qwen/Qwen2.5-0.5B`;
- one Ray actor and one GPU per concurrent partition;
- first run: 64 Ray blocks, interrupted at partition 12;
- resume run: 65 Ray blocks with the same input and recipe.

All four Ray GPU actors received distinct GPU IDs (`0`, `1`, `2`, and `3`) and imported Data-Juicer from this PR checkout.

Legacy behavior reproduced:

```text
Partition 0 row count mismatch: current=24, saved=16
Clearing invalid checkpoints
```

Fixed behavior with `--resume`:

- recreated the original 32×16-row partitions;
- validated all saved content hashes;
- reused all 11 completed GPU checkpoints without changing their mtimes;
- did not log `Clearing invalid checkpoints`;
- produced 32 final checkpoints;
- produced exactly 512 unique IDs in the range `0..511`;
- produced finite `llm_perplexity` values for all 512 rows;
- completed without CUDA OOM or unexpected exceptions.

## Performance note

Computing complete content hashes adds one validation scan when partition metadata is first created and another scan during explicit resume. This is intentional: checkpoint reuse is allowed only after the complete saved partition contents have been verified.

The synthetic tests also showed that reading many small Parquet checkpoints can increase the number of Ray blocks and final output shards. This affects merge/export overhead for very small test partitions, but it is independent of the checkpoint-correctness fix and is intentionally left for a separate optimization.

## Checklist

- [x] Added explicit `--resume <job_id>` CLI support.
- [x] Preserved existing `--job_id` behavior.
- [x] Persisted partition row boundaries and complete content hashes.
- [x] Added fail-safe validation that does not delete checkpoints.
- [x] Added unit coverage for the new behavior and compatibility checks.
- [x] Documented explicit resume behavior and usage in the English and Chinese partition/checkpoint guides.
- [x] Reproduced the original issue on CPU and four GPUs.
- [x] Verified checkpoint reuse and exact final output on CPU and GPU.
