### PR TITLE
fix(deduplicator): reset hash_tables between process() calls

### DIFF
--- a/data_juicer/ops/deduplicator/document_minhash_deduplicator.py
+++ b/data_juicer/ops/deduplicator/document_minhash_deduplicator.py
@@ -282,6 +282,9 @@ class DocumentMinhashDeduplicator(Deduplicator):
         sample[HashKeys.minhash] = [bytes(hash_values[start:end].byteswap().data) for start, end in self.hash_ranges]
         return sample
 
+    def _reset_hash_tables(self):
+        self.hash_tables = [defaultdict(set) for _ in range(self.num_bands)]
+
     def process(self, dataset, show_num=0):
         """
         For doc-level, dataset --> dataset.
@@ -291,12 +294,11 @@ class DocumentMinhashDeduplicator(Deduplicator):
             open.
         :return: deduplicated dataset and the sampled duplicate pairs.
         """
+        self._reset_hash_tables()
+
         # no need to deduplicate because too few samples
         if len(dataset) <= 1:
             return dataset, {}
-
-        # Reset hash tables to avoid stale state from previous calls
-        self.hash_tables = [defaultdict(set) for _ in range(self.num_bands)]
 
         minhashes = dataset[HashKeys.minhash]
         # remove bytes minhash column otherwise unexpected error would occur
@@ -384,12 +386,11 @@ class DocumentMinhashDeduplicatorWithUid(DocumentMinhashDeduplicator):
             open.
         :return: deduplicated dataset and the sampled duplicate pairs.
         """
+        self._reset_hash_tables()
+
         # no need to deduplicate because too few samples
         if len(dataset) <= 1:
             return dataset, {}
-
-        # Reset hash tables to avoid stale state from previous calls
-        self.hash_tables = [defaultdict(set) for _ in range(self.num_bands)]
 
         minhashes = dataset[HashKeys.minhash]
         # remove bytes minhash column otherwise unexpected error would occur

--- a/data_juicer/ops/deduplicator/document_minhash_deduplicator.py
+++ b/data_juicer/ops/deduplicator/document_minhash_deduplicator.py
@@ -295,6 +295,9 @@ class DocumentMinhashDeduplicator(Deduplicator):
         if len(dataset) <= 1:
             return dataset, {}
 
+        # Reset hash tables to avoid stale state from previous calls
+        self.hash_tables = [defaultdict(set) for _ in range(self.num_bands)]
+
         minhashes = dataset[HashKeys.minhash]
         # remove bytes minhash column otherwise unexpected error would occur
         # when exporting the processed dataset
@@ -384,6 +387,9 @@ class DocumentMinhashDeduplicatorWithUid(DocumentMinhashDeduplicator):
         # no need to deduplicate because too few samples
         if len(dataset) <= 1:
             return dataset, {}
+
+        # Reset hash tables to avoid stale state from previous calls
+        self.hash_tables = [defaultdict(set) for _ in range(self.num_bands)]
 
         minhashes = dataset[HashKeys.minhash]
         # remove bytes minhash column otherwise unexpected error would occur

--- a/tests/ops/deduplicator/test_document_minhash_deduplicator.py
+++ b/tests/ops/deduplicator/test_document_minhash_deduplicator.py
@@ -977,3 +977,81 @@ class DocumentMinhashDeduplicatorTest(DataJuicerTestCaseBase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class DocumentMinhashDeduplicatorRepeatedCallTest(DataJuicerTestCaseBase):
+    """Regression test: process() must not leak state between calls."""
+
+    def test_repeated_process_no_pollution(self):
+        """Calling process() twice on the same operator with disjoint datasets
+        must produce identical results to calling it once on each dataset
+        independently."""
+        from data_juicer.ops.deduplicator.document_minhash_deduplicator import (
+            DocumentMinhashDeduplicator,
+        )
+
+        # Two completely unrelated datasets
+        ds_a = Dataset.from_list([
+            {'text': 'The quick brown fox jumps over the lazy dog'},
+            {'text': 'A completely unique sentence about quantum physics'},
+        ])
+        ds_b = Dataset.from_list([
+            {'text': 'Pack my box with five dozen liquor jugs'},
+            {'text': 'How vexingly quick daft zebras jump'},
+        ])
+
+        op = DocumentMinhashDeduplicator(
+            tokenization='space',
+            num_permutations=128,
+            jaccard_threshold=0.7,
+        )
+
+        # First call
+        ds_a_hashed = ds_a.map(op.compute_hash)
+        result_a, _ = op.process(ds_a_hashed)
+
+        # Second call on same operator instance — must not be affected by first
+        ds_b_hashed = ds_b.map(op.compute_hash)
+        result_b, _ = op.process(ds_b_hashed)
+
+        # Neither dataset has duplicates, so both should retain all samples
+        self.assertEqual(len(result_a), 2,
+                         "First process() call should keep both distinct samples")
+        self.assertEqual(len(result_b), 2,
+                         "Second process() call should not be polluted by the first")
+
+    def test_repeated_process_with_uid_no_pollution(self):
+        """Same test for the UID-based variant."""
+        from data_juicer.ops.deduplicator.document_minhash_deduplicator import (
+            DocumentMinhashDeduplicatorWithUid,
+        )
+        from data_juicer.utils.constant import HashKeys
+
+        ds_a = Dataset.from_list([
+            {'text': 'The quick brown fox jumps over the lazy dog',
+             HashKeys.uid: 0},
+            {'text': 'A completely unique sentence about quantum physics',
+             HashKeys.uid: 1},
+        ])
+        ds_b = Dataset.from_list([
+            {'text': 'Pack my box with five dozen liquor jugs',
+             HashKeys.uid: 0},
+            {'text': 'How vexingly quick daft zebras jump',
+             HashKeys.uid: 1},
+        ])
+
+        op = DocumentMinhashDeduplicatorWithUid(
+            tokenization='space',
+            num_permutations=128,
+            jaccard_threshold=0.7,
+        )
+
+        ds_a_hashed = ds_a.map(op.compute_hash)
+        result_a, _ = op.process(ds_a_hashed)
+
+        ds_b_hashed = ds_b.map(op.compute_hash)
+        result_b, _ = op.process(ds_b_hashed)
+
+        self.assertEqual(len(result_a), 2)
+        self.assertEqual(len(result_b), 2,
+                         "UID-based dedup must not carry state between process() calls")

--- a/tests/ops/deduplicator/test_document_minhash_deduplicator.py
+++ b/tests/ops/deduplicator/test_document_minhash_deduplicator.py
@@ -975,10 +975,6 @@ class DocumentMinhashDeduplicatorTest(DataJuicerTestCaseBase):
         self._run_minhash_dedup(dataset, tgt_list, op)
 
 
-if __name__ == '__main__':
-    unittest.main()
-
-
 class DocumentMinhashDeduplicatorRepeatedCallTest(DataJuicerTestCaseBase):
     """Regression test: process() must not leak state between calls."""
 
@@ -1055,3 +1051,7 @@ class DocumentMinhashDeduplicatorRepeatedCallTest(DataJuicerTestCaseBase):
         self.assertEqual(len(result_a), 2)
         self.assertEqual(len(result_b), 2,
                          "UID-based dedup must not carry state between process() calls")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Reproduction

The same 3-sample dataset processed with the same parameters gives **different deduplication results** depending on whether the operator was previously used on other data.

```python
from datasets import Dataset
from data_juicer.ops.deduplicator.document_minhash_deduplicator import (
    DocumentMinhashDeduplicator,
)

target = Dataset.from_list([
    {"text": "the cat sat on the mat by the door"},
    {"text": "the dog sat on the rug by the window"},
    {"text": "a fish swam in the tank near the light"},
])

op = DocumentMinhashDeduplicator(
    tokenization="space", num_permutations=16, jaccard_threshold=0.5,
)

# Process some other data first (simulating a probe/preview run)
warmup = Dataset.from_list([
    {"text": "the cat sat on the mat by the door today"},
    {"text": "the cat lay on the mat by the wall yesterday"},
    {"text": "the dog sat on the rug by the window again"},
    {"text": "the dog lay on the rug by the curtain now"},
    {"text": "some unrelated text about cooking pasta sauce"},
    {"text": "another sentence about hiking in the mountains"},
])
op.process(warmup.map(op.compute_hash))

# Now process our target dataset on the same operator instance
result, _ = op.process(target.map(op.compute_hash))
print(f"Reused operator: {len(result)}/3 retained")

# Compare with a fresh operator
op_fresh = DocumentMinhashDeduplicator(
    tokenization="space", num_permutations=16, jaccard_threshold=0.5,
)
result_fresh, _ = op_fresh.process(target.map(op_fresh.compute_hash))
print(f"Fresh operator:  {len(result_fresh)}/3 retained")
```

### Before fix

```
Reused operator: 2/3 retained
Fresh operator:  3/3 retained
```

Same input, same parameters — **1 sample falsely deduplicated** because stale hash-table entries from the warmup run caused a spurious UnionFind merge.

### After fix

```
Reused operator: 3/3 retained
Fresh operator:  3/3 retained
```

Results are identical regardless of operator history.

## Root cause

`self.hash_tables` (list of `defaultdict(set)`) is created once in `__init__` and populated with sample indices inside `process()`, but never cleared between calls. Index entries from a prior `process()` call persist and participate in clustering on subsequent calls, merging unrelated samples.

## Fix

Reset `self.hash_tables` at the top of `process()`:
```python
self.hash_tables = [defaultdict(set) for _ in range(self.num_bands)]
```

Applied to both `DocumentMinhashDeduplicator` and `DocumentMinhashDeduplicatorWithUid`.

## Tests added

`DocumentMinhashDeduplicatorRepeatedCallTest` — calls `process()` twice on the same operator instance with disjoint datasets, asserts no cross-contamination. Covers both the base class and the UID variant.