### PR TITLE
perf(filter): bound token-count tokenizer batches

### DIFF
--- a/data_juicer/ops/filter/token_num_filter.py
+++ b/data_juicer/ops/filter/token_num_filter.py
@@ -6,6 +6,7 @@ from data_juicer.utils.model_utils import get_model, prepare_model
 from ..base_op import OPERATORS, Filter
 
 OP_NAME = "token_num_filter"
+_TOKENIZATION_BATCH_SIZE = 128
 
 
 @OPERATORS.register_module(OP_NAME)
@@ -63,9 +64,16 @@ class TokenNumFilter(Filter):
 
         if texts:
             tokenizer = get_model(self.model_key)
-            encoded = tokenizer(texts, add_special_tokens=False)
-            for i, idx in enumerate(indices):
-                samples_stats[idx][StatsKeys.num_token] = len(encoded["input_ids"][i])
+            token_counts = []
+            for start in range(0, len(texts), _TOKENIZATION_BATCH_SIZE):
+                text_batch = texts[start : start + _TOKENIZATION_BATCH_SIZE]
+                encoded = tokenizer(text_batch, add_special_tokens=False)
+                input_ids = encoded["input_ids"]
+                for index in range(len(text_batch)):
+                    token_counts.append(len(input_ids[index]))
+                del input_ids, encoded, text_batch
+            for idx, token_count in zip(indices, token_counts):
+                samples_stats[idx][StatsKeys.num_token] = token_count
 
         return samples
 

--- a/tests/ops/filter/test_token_num_filter_bounded_batch.py
+++ b/tests/ops/filter/test_token_num_filter_bounded_batch.py
@@ -1,0 +1,209 @@
+import random
+from unittest import mock
+
+import pytest
+
+from data_juicer.ops.filter import token_num_filter as token_num_module
+from data_juicer.ops.filter.token_num_filter import TokenNumFilter
+from data_juicer.utils.constant import Fields, StatsKeys
+
+
+def _token_ids(text):
+    return list(text.encode("utf-8")) + [0] * len(text.split())
+
+
+class RecordingTokenizer:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, texts, **kwargs):
+        self.calls.append((list(texts), kwargs))
+        input_ids = [_token_ids(text) for text in texts]
+        return {
+            "input_ids": input_ids,
+            "attention_mask": [[1] * len(ids) for ids in input_ids],
+        }
+
+
+def test_tokenizes_uncached_rows_in_bounded_batches():
+    tokenizer = RecordingTokenizer()
+    op = TokenNumFilter(hf_tokenizer="unused")
+    cached_indices = {3, 200}
+    payload = object()
+    samples = {
+        "text": [f"row-{index}" for index in range(259)],
+        Fields.stats: [
+            ({StatsKeys.num_token: 99, "marker": index} if index in cached_indices else {"marker": index})
+            for index in range(259)
+        ],
+        "payload": payload,
+    }
+
+    with mock.patch.object(token_num_module, "get_model", return_value=tokenizer) as get_model_mock:
+        returned = op.compute_stats_batched(samples)
+
+    assert returned is samples
+    assert samples["payload"] is payload
+    get_model_mock.assert_called_once_with(op.model_key)
+    assert [len(texts) for texts, _kwargs in tokenizer.calls] == [128, 128, 1]
+    assert all(kwargs == {"add_special_tokens": False} for _texts, kwargs in tokenizer.calls)
+    assert [text for texts, _kwargs in tokenizer.calls for text in texts] == [
+        text for index, text in enumerate(samples["text"]) if index not in cached_indices
+    ]
+    assert [stat["marker"] for stat in samples[Fields.stats]] == list(range(259))
+    assert [stat[StatsKeys.num_token] for stat in samples[Fields.stats]] == [
+        99 if index in cached_indices else len(_token_ids(text)) for index, text in enumerate(samples["text"])
+    ]
+
+
+@pytest.mark.parametrize(
+    ("uncached_rows", "expected_batch_sizes"),
+    [
+        (0, []),
+        (1, [1]),
+        (127, [127]),
+        (128, [128]),
+        (129, [128, 1]),
+        (255, [128, 127]),
+        (256, [128, 128]),
+        (257, [128, 128, 1]),
+    ],
+)
+def test_tokenization_batch_boundaries(uncached_rows, expected_batch_sizes):
+    tokenizer = RecordingTokenizer()
+    op = TokenNumFilter(hf_tokenizer="unused")
+    samples = {
+        "text": [f"boundary {index}" for index in range(uncached_rows)],
+        Fields.stats: [{} for _index in range(uncached_rows)],
+    }
+
+    with mock.patch.object(token_num_module, "get_model", return_value=tokenizer):
+        op.compute_stats_batched(samples)
+
+    assert [len(texts) for texts, _kwargs in tokenizer.calls] == expected_batch_sizes
+    assert [stat[StatsKeys.num_token] for stat in samples[Fields.stats]] == [
+        len(_token_ids(text)) for text in samples["text"]
+    ]
+
+
+def test_fully_cached_batch_bypasses_tokenizer():
+    op = TokenNumFilter(hf_tokenizer="unused")
+    samples = {
+        "text": ["cached", "缓存", "🙂"],
+        Fields.stats: [
+            {StatsKeys.num_token: 7, "marker": 0},
+            {StatsKeys.num_token: 8, "marker": 1},
+            {StatsKeys.num_token: 9, "marker": 2},
+        ],
+    }
+
+    with mock.patch.object(token_num_module, "get_model") as get_model_mock:
+        returned = op.compute_stats_batched(samples)
+
+    assert returned is samples
+    get_model_mock.assert_not_called()
+    assert samples[Fields.stats] == [
+        {StatsKeys.num_token: 7, "marker": 0},
+        {StatsKeys.num_token: 8, "marker": 1},
+        {StatsKeys.num_token: 9, "marker": 2},
+    ]
+
+
+def test_later_tokenizer_failure_does_not_partially_update_stats():
+    class FailingTokenizer:
+        def __init__(self):
+            self.batch_sizes = []
+
+        def __call__(self, texts, **_kwargs):
+            self.batch_sizes.append(len(texts))
+            if "explode" in texts:
+                raise RuntimeError("tokenizer failed on explode")
+            return {"input_ids": [[1] for _text in texts]}
+
+    tokenizer = FailingTokenizer()
+    op = TokenNumFilter(hf_tokenizer="unused")
+    samples = {
+        "text": ["ok"] * 128 + ["explode"],
+        Fields.stats: [{"marker": index} for index in range(129)],
+    }
+    expected_stats = [dict(stat) for stat in samples[Fields.stats]]
+
+    with mock.patch.object(token_num_module, "get_model", return_value=tokenizer):
+        with pytest.raises(RuntimeError, match="tokenizer failed on explode"):
+            op.compute_stats_batched(samples)
+
+    assert tokenizer.batch_sizes in ([129], [128, 1])
+    assert samples[Fields.stats] == expected_stats
+
+
+def test_releases_each_encoded_batch_before_tokenizing_the_next():
+    released_batches = []
+
+    class TrackedInputIds(list):
+        def __init__(self, batch_index, values):
+            super().__init__(values)
+            self.batch_index = batch_index
+
+        def __del__(self):
+            released_batches.append(self.batch_index)
+
+    class LifetimeCheckingTokenizer:
+        def __init__(self):
+            self.batch_sizes = []
+
+        def __call__(self, texts, **_kwargs):
+            if self.batch_sizes:
+                assert released_batches == [len(self.batch_sizes) - 1]
+            batch_index = len(self.batch_sizes)
+            self.batch_sizes.append(len(texts))
+            return {"input_ids": TrackedInputIds(batch_index, [[1] for _text in texts])}
+
+    tokenizer = LifetimeCheckingTokenizer()
+    op = TokenNumFilter(hf_tokenizer="unused")
+    samples = {
+        "text": [f"row-{index}" for index in range(129)],
+        Fields.stats: [{} for _index in range(129)],
+    }
+
+    with mock.patch.object(token_num_module, "get_model", return_value=tokenizer):
+        op.compute_stats_batched(samples)
+
+    assert tokenizer.batch_sizes == [128, 1]
+    assert released_batches == [0, 1]
+
+
+def test_randomized_counts_match_eager_reference():
+    rng = random.Random(20260806)
+    tokenizer = RecordingTokenizer()
+    op = TokenNumFilter(hf_tokenizer="unused")
+    alphabet = ["alpha", "two words", "中文", "🙂emoji", "", "tabs\tand\nlines"]
+
+    with mock.patch.object(token_num_module, "get_model", return_value=tokenizer):
+        for _case in range(200):
+            row_count = rng.randint(0, 350)
+            texts = [f"{rng.choice(alphabet)}-{index}-{rng.randint(0, 9999)}" for index in range(row_count)]
+            cached_indices = {index for index in range(row_count) if rng.random() < 0.25}
+            stats = [
+                (
+                    {StatsKeys.num_token: 10_000 + index, "marker": index}
+                    if index in cached_indices
+                    else {"marker": index}
+                )
+                for index in range(row_count)
+            ]
+            samples = {"text": texts, Fields.stats: stats}
+            calls_before = len(tokenizer.calls)
+
+            returned = op.compute_stats_batched(samples)
+
+            assert returned is samples
+            expected_counts = [
+                10_000 + index if index in cached_indices else len(_token_ids(text)) for index, text in enumerate(texts)
+            ]
+            assert [stat[StatsKeys.num_token] for stat in stats] == expected_counts
+            assert [stat["marker"] for stat in stats] == list(range(row_count))
+            new_calls = tokenizer.calls[calls_before:]
+            assert all(1 <= len(batch_texts) <= 128 for batch_texts, _kwargs in new_calls)
+            assert [text for batch_texts, _kwargs in new_calls for text in batch_texts] == [
+                text for index, text in enumerate(texts) if index not in cached_indices
+            ]


### PR DESCRIPTION
## Summary

- Tokenize at most 128 uncached rows per internal call instead of retaining token IDs for the full Data-Juicer batch.
- Reduce each encoded batch to scalar counts and release it before the next tokenizer call; publish stats only after every call succeeds.
- Preserve cached counts, row order, tokenizer arguments, failure atomicity, sibling fields, and filtering behavior with boundary and randomized differential tests.

Closes #1039.
Part of #1031.

## Benchmark

The reproducible harness is intentionally maintained outside this PR so normal CI does not execute the memory campaign:

- [benchmark branch](https://github.com/macroguo-ghy/data-juicer/tree/benchmark/token-num-bounded-batch)
- [script pinned at the measured commit](https://github.com/macroguo-ghy/data-juicer/blob/9d79acf9095ec664d13e09f90ceea02a550b40d1/tests/benchmark_performance/benchmark_token_num_bounded_batch.py)

### Controlled default-batch workload

The controlled tokenizer returns Hugging Face-shaped `input_ids` and `attention_mask` lists, with 1,024 token IDs per row. Every memory cell is the median of 5 fresh processes in randomized order; exact count digests matched at every size.

| Rows | Current eager RSS | Bounded RSS | RSS reduction | Current Python peak | Bounded Python peak | Python reduction |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 128 | 241.7 MiB | 241.3 MiB | 0.2% | 6.1 MiB | 6.1 MiB | 0.2% |
| 512 | 262.0 MiB | 242.9 MiB | 7.3% | 24.4 MiB | 6.2 MiB | 74.8% |
| 1,000 | 286.1 MiB | 243.1 MiB | 15.0% | 47.7 MiB | 6.2 MiB | 86.9% |

RSS growth decreased by 96.1%, and algorithm-local Python-allocation growth decreased by 99.7%. Maximum RSS sample CV was 2.62%.

### Real default Hugging Face tokenizer

The A/B harness used `EleutherAI/pythia-6.9b-deduped`; input rows produced 515-516 actual tokens each. Every memory cell is the median of 5 fresh processes, exact count digests matched, and maximum RSS sample CV was 5.49%.

| Rows | Current eager RSS | Bounded RSS | RSS reduction | Current Python peak | Bounded Python peak | Python reduction |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 128 | 553.5 MiB | 576.9 MiB | -4.2% | 3.2 MiB | 3.2 MiB | ~0% |
| 1,000 | 639.2 MiB | 562.0 MiB | 12.1% | 24.6 MiB | 3.3 MiB | 86.6% |

At 128 rows both implementations make one tokenizer call, so there is no mechanism-level allocation difference; the RSS reversal is process/model baseline noise. At the default 1,000 rows, peak RSS decreased by 77.2 MiB, and Python-allocation growth decreased by 99.4%.

Real-tokenizer latency used 256 rows with approximately 256 tokens per row, 3 fresh processes per variant, 40 observations per process, and 3 warmups (120 observations per variant). Process order was randomized.

| Current median | Bounded median | Throughput ratio | Bounded/current P95 |
| ---: | ---: | ---: | ---: |
| 34.232 ms | 31.072 ms | 1.102x | 1.081x |

Median throughput improved by 10.2%; P95 latency increased by 8.1%, within the normal 1.50x tail-latency budget.

Environment: Apple M2 Pro, 32 GiB RAM, macOS 26.2, Python 3.11.15. Full methodology, applicability, and remaining limits are recorded in #1039.

## Testing

```bash
PYTHONPATH="$PWD" python -m pytest -q \
  tests/ops/filter/test_token_num_filter.py \
  tests/ops/filter/test_token_num_filter_bounded_batch.py

PYTHONPATH="$PWD" python -m black --check \
  data_juicer/ops/filter/token_num_filter.py \
  tests/ops/filter/test_token_num_filter_bounded_batch.py

PYTHONPATH="$PWD" python -m flake8 \
  --max-line-length=120 --extend-ignore=E203,E501,BLK100,F541 \
  data_juicer/ops/filter/token_num_filter.py \
  tests/ops/filter/test_token_num_filter_bounded_batch.py
```

- 15 targeted tests passed, including the existing real-default-tokenizer tests and 13 focused cases added by this PR.
- Boundaries cover 0, 1, 127, 128, 129, 255, 256, and 257 uncached rows.
- 200 deterministic randomized cases cover cached/uncached mixtures, empty and Unicode text, exact counts and order, auxiliary outputs, object identity, and unrelated fields.
- Failure tests prove that a later internal tokenizer error leaves all uncached stats untouched, and lifetime tests prove each encoded batch is released before the next call.
