### PR TITLE
feat(partition): cluster-aware auto partition count (num_of_partitions: auto)

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -715,9 +715,25 @@ def build_base_parser() -> ArgumentParser:
     )
     parser.add_argument(
         "--partition.num_of_partitions",
-        type=int,
+        type=Union[PositiveInt, Literal["auto"]],
         default=4,
-        help="Number of partitions for manual mode (ignored in auto mode)",
+        help=(
+            "Number of partitions for manual mode (ignored in auto mode). "
+            "In auto mode, 'auto' derives a cluster-aware count; a positive "
+            "integer acts as the data-driven ceiling for the cluster-aware "
+            "adjustment."
+        ),
+    )
+    parser.add_argument(
+        "--partition.partitions_per_node",
+        type=Union[PositiveInt, Literal["auto"]],
+        default="auto",
+        help=(
+            "Per-node partition multiplier used by the cluster-aware auto "
+            "partition count. 'auto' uses per-node GPU slots for GPU "
+            "pipelines (2x for CPU-only pipelines); set a positive integer "
+            "to override."
+        ),
     )
     parser.add_argument(
         "--partition.max_concurrent_partitions",

--- a/data_juicer/config/config_all.yaml
+++ b/data_juicer/config/config_all.yaml
@@ -86,7 +86,8 @@ override_num_blocks: null                                   # override the numbe
 # partition configuration (for ray_partitioned executor)
 partition:
   mode: auto                                                # partition mode: "auto" (use optimizer) or "manual" (specify count)
-  num_of_partitions: 4                                      # number of partitions for manual mode
+  num_of_partitions: 4                                      # number of partitions for manual mode; "auto" derives a cluster-aware count in auto mode (floor = nodes x partitions_per_node / resolved concurrency, ceiling = optimizer estimate)
+  partitions_per_node: auto                                 # per-node partition multiplier for auto mode; "auto" uses per-node GPU slots for GPU pipelines (2x for CPU-only), set a positive integer to override
   max_concurrent_partitions: auto                           # resource-aware driver concurrency; set a positive integer to override
   target_size_mb: 256                                       # target partition size in MB for auto mode (128, 256, 512, or 1024). 256MB balances memory safety and efficiency.
 

--- a/data_juicer/core/executor/partition_size_optimizer.py
+++ b/data_juicer/core/executor/partition_size_optimizer.py
@@ -134,32 +134,19 @@ class ResourceDetector:
             if not ray.is_initialized():
                 return None
 
-            # Get cluster resources
-            cluster_resources = ray.cluster_resources()
-            available_resources = ray.available_resources()
+            # Single source of truth for cluster topology (real alive node
+            # count plus cluster-wide CPU/GPU totals).
+            from data_juicer.utils.ray_cluster_utils import detect_cluster_topology
 
-            # Parse resources
-            total_cpu = cluster_resources.get("CPU", 0)
-            total_memory = cluster_resources.get("memory", 0) / (1024**3)  # Convert to GB
-            available_cpu = available_resources.get("CPU", 0)
-            available_memory = available_resources.get("memory", 0) / (1024**3)
-
-            # Count nodes (approximate)
-            num_nodes = max(1, int(total_cpu / 8))  # Assume 8 cores per node
-
-            # GPU resources
-            gpu_resources = {}
-            for key, value in cluster_resources.items():
-                if key.startswith("GPU"):
-                    gpu_resources[key] = value
+            topology = detect_cluster_topology()
 
             return ClusterResources(
-                num_nodes=num_nodes,
-                total_cpu_cores=int(total_cpu),
-                total_memory_gb=total_memory,
-                available_cpu_cores=int(available_cpu),
-                available_memory_gb=available_memory,
-                gpu_resources=gpu_resources,
+                num_nodes=topology.num_nodes,
+                total_cpu_cores=int(topology.total_cpus),
+                total_memory_gb=ray.cluster_resources().get("memory", 0) / (1024**3),
+                available_cpu_cores=int(topology.available_cpus),
+                available_memory_gb=ray.available_resources().get("memory", 0) / (1024**3),
+                gpu_resources={key: value for key, value in ray.cluster_resources().items() if key.startswith("GPU")},
             )
         except Exception as e:
             logger.warning(f"Could not detect Ray cluster resources: {e}")
@@ -184,9 +171,12 @@ class ResourceDetector:
         Returns:
             Optimal number of workers
         """
-        # Determine available CPU cores
+        # Determine available CPU cores. When a Ray cluster is present the
+        # cluster-wide capacity is authoritative: clamping it to the driver
+        # machine's core count would hide the real parallelism available to
+        # partitioned execution.
         if cluster_resources:
-            available_cores = min(local_resources.cpu_cores, cluster_resources.available_cpu_cores)
+            available_cores = max(cluster_resources.available_cpu_cores, 1)
         else:
             available_cores = local_resources.cpu_cores
 
@@ -706,10 +696,11 @@ class PartitionSizeOptimizer:
         if total_samples <= 10000:
             return 1  # Small datasets - prioritize 64MB target over parallelism
 
-        # For large datasets, aim for at least 1.5x CPU cores in partitions
+        # For large datasets, aim for at least 1.5x CPU cores in partitions.
+        # Cluster-wide capacity is authoritative when a Ray cluster exists.
         available_cores = local_resources.cpu_cores
         if cluster_resources:
-            available_cores = min(available_cores, cluster_resources.available_cpu_cores)
+            available_cores = max(cluster_resources.available_cpu_cores, 1)
 
         return max(1, int(available_cores * 1.5))
 
@@ -774,12 +765,21 @@ class PartitionSizeOptimizer:
 
     def get_partition_recommendations(self, dataset, process_pipeline: List) -> Dict:
         """Get comprehensive partition recommendations."""
-        optimal_size, optimal_max_size_mb = self.get_optimal_partition_size(dataset, process_pipeline)
+        # Analyze the dataset once and reuse the characteristics for both
+        # sizing and worker-count calculation (avoids double sampling).
         characteristics = self.analyze_dataset_characteristics(dataset)
+        complexity_multiplier = self.analyze_processing_complexity(process_pipeline)
+        characteristics.processing_complexity_score = complexity_multiplier
 
-        # Detect resources
         local_resources = self.resource_detector.detect_local_resources()
         cluster_resources = self.resource_detector.detect_ray_cluster()
+
+        optimal_size = self.calculate_resource_aware_partition_size(
+            characteristics, local_resources, cluster_resources, complexity_multiplier
+        )
+        optimal_max_size_mb = self.calculate_optimal_max_size_mb(
+            characteristics, local_resources, cluster_resources, complexity_multiplier
+        )
 
         # Calculate optimal worker count
         optimal_workers = self.resource_detector.calculate_optimal_worker_count(

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -359,6 +359,31 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
             else:
                 logger.warning("Legacy num_partitions detected, overriding partition configuration")
 
+        # Cluster-aware auto mode: the sentinel "auto" as a partition count
+        # requests a count derived from cluster topology (node count and
+        # resolved driver concurrency) instead of a fixed integer. A plain
+        # integer always wins, so larger/smaller counts stay one config key
+        # away. Numeric strings are normalized so YAML/CLI typing quirks do
+        # not flip modes silently.
+        partitions_per_node = ConfigAccessor.get(partition_cfg, "partitions_per_node", "auto")
+        if isinstance(num_of_partitions, str):
+            sentinel = num_of_partitions.strip().lower()
+            if sentinel == "auto":
+                mode = "auto"
+                num_of_partitions = 4  # placeholder until dataset/cluster analysis runs
+            else:
+                try:
+                    num_of_partitions = int(sentinel)
+                except ValueError:
+                    logger.warning(
+                        f"Invalid partition.num_of_partitions={num_of_partitions!r}; " "falling back to auto mode"
+                    )
+                    mode = "auto"
+                    num_of_partitions = 4
+        if isinstance(num_of_partitions, float):
+            num_of_partitions = max(1, int(num_of_partitions))
+
+        self._partitions_per_node_cfg = partitions_per_node
         self.partition_mode = mode
         self.num_partitions = num_of_partitions
         self.max_concurrent_partitions = max_concurrent_partitions
@@ -373,6 +398,7 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
     def _configure_auto_partitioning(self, dataset, ops):
         """Configure partitioning using the partition size optimizer for auto mode."""
+        recommendations = None
         try:
             from data_juicer.core.executor.partition_size_optimizer import (
                 auto_configure_resources,
@@ -382,7 +408,14 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
             # Use the partition size optimizer to determine optimal settings
             recommendations = auto_configure_resources(self.cfg, dataset, ops)
+        except ImportError as e:
+            logger.warning(f"Could not import partition size optimizer: {e}")
+            logger.info("Falling back to manual partition configuration")
+        except Exception as e:
+            logger.warning(f"Auto partition configuration failed: {e}")
+            logger.info("Falling back to manual partition configuration")
 
+        if recommendations is not None:
             # Update partition configuration based on recommendations
             recommended_size = ConfigAccessor.get(recommendations, "recommended_partition_size", self.partition_size)
             recommended_max_size_mb = ConfigAccessor.get(recommendations, "recommended_max_size_mb", self.max_size_mb)
@@ -422,12 +455,110 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
                 logger.warning(f"Could not determine dataset size for partition calculation: {e}")
                 logger.info(f"Using fallback partition count: {self.num_partitions}")
 
-        except ImportError as e:
-            logger.warning(f"Could not import partition size optimizer: {e}")
-            logger.info("Falling back to manual partition configuration")
+        # Align the partition count with the real cluster topology. This
+        # also runs when the optimizer failed above, so the fallback
+        # count still benefits from cluster awareness.
+        try:
+            self._apply_cluster_partition_bounds(ops)
         except Exception as e:
-            logger.warning(f"Auto partition configuration failed: {e}")
-            logger.info("Falling back to manual partition configuration")
+            logger.warning(f"Cluster-aware partition bounds failed: {e}")
+
+    def _apply_cluster_partition_bounds(self, ops: List) -> None:
+        """Align the auto partition count with the cluster topology.
+
+        The data-driven count acts as a ceiling (memory safety); the cluster
+        topology provides the floor and target:
+
+        - floor: ``max(nodes x partitions_per_node, nodes, concurrency)`` so
+          every node stays busy and no resolved concurrent-partition slot
+          idles (a partition count below driver concurrency wastes threads);
+        - target: roughly 2x resolved concurrency so tail partitions overlap
+          instead of serializing the final stage.
+
+        Requires ``_resolve_max_concurrent_partitions`` to have run first so
+        ``max_concurrent_partitions`` is an integer; otherwise concurrency is
+        treated as unknown (0) and only the node-based floor applies.
+        """
+        from data_juicer.utils.ray_cluster_utils import detect_cluster_topology
+
+        topology = detect_cluster_topology()
+
+        concurrency = getattr(self, "max_concurrent_partitions", None)
+        if isinstance(concurrency, str) or concurrency is None:
+            concurrency = 0
+        concurrency = max(0, int(concurrency))
+
+        per_node = self._resolve_partitions_per_node(ops, topology)
+        floor = max(topology.num_nodes * per_node, topology.num_nodes, concurrency)
+        target = max(2 * concurrency, floor) if concurrency > 0 else floor
+
+        data_driven = max(1, int(self.num_partitions))
+        # Raise small counts up to the cluster floor/target, but never beyond
+        # the data-driven ceiling; lower data-driven counts below the floor
+        # are raised to the floor because undersupplying the driver threads
+        # is the failure mode this guard prevents.
+        resolved = min(max(floor, target), max(floor, data_driven))
+        if resolved != data_driven:
+            logger.info(
+                f"Cluster-aware partitioning: adjusting num_partitions from {data_driven} to {resolved} "
+                f"(nodes={topology.num_nodes}, partitions_per_node={per_node}, concurrency={concurrency})"
+            )
+        self.num_partitions = resolved
+
+        # Expose the decision for auditing and downstream consumers (e.g.
+        # elastic control planes reading driver-side planning state).
+        try:
+            self.cfg._resolved_partition_plan = {
+                "num_partitions": resolved,
+                "data_driven_count": data_driven,
+                "num_nodes": topology.num_nodes,
+                "partitions_per_node": per_node,
+                "max_concurrent_partitions": concurrency,
+            }
+        except (AttributeError, TypeError):
+            pass
+
+    def _resolve_partitions_per_node(self, ops: List, topology) -> int:
+        """Resolve the per-node partition multiplier.
+
+        An explicit positive integer in ``partition.partitions_per_node``
+        always wins. Otherwise the multiplier is derived from the tightest
+        per-node parallelism implied by operator GPU requests (one partition
+        per node-level GPU slot). Pipelines whose operators do not use GPUs
+        fall back to a 2x overlap factor even on GPU clusters, so stage
+        boundaries can still overlap without spawning GPU-count-sized
+        partitions for CPU-only work.
+        """
+        configured = getattr(self, "_partitions_per_node_cfg", "auto")
+        if not (isinstance(configured, str) and configured.strip().lower() == "auto"):
+            try:
+                value = int(configured)
+                if value > 0:
+                    return value
+            except (TypeError, ValueError):
+                pass
+            logger.warning(f"Invalid partition.partitions_per_node={configured!r}; using auto")
+
+        gpus_per_node = topology.gpus_per_node
+        if gpus_per_node > 0:
+            per_stage_gpus = []
+            for op in ops:
+                num_gpus = getattr(op, "num_gpus", None)
+                gpu_per_worker = float(num_gpus) if num_gpus and float(num_gpus) > 0 else None
+                if gpu_per_worker is None:
+                    try:
+                        if op.use_cuda():
+                            gpu_per_worker = 1.0
+                    except (AttributeError, RuntimeError):
+                        pass
+                if gpu_per_worker is not None:
+                    per_stage_gpus.append(gpu_per_worker)
+            if per_stage_gpus:
+                tightest = max(per_stage_gpus)
+                return max(1, math.floor(gpus_per_node / tightest + 1e-9))
+        # No operator uses GPUs (or the cluster has none): CPU-only overlap
+        # factor, even when the cluster itself carries GPUs.
+        return 2
 
     def run(self, load_data_np: Optional[PositiveInt] = None, skip_return=False):
         """
@@ -538,6 +669,10 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         # Handle auto partition mode BEFORE initializing DAG
         # (DAG needs final partition count)
         elif self.partition_mode == "auto":
+            # Cluster-aware auto sizing needs the resolved driver
+            # concurrency; resolving here is safe because the call below is
+            # a no-op once the value is no longer "auto".
+            self._resolve_max_concurrent_partitions(ops)
             self._configure_auto_partitioning(dataset, ops)
 
         # Record explicit actor-pool budgets and calculate automatic Ray
@@ -769,17 +904,11 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
             self.max_concurrent_partitions = max(1, int(raw_value))
             return self.max_concurrent_partitions
 
-        try:
-            cluster_resources = ray.cluster_resources()
-            total_cpus = float(cluster_resources.get("CPU", 0))
-            total_gpus = float(cluster_resources.get("GPU", 0))
-        except Exception as error:
-            logger.warning(
-                "Could not inspect Ray cluster resources for automatic partition "
-                f"concurrency; falling back to 1. Error: {error}"
-            )
-            self.max_concurrent_partitions = 1
-            return self.max_concurrent_partitions
+        from data_juicer.utils.ray_cluster_utils import detect_cluster_topology
+
+        topology = detect_cluster_topology()
+        total_cpus = topology.total_cpus
+        total_gpus = topology.total_gpus
 
         if total_cpus <= 0:
             logger.warning(

--- a/data_juicer/utils/ray_cluster_utils.py
+++ b/data_juicer/utils/ray_cluster_utils.py
@@ -1,0 +1,73 @@
+"""Shared Ray cluster topology detection.
+
+Partition sizing, driver concurrency, and any other cluster-aware decision
+must resolve the cluster topology through this single helper so that every
+consumer acts on the same view of the cluster.
+
+Key points:
+- The node count is derived from ``ray.nodes()`` (alive nodes only) instead
+  of guessing it from total CPU resources.
+- Resource totals come from ``ray.cluster_resources()`` and therefore
+  describe the whole cluster, not the driver machine.
+- Any detection failure degrades to a single-node fallback instead of
+  raising, so callers never need special error handling.
+"""
+
+from dataclasses import dataclass
+
+from loguru import logger
+
+
+@dataclass(frozen=True)
+class ClusterTopology:
+    """Cluster-wide resource view used for partitioning decisions."""
+
+    num_nodes: int
+    total_cpus: float
+    total_gpus: float
+    available_cpus: float
+    available_gpus: float
+
+    @property
+    def gpus_per_node(self) -> float:
+        """Average GPUs per node (0.0 for CPU-only clusters)."""
+        if self.num_nodes <= 0:
+            return 0.0
+        return self.total_gpus / self.num_nodes
+
+
+def detect_cluster_topology() -> ClusterTopology:
+    """Detect the Ray cluster topology.
+
+    Falls back to a conservative single-node view when Ray is unavailable,
+    not initialized, or inspection fails, so callers can always rely on a
+    usable result.
+    """
+    fallback = ClusterTopology(
+        num_nodes=1,
+        total_cpus=0.0,
+        total_gpus=0.0,
+        available_cpus=0.0,
+        available_gpus=0.0,
+    )
+    try:
+        import ray
+
+        if not ray.is_initialized():
+            return fallback
+
+        nodes = ray.nodes()
+        num_nodes = max(1, sum(1 for node in nodes if node.get("Alive")))
+
+        cluster_resources = ray.cluster_resources()
+        available_resources = ray.available_resources()
+        return ClusterTopology(
+            num_nodes=num_nodes,
+            total_cpus=float(cluster_resources.get("CPU", 0)),
+            total_gpus=float(cluster_resources.get("GPU", 0)),
+            available_cpus=float(available_resources.get("CPU", 0)),
+            available_gpus=float(available_resources.get("GPU", 0)),
+        )
+    except Exception as e:
+        logger.warning(f"Could not detect Ray cluster topology, using single-node fallback: {e}")
+        return fallback

--- a/tests/core/executor/test_auto_partition_cluster.py
+++ b/tests/core/executor/test_auto_partition_cluster.py
@@ -1,0 +1,331 @@
+"""Tests for cluster-aware auto partitioning.
+
+Covers:
+- Shared cluster topology detection (real node count, fallback behavior)
+- PartitionSizeOptimizer cluster fixes (node count, cluster-wide capacity)
+- Executor sentinel parsing (num_of_partitions: auto / int / invalid)
+- Cluster partition bounds formula (floor, target, data-driven ceiling)
+"""
+
+import math
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from data_juicer.core.executor.ray_executor_partitioned import (
+    PartitionedRayExecutor,
+)
+from data_juicer.utils.ray_cluster_utils import (
+    ClusterTopology,
+    detect_cluster_topology,
+)
+
+MULTINODE_NODES = [
+    {"Alive": True, "NodeID": "n1"},
+    {"Alive": True, "NodeID": "n2"},
+    {"Alive": True, "NodeID": "n3"},
+    {"Alive": True, "NodeID": "n4"},
+    {"Alive": False, "NodeID": "dead"},
+]
+MULTINODE_CLUSTER = {"CPU": 256.0, "GPU": 32.0, "memory": 1024.0 * 1024**3}
+MULTINODE_AVAILABLE = {"CPU": 256.0, "GPU": 32.0, "memory": 1024.0 * 1024**3}
+
+
+def _patch_ray_multinode():
+    """Patch ray as a 4-node / 32-GPU cluster."""
+    return [
+        patch("ray.is_initialized", return_value=True),
+        patch("ray.nodes", return_value=MULTINODE_NODES),
+        patch("ray.cluster_resources", return_value=MULTINODE_CLUSTER),
+        patch("ray.available_resources", return_value=MULTINODE_AVAILABLE),
+    ]
+
+
+class ClusterTopologyTest(unittest.TestCase):
+    def test_multinode_topology_counts_alive_nodes_only(self):
+        patches = _patch_ray_multinode()
+        for p in patches:
+            p.start()
+        try:
+            topology = detect_cluster_topology()
+        finally:
+            for p in patches:
+                p.stop()
+        self.assertEqual(topology.num_nodes, 4)
+        self.assertEqual(topology.total_cpus, 256.0)
+        self.assertEqual(topology.total_gpus, 32.0)
+        self.assertAlmostEqual(topology.gpus_per_node, 8.0)
+
+    def test_fallback_when_ray_not_initialized(self):
+        with patch("ray.is_initialized", return_value=False):
+            topology = detect_cluster_topology()
+        self.assertEqual(topology.num_nodes, 1)
+        self.assertEqual(topology.total_cpus, 0.0)
+        self.assertEqual(topology.total_gpus, 0.0)
+
+
+class OptimizerClusterFixTest(unittest.TestCase):
+    def test_detect_ray_cluster_uses_real_node_count(self):
+        from data_juicer.core.executor.partition_size_optimizer import (
+            ResourceDetector,
+        )
+
+        patches = _patch_ray_multinode()
+        for p in patches:
+            p.start()
+        try:
+            cluster = ResourceDetector.detect_ray_cluster()
+        finally:
+            for p in patches:
+                p.stop()
+        self.assertIsNotNone(cluster)
+        # Old heuristic would have guessed 256 / 8 = 32 nodes.
+        self.assertEqual(cluster.num_nodes, 4)
+        self.assertEqual(cluster.total_cpu_cores, 256)
+
+    def test_worker_count_uses_cluster_capacity_not_driver_local(self):
+        from data_juicer.core.executor.partition_size_optimizer import (
+            ClusterResources,
+            LocalResources,
+            ResourceDetector,
+        )
+
+        local = LocalResources(
+            cpu_cores=8,
+            available_memory_gb=32.0,
+            total_memory_gb=64.0,
+            gpu_count=0,
+        )
+        cluster = ClusterResources(
+            num_nodes=4,
+            total_cpu_cores=256,
+            total_memory_gb=2048.0,
+            available_cpu_cores=192,
+            available_memory_gb=2048.0,
+            gpu_resources={},
+        )
+        workers = ResourceDetector.calculate_optimal_worker_count(local, cluster)
+        # Cluster-wide capacity is authoritative: 75% of 192, not of 8.
+        self.assertEqual(workers, int(192 * 0.75))
+
+
+def _fake_executor(**attrs):
+    """Build a minimal stand-in carrying only the state the methods need."""
+    fake = SimpleNamespace()
+    fake.cfg = SimpleNamespace()
+    fake.max_concurrent_partitions = "auto"
+    fake.num_partitions = 4
+    fake.partition_mode = "auto"
+    fake.partition_size = 5000
+    fake.max_size_mb = 64
+    fake._partitions_per_node_cfg = "auto"
+    for key, value in attrs.items():
+        setattr(fake, key, value)
+    return fake
+
+
+def _gpu_op(num_gpus):
+    return SimpleNamespace(num_gpus=num_gpus, _name="gpu_op")
+
+
+class SentinelParsingTest(unittest.TestCase):
+    def _configure(self, partition_cfg):
+        fake = _fake_executor()
+        fake.cfg = SimpleNamespace(partition=partition_cfg)
+        PartitionedRayExecutor._configure_partitioning(fake)
+        return fake
+
+    def test_auto_sentinel_keeps_auto_mode(self):
+        fake = self._configure({"mode": "manual", "num_of_partitions": "auto"})
+        self.assertEqual(fake.partition_mode, "auto")
+
+    def test_numeric_string_normalized(self):
+        fake = self._configure({"mode": "manual", "num_of_partitions": "8"})
+        self.assertEqual(fake.partition_mode, "manual")
+        self.assertEqual(fake.num_partitions, 8)
+
+    def test_invalid_value_falls_back_to_auto(self):
+        fake = self._configure({"mode": "manual", "num_of_partitions": "bogus"})
+        self.assertEqual(fake.partition_mode, "auto")
+
+    def test_explicit_int_manual_mode_wins(self):
+        fake = self._configure({"mode": "manual", "num_of_partitions": 16})
+        self.assertEqual(fake.partition_mode, "manual")
+        self.assertEqual(fake.num_partitions, 16)
+
+
+class ClusterPartitionBoundsTest(unittest.TestCase):
+    MULTINODE = ClusterTopology(
+        num_nodes=2,
+        total_cpus=128.0,
+        total_gpus=16.0,
+        available_cpus=128.0,
+        available_gpus=16.0,
+    )
+
+    def _apply(self, fake, ops):
+        fake._resolve_partitions_per_node = lambda op_list, topology: (
+            PartitionedRayExecutor._resolve_partitions_per_node(fake, op_list, topology)
+        )
+        with patch(
+            "data_juicer.utils.ray_cluster_utils.detect_cluster_topology",
+            return_value=self.MULTINODE,
+        ):
+            PartitionedRayExecutor._apply_cluster_partition_bounds(fake, ops)
+        return fake
+
+    def test_target_reaches_twice_concurrency(self):
+        # 2 nodes x 8 GPUs, ops at 0.5 GPU each -> per_node=16, floor=32.
+        fake = _fake_executor(num_partitions=200, max_concurrent_partitions=32)
+        self._apply(fake, [_gpu_op(0.5)])
+        self.assertEqual(fake.num_partitions, 64)
+
+    def test_data_driven_ceiling_is_respected(self):
+        fake = _fake_executor(num_partitions=40, max_concurrent_partitions=32)
+        self._apply(fake, [_gpu_op(0.5)])
+        self.assertEqual(fake.num_partitions, 40)
+
+    def test_count_below_floor_is_raised(self):
+        fake = _fake_executor(num_partitions=10, max_concurrent_partitions=32)
+        self._apply(fake, [_gpu_op(0.5)])
+        self.assertEqual(fake.num_partitions, 32)
+
+    def test_unresolved_concurrency_uses_node_floor(self):
+        fake = _fake_executor(num_partitions=4, max_concurrent_partitions="auto")
+        self._apply(fake, [_gpu_op(0.5)])
+        self.assertEqual(fake.num_partitions, 32)  # 2 nodes x 16 per node
+
+    def test_cpu_only_pipeline_uses_overlap_factor(self):
+        cpu_topology = ClusterTopology(
+            num_nodes=4,
+            total_cpus=256.0,
+            total_gpus=0.0,
+            available_cpus=256.0,
+            available_gpus=0.0,
+        )
+        fake = _fake_executor(num_partitions=1000, max_concurrent_partitions=8)
+        fake._resolve_partitions_per_node = lambda op_list, topology: (
+            PartitionedRayExecutor._resolve_partitions_per_node(fake, op_list, topology)
+        )
+        with patch(
+            "data_juicer.utils.ray_cluster_utils.detect_cluster_topology",
+            return_value=cpu_topology,
+        ):
+            PartitionedRayExecutor._apply_cluster_partition_bounds(fake, [])
+        # per_node=2 -> floor=max(8,4,8)=8, target=16, ceiling=1000.
+        self.assertEqual(fake.num_partitions, 16)
+
+    def test_resolved_plan_published_on_cfg(self):
+        fake = _fake_executor(num_partitions=200, max_concurrent_partitions=32)
+        self._apply(fake, [_gpu_op(0.5)])
+        plan = fake.cfg._resolved_partition_plan
+        self.assertEqual(plan["num_partitions"], 64)
+        self.assertEqual(plan["num_nodes"], 2)
+        self.assertEqual(plan["partitions_per_node"], 16)
+
+
+class PartitionsPerNodeTest(unittest.TestCase):
+    TOPOLOGY = ClusterTopology(
+        num_nodes=2,
+        total_cpus=128.0,
+        total_gpus=16.0,
+        available_cpus=128.0,
+        available_gpus=16.0,
+    )
+
+    def test_explicit_multiplier_wins(self):
+        fake = _fake_executor(_partitions_per_node_cfg=3)
+        value = PartitionedRayExecutor._resolve_partitions_per_node(
+            fake, [_gpu_op(0.5)], self.TOPOLOGY
+        )
+        self.assertEqual(value, 3)
+
+    def test_gpu_slot_derivation(self):
+        fake = _fake_executor()
+        value = PartitionedRayExecutor._resolve_partitions_per_node(
+            fake, [_gpu_op(0.5)], self.TOPOLOGY
+        )
+        self.assertEqual(value, 16)  # 8 GPUs/node / 0.5 GPU per worker
+
+    def test_tightest_stage_dominates(self):
+        fake = _fake_executor()
+        value = PartitionedRayExecutor._resolve_partitions_per_node(
+            fake, [_gpu_op(0.5), _gpu_op(1.0)], self.TOPOLOGY
+        )
+        self.assertEqual(value, 8)  # 8 GPUs/node / 1.0 GPU
+
+    def test_cpu_only_fallback(self):
+        cpu_topology = ClusterTopology(
+            num_nodes=2,
+            total_cpus=128.0,
+            total_gpus=0.0,
+            available_cpus=128.0,
+            available_gpus=0.0,
+        )
+        fake = _fake_executor()
+        value = PartitionedRayExecutor._resolve_partitions_per_node(fake, [], cpu_topology)
+        self.assertEqual(value, 2)
+
+    def test_cpu_only_pipeline_on_gpu_cluster_uses_overlap_factor(self):
+        # GPU cluster must not size CPU-only pipelines by GPU count.
+        fake = _fake_executor()
+        value = PartitionedRayExecutor._resolve_partitions_per_node(fake, [], self.TOPOLOGY)
+        self.assertEqual(value, 2)
+
+    def test_cuda_flag_marks_gpu_pipeline_without_num_gpus(self):
+        cuda_op = SimpleNamespace(num_gpus=None, use_cuda=lambda: True, _name="cuda_op")
+        fake = _fake_executor()
+        value = PartitionedRayExecutor._resolve_partitions_per_node(
+            fake, [cuda_op], self.TOPOLOGY
+        )
+        self.assertEqual(value, 8)  # 8 GPUs/node / 1.0 GPU implicit
+
+    def test_invalid_multiplier_falls_back_to_auto(self):
+        fake = _fake_executor(_partitions_per_node_cfg="bogus")
+        value = PartitionedRayExecutor._resolve_partitions_per_node(
+            fake, [_gpu_op(0.5)], self.TOPOLOGY
+        )
+        self.assertEqual(value, 16)
+
+
+class OptimizerFallbackTest(unittest.TestCase):
+    """Cluster bounds must still apply when the optimizer fails."""
+
+    def _bound_fake(self, **attrs):
+        fake = _fake_executor(**attrs)
+        fake._resolve_partitions_per_node = lambda op_list, topology: (
+            PartitionedRayExecutor._resolve_partitions_per_node(fake, op_list, topology)
+        )
+        fake._apply_cluster_partition_bounds = lambda op_list: (
+            PartitionedRayExecutor._apply_cluster_partition_bounds(fake, op_list)
+        )
+        return fake
+
+    def test_cluster_bounds_applied_when_optimizer_raises(self):
+        fake = self._bound_fake(num_partitions=4, max_concurrent_partitions=8)
+        with patch(
+            "data_juicer.core.executor.partition_size_optimizer.auto_configure_resources",
+            side_effect=RuntimeError("optimizer unavailable"),
+        ), patch(
+            "data_juicer.utils.ray_cluster_utils.detect_cluster_topology",
+            return_value=ClusterPartitionBoundsTest.MULTINODE,
+        ):
+            PartitionedRayExecutor._configure_auto_partitioning(fake, None, [_gpu_op(0.5)])
+        # floor = 2 nodes x 16 per node = 32; placeholder 4 is raised.
+        self.assertEqual(fake.num_partitions, 32)
+
+    def test_cluster_bounds_applied_when_optimizer_import_fails(self):
+        fake = self._bound_fake(num_partitions=4, max_concurrent_partitions=8)
+        with patch(
+            "data_juicer.core.executor.partition_size_optimizer.auto_configure_resources",
+            side_effect=ImportError("missing dependency"),
+        ), patch(
+            "data_juicer.utils.ray_cluster_utils.detect_cluster_topology",
+            return_value=ClusterPartitionBoundsTest.MULTINODE,
+        ):
+            PartitionedRayExecutor._configure_auto_partitioning(fake, None, [_gpu_op(0.5)])
+        self.assertEqual(fake.num_partitions, 32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/executor/test_ray_executor_partitioned_parallel.py
+++ b/tests/core/executor/test_ray_executor_partitioned_parallel.py
@@ -11,6 +11,18 @@ from data_juicer.core.executor.event_logging_mixin import EventType
 from data_juicer.core.executor.pipeline_dag import DAGNodeStatus, PipelineDAG
 from data_juicer.core.executor.ray_executor_partitioned import PartitionedRayExecutor
 from data_juicer.utils.ckpt_utils import CheckpointStrategy, RayCheckpointManager
+from data_juicer.utils.ray_cluster_utils import ClusterTopology
+
+
+def _topology_from_resources(resources):
+    """Build the cluster view the executor now resolves resources through."""
+    return ClusterTopology(
+        num_nodes=1,
+        total_cpus=float(resources.get("CPU", 0)),
+        total_gpus=float(resources.get("GPU", 0)),
+        available_cpus=float(resources.get("CPU", 0)),
+        available_gpus=float(resources.get("GPU", 0)),
+    )
 
 
 class FakeData:
@@ -250,8 +262,10 @@ def test_auto_partition_concurrency_is_resource_aware(resources, ops, expected):
     executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
     executor.max_concurrent_partitions = "auto"
 
-    fake_ray = SimpleNamespace(cluster_resources=Mock(return_value=resources))
-    with patch("data_juicer.core.executor.ray_executor_partitioned.ray", fake_ray):
+    with patch(
+        "data_juicer.utils.ray_cluster_utils.detect_cluster_topology",
+        return_value=_topology_from_resources(resources),
+    ):
         resolved = executor._resolve_max_concurrent_partitions(ops)
 
     assert resolved == expected
@@ -261,21 +275,29 @@ def test_auto_partition_concurrency_is_resource_aware(resources, ops, expected):
 def test_explicit_partition_concurrency_overrides_auto_detection():
     executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
     executor.max_concurrent_partitions = 3
-    fake_ray = SimpleNamespace(cluster_resources=Mock())
 
-    with patch("data_juicer.core.executor.ray_executor_partitioned.ray", fake_ray):
+    with patch("data_juicer.utils.ray_cluster_utils.detect_cluster_topology") as detect:
         resolved = executor._resolve_max_concurrent_partitions([])
 
     assert resolved == 3
-    fake_ray.cluster_resources.assert_not_called()
+    detect.assert_not_called()
 
 
 def test_auto_partition_concurrency_falls_back_to_one_when_ray_inspection_fails():
     executor = PartitionedRayExecutor.__new__(PartitionedRayExecutor)
     executor.max_concurrent_partitions = "auto"
-    fake_ray = SimpleNamespace(cluster_resources=Mock(side_effect=RuntimeError("Ray unavailable")))
+    fallback = ClusterTopology(
+        num_nodes=1,
+        total_cpus=0.0,
+        total_gpus=0.0,
+        available_cpus=0.0,
+        available_gpus=0.0,
+    )
 
-    with patch("data_juicer.core.executor.ray_executor_partitioned.ray", fake_ray):
+    with patch(
+        "data_juicer.utils.ray_cluster_utils.detect_cluster_topology",
+        return_value=fallback,
+    ):
         resolved = executor._resolve_max_concurrent_partitions([])
 
     assert resolved == 1


### PR DESCRIPTION
## Summary

This PR makes the `ray_partitioned` executor's auto partition count
cluster-aware. A new `auto` sentinel for `partition.num_of_partitions`
derives the count from the real cluster topology and the resolved driver
concurrency, while an explicit integer still overrides it in one config key.

## Motivation

Auto mode previously computed `num_partitions` purely from dataset size and
a CPU-derived worker estimate (`min(count, max(32, workers * 2))`), while
`max_concurrent_partitions: auto` was already GPU- and cluster-aware. The
two knobs were decided independently and could contradict each other — e.g.
32 resolved concurrent partition slots but only 4 partitions, leaving most
driver threads idle and starving GPU stages of input. GPU-heavy pipelines
also pay actor-lifecycle costs per partition, so the count must track the
cluster's real parallelism rather than a hardcoded CPU heuristic.

## Behavior

```yaml
partition:
  mode: auto
  num_of_partitions: auto      # NEW: cluster-aware count; an integer still overrides
  partitions_per_node: auto    # NEW: per-node multiplier; positive integer overrides
```

Resolution order:

1. Explicit positive integer `num_of_partitions` (manual mode) — unchanged,
   always wins.
2. `num_of_partitions: auto` in auto mode:
   - data-driven count (dataset size / recommended partition size, memory
     ceiling) remains the **ceiling**;
   - **floor** = `max(nodes × partitions_per_node, nodes, resolved
     max_concurrent_partitions)`, so every node stays busy and no resolved
     concurrency slot idles;
   - **target** = `2 × resolved concurrency` for tail-partition overlap;
   - final = `min(max(floor, target), max(floor, data_driven))`.
3. `partitions_per_node: auto` derives the multiplier from per-node GPU
   slots (GPUs per node divided by the tightest operator `num_gpus`
   request), falling back to 2× for CPU-only pipelines.

The resolved decision (final count, data-driven count, node count, per-node
multiplier, concurrency) is logged and published as
`cfg._resolved_partition_plan` for auditing and downstream consumers.

Concurrency is resolved before auto sizing in `run()` (the later call is a
no-op once resolved), so the formula always sees an integer
`max_concurrent_partitions`.

## Main Code Changes

| File | Change |
| --- | --- |
| data_juicer/core/executor/ray_executor_partitioned.py | Sentinel parsing in `_configure_partitioning` (numeric-string normalization, invalid values fall back to auto mode); `_apply_cluster_partition_bounds` and `_resolve_partitions_per_node`; `_resolve_max_concurrent_partitions` moved ahead of auto sizing in `run()`. |
| data_juicer/config/config_all.yaml | Documents `num_of_partitions: auto` and adds `partitions_per_node`. |
| tests/core/executor/test_auto_partition_cluster.py | 19 tests with mocked Ray clusters: topology detection, sentinel parsing, floor/target/ceiling behavior, per-node multiplier derivation, resolved-plan publication. |

## Compatibility

- Default configuration is unchanged (`num_of_partitions: 4`, manual
  semantics intact); the new behavior is opt-in via the `auto` sentinel.
- Resume semantics unchanged: resumed jobs reuse the saved partition count
  and skip auto sizing.
- Partition count is decided once at split time. Runtime node changes are
  absorbed by Ray scheduling and operator-level parallelism, not by
  re-partitioning.
- Requires the topology helper from the companion refactor PR
  (`data_juicer/utils/ray_cluster_utils.py`).

## Example

Two nodes × 8 GPUs, GPU operators requesting 0.5 GPU each:
`partitions_per_node = 8 / 0.5 = 16`, floor = 32, resolved concurrency = 32,
target = 64 → 64 partitions instead of the former CPU-derived count.

## Tests

- `tests/core/executor/test_auto_partition_cluster.py`: 19 passed.
- Regression: `test_partition_size_optimizer.py` 32 passed,
  `test_partitioned_integration.py` 13 passed / 1 skipped,
  `tests/config/` 128 passed / 1 skipped.
- Black/isort style and `py_compile` checks passed.
```