### PR TITLE
feat(selector): add image OHEM selector

### DIFF
--- a/data_juicer/config/config_all.yaml
+++ b/data_juicer/config/config_all.yaml
@@ -859,6 +859,15 @@ process:
       words_aug_join_char: ""                                 # the join char between words to augment
   - general_field_filter:                                    # Filter to keep samples based on a general field filter condition.
       filter_condition: ""                                  # The filter condition as a string. It can include logical operators (and/or) and chain comparisons.
+  - image_ohem_selector:                                   # select high-loss image samples using a user-defined model/loss.
+      score_file: ""                                        # Python file defining score_fn(model, samples, images, device, **kwargs)
+      score_function: score_fn
+      model_function: model_factory
+      top_ratio: 0.3                                        # retain this fraction of highest-loss samples
+      topk: null                                             # optional maximum number of selected samples
+      batch_size: 8
+      loss_field: image_ohem_loss
+      device: auto
   - image_aesthetics_filter:                                # filter samples according to the aesthetics score of images.
       hf_scorer_model: shunk031/aesthetics-predictor-v2-sac-logos-ava1-l14-linearMSE # Huggingface model name for the aesthetics predictor
       min_score: 0.3                                          # the min aesthetics score of filter range

--- a/data_juicer/ops/selector/__init__.py
+++ b/data_juicer/ops/selector/__init__.py
@@ -1,4 +1,5 @@
 from .frequency_specified_field_selector import FrequencySpecifiedFieldSelector
+from .image_ohem_selector import ImageOHEMSelector
 from .random_selector import RandomSelector
 from .range_specified_field_selector import RangeSpecifiedFieldSelector
 from .tags_specified_field_selector import TagsSpecifiedFieldSelector
@@ -6,6 +7,7 @@ from .topk_specified_field_selector import TopkSpecifiedFieldSelector
 
 __all__ = [
     "FrequencySpecifiedFieldSelector",
+    "ImageOHEMSelector",
     "RandomSelector",
     "RangeSpecifiedFieldSelector",
     "TagsSpecifiedFieldSelector",

--- a/data_juicer/ops/selector/image_ohem_selector.py
+++ b/data_juicer/ops/selector/image_ohem_selector.py
@@ -1,16 +1,22 @@
 """Select hard image examples using a user supplied per-sample loss function."""
 
+import hashlib
 import heapq
 import importlib.util
+import logging
 import os
+import sys
+import uuid
 from typing import Optional
 
 import numpy as np
 
 from data_juicer.utils.constant import Fields
-from data_juicer.utils.mm_utils import load_image
+from data_juicer.utils.mm_utils import load_image, load_mm_bytes_from_sample
 
 from ..base_op import OPERATORS, Selector
+
+logger = logging.getLogger(__name__)
 
 
 @OPERATORS.register_module("image_ohem_selector")
@@ -36,7 +42,7 @@ class ImageOHEMSelector(Selector):
         topk: Optional[int] = None,
         batch_size: int = 8,
         image_key: str = "images",
-        image_bytes_key: str = "",
+        image_bytes_key: str = "image_bytes",
         loss_field: str = "image_ohem_loss",
         device: str = "auto",
         model_kwargs: Optional[dict] = None,
@@ -64,19 +70,38 @@ class ImageOHEMSelector(Selector):
         self.model_kwargs = model_kwargs or {}
         self.score_kwargs = score_kwargs or {}
         self._model = None
+        self._module_name = None
         if score_file:
             self._load_user_functions()
         if not callable(self.score_fn):
             raise ValueError("score_fn or a score_file containing a callable score_fn is required")
+        if self.model_factory is not None and not callable(self.model_factory):
+            raise ValueError("model_factory must be callable or None")
 
     def _load_user_functions(self):
+        self.score_file = os.path.abspath(self.score_file)
         if not os.path.isfile(self.score_file) or not self.score_file.endswith(".py"):
             raise ValueError(f"score_file must be an existing Python file: {self.score_file}")
-        spec = importlib.util.spec_from_file_location("data_juicer_image_ohem_user", self.score_file)
+
+        path_digest = hashlib.sha256(self.score_file.encode()).hexdigest()[:12]
+        module_name = f"data_juicer_image_ohem_{path_digest}_{uuid.uuid4().hex}"
+        spec = importlib.util.spec_from_file_location(module_name, self.score_file)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not load a Python module from score_file: {self.score_file}")
+
         module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        self.score_fn = getattr(module, self.score_function, self.score_fn)
-        self.model_factory = getattr(module, self.model_function, self.model_factory)
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+            if not hasattr(module, self.score_function):
+                raise ValueError(f"Function '{self.score_function}' not found in '{self.score_file}'")
+            self.score_fn = getattr(module, self.score_function)
+            if hasattr(module, self.model_function):
+                self.model_factory = getattr(module, self.model_function)
+        except Exception:
+            sys.modules.pop(module_name, None)
+            raise
+        self._module_name = module_name
 
     def _device(self):
         if self.device_name != "auto":
@@ -97,30 +122,47 @@ class ImageOHEMSelector(Selector):
                 self._model.eval()
         return self._model
 
+    def _release_model(self):
+        model = self._model
+        self._model = None
+        if model is not None and hasattr(model, "to"):
+            try:
+                model.to("cpu")
+            except Exception as error:
+                logger.warning("Failed to move the user model to CPU during cleanup: %s", error)
+
     def _images(self, sample):
         paths = sample.get(self.image_key, []) or []
         if not isinstance(paths, (list, tuple)):
             paths = [paths]
-        byte_values = sample.get(self.image_bytes_key, []) if self.image_bytes_key else []
-        if byte_values and len(byte_values) == len(paths):
-            return [load_image(value) for value in byte_values]
-        return [load_image(path) for path in paths]
+        images = []
+        for index, path in enumerate(paths):
+            image_bytes = load_mm_bytes_from_sample(sample, index, self.image_bytes_key)
+            images.append(load_image(image_bytes if image_bytes is not None else path))
+        return images
 
     def process(self, dataset):
         if not len(dataset):
             return dataset
-        model, device = self._ensure_model(), self._device()
+        model = None
         losses = []
-        for start in range(0, len(dataset), self.batch_size):
-            samples = dataset.select(range(start, min(start + self.batch_size, len(dataset)))).to_list()
-            images = [self._images(sample) for sample in samples]
-            batch_losses = self.score_fn(model, samples, images, device, **self.score_kwargs)
-            if hasattr(batch_losses, "detach"):
-                batch_losses = batch_losses.detach().cpu().reshape(-1).tolist()
-            batch_losses = np.asarray(batch_losses, dtype=float).reshape(-1).tolist()
-            if len(batch_losses) != len(samples):
-                raise ValueError("score_fn must return exactly one loss per sample")
-            losses.extend(batch_losses)
+        try:
+            model, device = self._ensure_model(), self._device()
+            for start in range(0, len(dataset), self.batch_size):
+                samples = dataset.select(range(start, min(start + self.batch_size, len(dataset)))).to_list()
+                images = [self._images(sample) for sample in samples]
+                batch_losses = self.score_fn(model, samples, images, device, **self.score_kwargs)
+                if hasattr(batch_losses, "detach"):
+                    batch_losses = batch_losses.detach().cpu().reshape(-1).tolist()
+                batch_losses = np.asarray(batch_losses, dtype=float).reshape(-1).tolist()
+                if len(batch_losses) != len(samples):
+                    raise ValueError("score_fn must return exactly one loss per sample")
+                if not np.isfinite(batch_losses).all():
+                    raise ValueError("score_fn returned NaN or infinite loss")
+                losses.extend(batch_losses)
+        finally:
+            self._release_model()
+            model = None
 
         def attach_loss(sample, index):
             stats = dict(sample.get(Fields.stats, {}))
@@ -137,7 +179,5 @@ class ImageOHEMSelector(Selector):
         if select_num <= 0:
             return dataset.select([])
         values = [float(sample[Fields.stats][self.loss_field]) for sample in dataset]
-        if not np.isfinite(values).all():
-            raise ValueError("score_fn returned NaN or infinite loss")
         indices = heapq.nlargest(select_num, range(len(dataset)), values.__getitem__)
         return dataset.select(indices)

--- a/data_juicer/ops/selector/image_ohem_selector.py
+++ b/data_juicer/ops/selector/image_ohem_selector.py
@@ -83,6 +83,7 @@ class ImageOHEMSelector(Selector):
             return self.device_name
         try:
             import torch
+
             return "cuda" if torch.cuda.is_available() else "cpu"
         except ImportError:
             return "cpu"

--- a/data_juicer/ops/selector/image_ohem_selector.py
+++ b/data_juicer/ops/selector/image_ohem_selector.py
@@ -1,0 +1,142 @@
+"""Select hard image examples using a user supplied per-sample loss function."""
+
+import heapq
+import importlib.util
+import os
+from typing import Optional
+
+import numpy as np
+
+from data_juicer.utils.constant import Fields
+from data_juicer.utils.mm_utils import load_image
+
+from ..base_op import OPERATORS, Selector
+
+
+@OPERATORS.register_module("image_ohem_selector")
+class ImageOHEMSelector(Selector):
+    """Keep the highest-loss image samples (Online Hard Example Mining).
+
+    ``score_fn`` is supplied by the user and must have the signature
+    ``score_fn(model, samples, images, device, **score_kwargs)``. It must return one
+    numeric loss per sample in the batch. ``model_factory`` is optional and, when
+    supplied, is called once as ``model_factory(**model_kwargs)``.
+    """
+
+    _accelerator = "cuda"
+
+    def __init__(
+        self,
+        score_fn=None,
+        model_factory=None,
+        score_file: str = "",
+        score_function: str = "score_fn",
+        model_function: str = "model_factory",
+        top_ratio: Optional[float] = None,
+        topk: Optional[int] = None,
+        batch_size: int = 8,
+        image_key: str = "images",
+        image_bytes_key: str = "",
+        loss_field: str = "image_ohem_loss",
+        device: str = "auto",
+        model_kwargs: Optional[dict] = None,
+        score_kwargs: Optional[dict] = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(image_key=image_key, image_bytes_key=image_bytes_key, *args, **kwargs)
+        if top_ratio is None and topk is None:
+            raise ValueError("At least one of top_ratio or topk must be specified")
+        if top_ratio is not None and not 0 <= top_ratio <= 1:
+            raise ValueError("top_ratio must be in [0, 1]")
+        if topk is not None and topk < 0:
+            raise ValueError("topk must be non-negative")
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        self.score_fn = score_fn
+        self.model_factory = model_factory
+        self.score_file = score_file
+        self.score_function = score_function
+        self.model_function = model_function
+        self.top_ratio, self.topk = top_ratio, topk
+        self.batch_size, self.loss_field = batch_size, loss_field
+        self.device_name = device
+        self.model_kwargs = model_kwargs or {}
+        self.score_kwargs = score_kwargs or {}
+        self._model = None
+        if score_file:
+            self._load_user_functions()
+        if not callable(self.score_fn):
+            raise ValueError("score_fn or a score_file containing a callable score_fn is required")
+
+    def _load_user_functions(self):
+        if not os.path.isfile(self.score_file) or not self.score_file.endswith(".py"):
+            raise ValueError(f"score_file must be an existing Python file: {self.score_file}")
+        spec = importlib.util.spec_from_file_location("data_juicer_image_ohem_user", self.score_file)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        self.score_fn = getattr(module, self.score_function, self.score_fn)
+        self.model_factory = getattr(module, self.model_function, self.model_factory)
+
+    def _device(self):
+        if self.device_name != "auto":
+            return self.device_name
+        try:
+            import torch
+            return "cuda" if torch.cuda.is_available() else "cpu"
+        except ImportError:
+            return "cpu"
+
+    def _ensure_model(self):
+        if self._model is None and self.model_factory is not None:
+            self._model = self.model_factory(**self.model_kwargs)
+            if hasattr(self._model, "to"):
+                self._model.to(self._device())
+            if hasattr(self._model, "eval"):
+                self._model.eval()
+        return self._model
+
+    def _images(self, sample):
+        paths = sample.get(self.image_key, []) or []
+        if not isinstance(paths, (list, tuple)):
+            paths = [paths]
+        byte_values = sample.get(self.image_bytes_key, []) if self.image_bytes_key else []
+        if byte_values and len(byte_values) == len(paths):
+            return [load_image(value) for value in byte_values]
+        return [load_image(path) for path in paths]
+
+    def process(self, dataset):
+        if not len(dataset):
+            return dataset
+        model, device = self._ensure_model(), self._device()
+        losses = []
+        for start in range(0, len(dataset), self.batch_size):
+            samples = dataset.select(range(start, min(start + self.batch_size, len(dataset)))).to_list()
+            images = [self._images(sample) for sample in samples]
+            batch_losses = self.score_fn(model, samples, images, device, **self.score_kwargs)
+            if hasattr(batch_losses, "detach"):
+                batch_losses = batch_losses.detach().cpu().reshape(-1).tolist()
+            batch_losses = np.asarray(batch_losses, dtype=float).reshape(-1).tolist()
+            if len(batch_losses) != len(samples):
+                raise ValueError("score_fn must return exactly one loss per sample")
+            losses.extend(batch_losses)
+
+        def attach_loss(sample, index):
+            stats = dict(sample.get(Fields.stats, {}))
+            stats[self.loss_field] = float(losses[index])
+            sample[Fields.stats] = stats
+            return sample
+
+        dataset = dataset.map(attach_loss, with_indices=True)
+        select_num = len(dataset)
+        if self.top_ratio is not None:
+            select_num = int(self.top_ratio * len(dataset))
+        if self.topk is not None:
+            select_num = min(select_num, self.topk)
+        if select_num <= 0:
+            return dataset.select([])
+        values = [float(sample[Fields.stats][self.loss_field]) for sample in dataset]
+        if not np.isfinite(values).all():
+            raise ValueError("score_fn returned NaN or infinite loss")
+        indices = heapq.nlargest(select_num, range(len(dataset)), values.__getitem__)
+        return dataset.select(indices)

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -334,7 +334,7 @@ All the specific operators are listed below, each featured with several capabili
 | Operator 算子 | Tags 标签 | Description 描述 | Details 详情 | Reference 参考 |
 |----------|------|-------------|-------------|-------------|
 | frequency_specified_field_selector | 💻CPU 🟢Stable | Selector to filter samples based on the frequency of a specified field. 选择器根据指定字段的频率过滤样本。 | [info](operators/selector/frequency_specified_field_selector.md) | - |
-| image_ohem_selector | 🏞Image 🚀GPU 🟡Beta | Selects high-loss image samples using a user-defined model and loss function. 使用用户自定义模型和损失函数选择高损失图像样本。 | [info](operators/selector/image_ohem_selector.md) | - |
+| image_ohem_selector | 🏞Image 🚀GPU 🟡Beta | Keep the highest-loss image samples (Online Hard Example Mining). 保留损失最大的样本（在线难例挖掘）。 | [info](operators/selector/image_ohem_selector.md) | - |
 | random_selector | 💻CPU 🟢Stable | Randomly selects a subset of samples from the dataset. 从数据集中随机选择样本子集。 | [info](operators/selector/random_selector.md) | - |
 | range_specified_field_selector | 💻CPU 🟢Stable | Selects a range of samples based on the sorted values of a specified field. 根据指定字段的排序值选择采样范围。 | [info](operators/selector/range_specified_field_selector.md) | - |
 | tags_specified_field_selector | 💻CPU 🟢Stable | Selector to filter samples based on the tags of a specified field. 选择器根据指定字段的标签过滤样本。 | [info](operators/selector/tags_specified_field_selector.md) | - |

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -48,7 +48,7 @@ Data-Juicer 中的算子分为以下 8 种类型。
 | [grouper](#grouper) | 3 | Group samples to batched samples. 将样本分组，每一组组成一个批量样本。 |
 | [mapper](#mapper) | 138 | Edits and transforms samples. 对数据样本进行编辑和转换。 |
 | [pipeline](#pipeline) | 3 | Applies dataset-level processing; both input and output are datasets. 执行数据集级别的操作，输入和输出均为完整数据集。 |
-| [selector](#selector) | 5 | Selects top samples based on ranking. 基于排序选取高质量样本。 |
+| [selector](#selector) | 6 | Selects top samples based on ranking. 基于排序选取高质量样本。 |
 
 All the specific operators are listed below, each featured with several capability tags. 
 下面列出所有具体算子，每种算子都通过多个标签来注明其主要功能。
@@ -334,6 +334,7 @@ All the specific operators are listed below, each featured with several capabili
 | Operator 算子 | Tags 标签 | Description 描述 | Details 详情 | Reference 参考 |
 |----------|------|-------------|-------------|-------------|
 | frequency_specified_field_selector | 💻CPU 🟢Stable | Selector to filter samples based on the frequency of a specified field. 选择器根据指定字段的频率过滤样本。 | [info](operators/selector/frequency_specified_field_selector.md) | - |
+| image_ohem_selector | 🏞Image 🚀GPU 🟡Beta | Selects high-loss image samples using a user-defined model and loss function. 使用用户自定义模型和损失函数选择高损失图像样本。 | [info](operators/selector/image_ohem_selector.md) | - |
 | random_selector | 💻CPU 🟢Stable | Randomly selects a subset of samples from the dataset. 从数据集中随机选择样本子集。 | [info](operators/selector/random_selector.md) | - |
 | range_specified_field_selector | 💻CPU 🟢Stable | Selects a range of samples based on the sorted values of a specified field. 根据指定字段的排序值选择采样范围。 | [info](operators/selector/range_specified_field_selector.md) | - |
 | tags_specified_field_selector | 💻CPU 🟢Stable | Selector to filter samples based on the tags of a specified field. 选择器根据指定字段的标签过滤样本。 | [info](operators/selector/tags_specified_field_selector.md) | - |

--- a/docs/operators/selector/image_ohem_selector.md
+++ b/docs/operators/selector/image_ohem_selector.md
@@ -1,0 +1,54 @@
+# image_ohem_selector
+
+Select image samples with the highest user-defined per-sample loss. This is an
+offline OHEM selector: it scores the complete dataset and retains the highest-loss
+`top_ratio` or `topk` samples.
+
+The user Python file may define:
+
+```python
+def model_factory(checkpoint):
+    model = load_your_model(checkpoint)
+    return model
+
+
+def score_fn(model, samples, images, device, **kwargs):
+    # images is a list of image lists, one list for each sample.
+    # Return exactly one numeric loss for every sample.
+    return compute_per_sample_losses(model, samples, images, device)
+```
+
+Example configuration:
+
+```yaml
+process:
+  - image_ohem_selector:
+      score_file: /path/to/ohem_functions.py
+      model_function: model_factory
+      score_function: score_fn
+      model_kwargs:
+        checkpoint: /path/to/model.pt
+      top_ratio: 0.3
+      batch_size: 32
+      device: cuda
+```
+
+When both `top_ratio` and `topk` are specified, the smaller resulting sample count
+is used. The computed loss is stored in `__dj__stats__.image_ohem_loss` by default.
+
+Type: **selector**
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---:|---|
+| `score_file` | `""` | Python file containing the user functions. |
+| `score_function` | `score_fn` | Per-sample loss function name. |
+| `model_function` | `model_factory` | Optional model factory name. |
+| `top_ratio` | `None` | Fraction of highest-loss samples to retain. |
+| `topk` | `None` | Maximum number of highest-loss samples to retain. |
+| `batch_size` | `8` | Number of samples passed to `score_fn` at once. |
+| `loss_field` | `image_ohem_loss` | Loss key inside `__dj__stats__`. |
+| `device` | `auto` | Device string passed to the user functions. |
+| `model_kwargs` | `{}` | Keyword arguments for `model_factory`. |
+| `score_kwargs` | `{}` | Extra keyword arguments for `score_fn`. |

--- a/docs/operators/selector/image_ohem_selector.md
+++ b/docs/operators/selector/image_ohem_selector.md
@@ -1,46 +1,163 @@
 # image_ohem_selector
 
 Select image samples with the highest user-defined per-sample loss. This is an
-offline OHEM selector: it scores the complete dataset and retains the highest-loss
-`top_ratio` or `topk` samples.
+offline hard-example selector: it scores the complete dataset and retains the
+highest-loss `top_ratio` or `topk` samples.
 
-The user Python file may define:
+The selector performs these steps:
 
-```python
-def model_factory(checkpoint):
-    model = load_your_model(checkpoint)
-    return model
+1. Load the user model by calling `model_factory(**model_kwargs)`.
+2. Load each sample's images and pass batches to `score_fn`.
+3. Require exactly one finite loss value for every sample.
+4. Store the loss in `__dj__stats__.image_ohem_loss` by default.
+5. Rank all samples by loss in descending order and retain the requested amount.
 
-
-def score_fn(model, samples, images, device, **kwargs):
-    # images is a list of image lists, one list for each sample.
-    # Return exactly one numeric loss for every sample.
-    return compute_per_sample_losses(model, samples, images, device)
-```
-
-Example configuration:
-
-```yaml
-process:
-  - image_ohem_selector:
-      score_file: /path/to/ohem_functions.py
-      model_function: model_factory
-      score_function: score_fn
-      model_kwargs:
-        checkpoint: /path/to/model.pt
-      top_ratio: 0.3
-      batch_size: 32
-      device: cuda
-```
-
-When both `top_ratio` and `topk` are specified, the smaller resulting sample count
-is used. The computed loss is stored in `__dj__stats__.image_ohem_loss` by default.
+> [!IMPORTANT]
+> This Beta selector currently supports the local dataset execution path only.
+> It scores batches serially at dataset level and is not supported by the Ray
+> executor. It implements offline hard-example selection, not OHEM inside a
+> model training loop.
 
 Type 算子类型: **selector**
 
 Tags 标签: image, gpu
 
-## Parameters
+## Input data
+
+The selector does not prescribe a label schema. The user-defined `score_fn`
+reads task-specific labels, bounding boxes, masks, or other fields directly from
+each sample. A classification sample may look like:
+
+```json
+{"images":["/data/images/cat.jpg"],"label":282}
+```
+
+`images` is normally a list. A sample may contain multiple images, but
+`score_fn` must combine them into one sample-level loss.
+
+## User functions
+
+`score_file` must be a Python file containing a score function and, optionally,
+a model factory:
+
+```python
+def model_factory(**model_kwargs):
+    return model
+
+
+def score_fn(model, samples, images, device, **score_kwargs):
+    return per_sample_losses
+```
+
+The arguments passed to `score_fn` are:
+
+- `model`: the object returned by `model_factory`, or `None` if no factory is
+  provided.
+- `samples`: a list of the original sample dictionaries in the current batch.
+- `images`: a list of image lists. `images[i]` contains the loaded PIL images
+  for `samples[i]`.
+- `device`: the configured device, such as `cpu` or `cuda`.
+- `score_kwargs`: additional values from the operator configuration.
+
+The return value must contain exactly one finite numeric loss per sample. A
+PyTorch tensor with shape `[batch_size]` or a list of floats is accepted. A
+single batch-mean loss is not accepted.
+
+## Classification example
+
+The following `/data/ohem_functions.py` example uses a pretrained ImageNet
+ResNet-18. The input `label` values must use the ImageNet class indices from 0 to
+999.
+
+```python
+import torch
+from torchvision.models import ResNet18_Weights, resnet18
+
+
+weights = ResNet18_Weights.DEFAULT
+transform = weights.transforms()
+
+
+def model_factory():
+    return resnet18(weights=weights)
+
+
+def score_fn(model, samples, images, device):
+    image_tensors = [transform(sample_images[0]) for sample_images in images]
+    inputs = torch.stack(image_tensors).to(device)
+    labels = torch.tensor(
+        [sample["label"] for sample in samples],
+        dtype=torch.long,
+        device=device,
+    )
+
+    with torch.inference_mode():
+        logits = model(inputs)
+        return torch.nn.functional.cross_entropy(
+            logits,
+            labels,
+            reduction="none",
+        )
+```
+
+Use it in a Data Juicer recipe:
+
+```yaml
+process:
+  - image_ohem_selector:
+      score_file: /data/ohem_functions.py
+      model_function: model_factory
+      score_function: score_fn
+      top_ratio: 0.3
+      batch_size: 32
+      device: cuda
+      image_key: images
+      image_bytes_key: image_bytes
+      loss_field: image_ohem_loss
+```
+
+This configuration retains the 30% of samples with the highest loss. To retain
+a fixed number instead, use:
+
+```yaml
+top_ratio: null
+topk: 10000
+```
+
+When both `top_ratio` and `topk` are specified, the smaller resulting sample
+count is used.
+
+## Image loading
+
+For every image position, the selector first checks `image_bytes_key`. Valid
+bytes are loaded directly; a missing, invalid, or `None` entry falls back to the
+corresponding path in `image_key`.
+
+```json
+{
+  "images": ["unavailable-a.jpg", "/data/images/b.jpg"],
+  "image_bytes": ["<bytes for image A>", null]
+}
+```
+
+In this example, the first image is loaded from bytes and the second image is
+loaded from `/data/images/b.jpg`.
+
+## Output data
+
+The selected samples retain their computed loss:
+
+```json
+{
+  "images": ["/data/images/cat.jpg"],
+  "label": 282,
+  "__dj__stats__": {
+    "image_ohem_loss": 1.37
+  }
+}
+```
+
+## Parameter configuration
 
 | Parameter | Default | Description |
 |---|---:|---|
@@ -50,7 +167,24 @@ Tags 标签: image, gpu
 | `top_ratio` | `None` | Fraction of highest-loss samples to retain. |
 | `topk` | `None` | Maximum number of highest-loss samples to retain. |
 | `batch_size` | `8` | Number of samples passed to `score_fn` at once. |
+| `image_key` | `images` | Field containing image paths. |
+| `image_bytes_key` | `image_bytes` | Image bytes field; missing entries fall back to paths. |
 | `loss_field` | `image_ohem_loss` | Loss key inside `__dj__stats__`. |
-| `device` | `auto` | Device string passed to the user functions. |
+| `device` | `auto` | Device passed to user functions. |
 | `model_kwargs` | `{}` | Keyword arguments for `model_factory`. |
 | `score_kwargs` | `{}` | Extra keyword arguments for `score_fn`. |
+
+## Common errors
+
+- Returning one batch-mean loss instead of one loss per sample.
+- Returning NaN or infinite loss values.
+- Using labels that do not match the model's class indices.
+- Returning a loss list whose length differs from the batch size.
+- Referencing a `score_file`, checkpoint, or image path unavailable on the
+  machine running Data Juicer.
+
+## Related links
+
+- [Source code](../../../data_juicer/ops/selector/image_ohem_selector.py)
+- [Unit test](../../../tests/ops/selector/test_image_ohem_selector.py)
+- [Operator list](../../Operators.md)

--- a/docs/operators/selector/image_ohem_selector.md
+++ b/docs/operators/selector/image_ohem_selector.md
@@ -36,7 +36,9 @@ process:
 When both `top_ratio` and `topk` are specified, the smaller resulting sample count
 is used. The computed loss is stored in `__dj__stats__.image_ohem_loss` by default.
 
-Type: **selector**
+Type 算子类型: **selector**
+
+Tags 标签: image, gpu
 
 ## Parameters
 

--- a/tests/ops/selector/test_image_ohem_selector.py
+++ b/tests/ops/selector/test_image_ohem_selector.py
@@ -1,5 +1,9 @@
+import io
+import sys
 import tempfile
 import unittest
+
+from PIL import Image
 
 from data_juicer.core.data import NestedDataset as Dataset
 from data_juicer.ops.selector.image_ohem_selector import ImageOHEMSelector
@@ -18,9 +22,9 @@ class ImageOHEMSelectorTest(DataJuicerTestCaseBase):
             calls.append(len(samples))
             return [sample["id"] for sample in samples]
 
-        result = ImageOHEMSelector(
-            score_fn=score_fn, top_ratio=0.4, batch_size=2, device="cpu"
-        ).process(self._dataset())
+        result = ImageOHEMSelector(score_fn=score_fn, top_ratio=0.4, batch_size=2, device="cpu").process(
+            self._dataset()
+        )
 
         self.assertEqual(calls, [2, 2, 1])
         self.assertEqual([sample["id"] for sample in result], [4, 3])
@@ -57,6 +61,117 @@ class ImageOHEMSelectorTest(DataJuicerTestCaseBase):
             ).process(self._dataset())
         self.assertEqual(result[0]["id"], 4)
         self.assertEqual(result[0]["__dj__stats__"]["image_ohem_loss"], 10.0)
+
+    def test_load_dataclass_from_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+") as score_file:
+            score_file.write(
+                "from __future__ import annotations\n"
+                "from dataclasses import dataclass\n\n"
+                "@dataclass\n"
+                "class ScoreConfig:\n"
+                "    offset: float = 1.0\n\n"
+                "def score_fn(model, samples, images, device):\n"
+                "    config = ScoreConfig()\n"
+                "    return [sample['id'] + config.offset for sample in samples]\n"
+            )
+            score_file.flush()
+            selector = ImageOHEMSelector(score_file=score_file.name, topk=1, device="cpu")
+            result = selector.process(self._dataset())
+
+        self.assertIn(selector._module_name, sys.modules)
+        self.assertEqual(result[0]["id"], 4)
+        sys.modules.pop(selector._module_name, None)
+
+    def test_score_modules_have_unique_names(self):
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+") as score_file:
+            score_file.write("def score_fn(model, samples, images, device):\n    return [0] * len(samples)\n")
+            score_file.flush()
+            first_selector = ImageOHEMSelector(score_file=score_file.name, topk=1)
+            second_selector = ImageOHEMSelector(score_file=score_file.name, topk=1)
+
+        self.assertNotEqual(first_selector._module_name, second_selector._module_name)
+        sys.modules.pop(first_selector._module_name, None)
+        sys.modules.pop(second_selector._module_name, None)
+
+    def test_failed_module_is_removed(self):
+        module_names_before = set(sys.modules)
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+") as score_file:
+            score_file.write("raise RuntimeError('module load failed')\n")
+            score_file.flush()
+            with self.assertRaisesRegex(RuntimeError, "module load failed"):
+                ImageOHEMSelector(score_file=score_file.name, topk=1)
+
+        new_module_names = set(sys.modules) - module_names_before
+        self.assertFalse(any(name.startswith("data_juicer_image_ohem_") for name in new_module_names))
+
+    def test_load_images_from_bytes_only(self):
+        first_image = Image.new("RGB", (3, 2), color="red")
+        first_image_buffer = io.BytesIO()
+        first_image.save(first_image_buffer, format="PNG")
+        selector = ImageOHEMSelector(score_fn=lambda *args: [], topk=1)
+        images = selector._images(
+            {
+                "images": ["/path/does/not/exist.png"],
+                "image_bytes": [first_image_buffer.getvalue()],
+            }
+        )
+        self.assertEqual(images[0].size, (3, 2))
+
+    def test_load_images_with_partial_bytes(self):
+        first_image = Image.new("RGB", (3, 2), color="red")
+        first_image_buffer = io.BytesIO()
+        first_image.save(first_image_buffer, format="PNG")
+
+        with tempfile.NamedTemporaryFile(suffix=".png") as second_image_file:
+            Image.new("RGB", (5, 4), color="blue").save(second_image_file.name)
+            selector = ImageOHEMSelector(score_fn=lambda *args: [], topk=1)
+            images = selector._images(
+                {
+                    "images": ["/path/does/not/exist.png", second_image_file.name],
+                    "image_bytes": [first_image_buffer.getvalue(), None],
+                }
+            )
+
+        self.assertEqual([image.size for image in images], [(3, 2), (5, 4)])
+
+    def test_release_model_after_success_and_error(self):
+        class Model:
+            def __init__(self):
+                self.devices = []
+
+            def to(self, device):
+                self.devices.append(device)
+                return self
+
+            def eval(self):
+                return self
+
+        success_model = Model()
+        success_selector = ImageOHEMSelector(
+            model_factory=lambda: success_model,
+            score_fn=lambda model, samples, images, device: [sample["id"] for sample in samples],
+            topk=1,
+            device="cuda",
+        )
+        success_selector.process(self._dataset())
+        self.assertIsNone(success_selector._model)
+        self.assertEqual(success_model.devices, ["cuda", "cpu"])
+
+        failed_model = Model()
+
+        def failed_score_fn(model, samples, images, device):
+            raise RuntimeError("scoring failed")
+
+        failed_selector = ImageOHEMSelector(
+            model_factory=lambda: failed_model,
+            score_fn=failed_score_fn,
+            topk=1,
+            device="cuda",
+        )
+        with self.assertRaisesRegex(RuntimeError, "scoring failed"):
+            failed_selector.process(self._dataset())
+        self.assertIsNone(failed_selector._model)
+        self.assertEqual(failed_model.devices, ["cuda", "cpu"])
 
     def test_reject_wrong_number_of_losses(self):
         selector = ImageOHEMSelector(

--- a/tests/ops/selector/test_image_ohem_selector.py
+++ b/tests/ops/selector/test_image_ohem_selector.py
@@ -1,0 +1,81 @@
+import tempfile
+import unittest
+
+from data_juicer.core.data import NestedDataset as Dataset
+from data_juicer.ops.selector.image_ohem_selector import ImageOHEMSelector
+from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
+
+
+class ImageOHEMSelectorTest(DataJuicerTestCaseBase):
+    @staticmethod
+    def _dataset():
+        return Dataset.from_list([{"id": i, "images": []} for i in range(5)])
+
+    def test_select_top_ratio_and_attach_loss(self):
+        calls = []
+
+        def score_fn(model, samples, images, device, **kwargs):
+            calls.append(len(samples))
+            return [sample["id"] for sample in samples]
+
+        result = ImageOHEMSelector(
+            score_fn=score_fn, top_ratio=0.4, batch_size=2, device="cpu"
+        ).process(self._dataset())
+
+        self.assertEqual(calls, [2, 2, 1])
+        self.assertEqual([sample["id"] for sample in result], [4, 3])
+        self.assertEqual(
+            [sample["__dj__stats__"]["image_ohem_loss"] for sample in result],
+            [4.0, 3.0],
+        )
+
+    def test_topk_limits_ratio(self):
+        result = ImageOHEMSelector(
+            score_fn=lambda model, samples, images, device: [sample["id"] for sample in samples],
+            top_ratio=1.0,
+            topk=2,
+            device="cpu",
+        ).process(self._dataset())
+        self.assertEqual([sample["id"] for sample in result], [4, 3])
+
+    def test_load_functions_from_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w+") as score_file:
+            score_file.write(
+                "def model_factory(offset=0):\n"
+                "    return {'offset': offset}\n\n"
+                "def score_fn(model, samples, images, device, multiplier=1):\n"
+                "    return [(sample['id'] + model['offset']) * multiplier "
+                "for sample in samples]\n"
+            )
+            score_file.flush()
+            result = ImageOHEMSelector(
+                score_file=score_file.name,
+                model_kwargs={"offset": 1},
+                score_kwargs={"multiplier": 2},
+                topk=1,
+                device="cpu",
+            ).process(self._dataset())
+        self.assertEqual(result[0]["id"], 4)
+        self.assertEqual(result[0]["__dj__stats__"]["image_ohem_loss"], 10.0)
+
+    def test_reject_wrong_number_of_losses(self):
+        selector = ImageOHEMSelector(
+            score_fn=lambda model, samples, images, device: [1.0],
+            topk=1,
+            batch_size=2,
+            device="cpu",
+        )
+        with self.assertRaisesRegex(ValueError, "one loss per sample"):
+            selector.process(self._dataset())
+
+    def test_validate_parameters(self):
+        with self.assertRaises(ValueError):
+            ImageOHEMSelector(score_fn=lambda *args: [], top_ratio=1.1)
+        with self.assertRaises(ValueError):
+            ImageOHEMSelector(score_fn=lambda *args: [], topk=-1)
+        with self.assertRaises(ValueError):
+            ImageOHEMSelector(score_fn=lambda *args: [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Add a generic image OHEM selector for retaining high-loss image samples.

## Changes

- Add `image_ohem_selector`
- Support user-defined model factory and per-sample loss function
- Support `top_ratio` and `topk`
- Add documentation and unit tests

## Algorithm

For each image sample, the user-defined scoring function computes an individual training loss. After scoring the dataset, samples are sorted by loss in descending order. The selector keeps the specified top-k or top-ratio samples and filters out low-loss samples. The computed losses are also cached in the sample statistics for later analysis or reuse.

## Testing

- `python3 -m py_compile ...`
- `git diff --check`