### PR TITLE
fix(text_chunk_mapper): filter empty fragments from recursively_chunk

### DIFF
--- a/data_juicer/ops/mapper/text_chunk_mapper.py
+++ b/data_juicer/ops/mapper/text_chunk_mapper.py
@@ -105,7 +105,8 @@ class TextChunkMapper(Mapper):
             cur_text = sub_text[: last_match.start()]
             left_text = text[last_match.end() :]
 
-        return [cur_text] + self.recursively_chunk(left_text)
+        chunks = [cur_text] if cur_text.strip() else []
+        return chunks + self.recursively_chunk(left_text)
 
     def get_text_chunks(self, text, rank=None):
         if self.split_pattern is not None and self.max_len is None:

--- a/tests/ops/mapper/test_text_chunk_mapper.py
+++ b/tests/ops/mapper/test_text_chunk_mapper.py
@@ -380,5 +380,31 @@ class TextChunkMapperTest(DataJuicerTestCaseBase):
         self._run_helper(op, ds_list, tgt_list)
 
 
+    def test_recursive_chunk_no_empty_fragments(self):
+        """Regression: recursively_chunk must not produce empty strings when
+        split_pattern matches at the start of a chunk boundary."""
+        ds_list = [
+            {'text': '\n\nHello world is a long sentence\n\nFoo bar baz qux'},
+        ]
+        op = TextChunkMapper(max_len=20, split_pattern='\n\n')
+        dataset = Dataset.from_list(ds_list)
+        dataset = dataset.map(op.process, batch_size=1)
+        texts = [d['text'] for d in dataset]
+        for t in texts:
+            self.assertTrue(t.strip(), f"Got empty/whitespace fragment: {repr(t)}")
+
+    def test_recursive_chunk_consecutive_delimiters(self):
+        """Consecutive delimiters should not produce empty fragments."""
+        ds_list = [
+            {'text': 'aaa\n\n\n\nbbb'},
+        ]
+        op = TextChunkMapper(max_len=20, split_pattern='\n\n')
+        dataset = Dataset.from_list(ds_list)
+        dataset = dataset.map(op.process, batch_size=1)
+        texts = [d['text'] for d in dataset]
+        for t in texts:
+            self.assertTrue(t.strip(), f"Got empty/whitespace fragment: {repr(t)}")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Reproduction

```python
from data_juicer.ops.mapper.text_chunk_mapper import TextChunkMapper

op = TextChunkMapper(max_len=20, split_pattern="\n\n")
chunks = op.recursively_chunk("\n\nHello world is long enough\n\nSecond part here")
for i, c in enumerate(chunks):
    print(f"[{i}] {repr(c)}")
```

### Before fix (on main)

```
[0] '' ← empty string
[1] 'Hello world is long '
[2] 'enough'
[3] 'Second part here'
```

An empty-string fragment is produced when `split_pattern` (`\n\n`) matches at position 0 of the current chunk. This empty fragment propagates into the output dataset as a blank sample.

### After fix

```
[0] 'Hello world is long '
[1] 'enough'
[2] 'Second part here'
```

## Root cause

`recursively_chunk()` returns `[cur_text] + self.recursively_chunk(left_text)` where `cur_text = sub_text[:last_match.start()]`. When `last_match.start() == 0` (pattern at position 0), `cur_text` is `""`. The split-only code path filters these, but the recursive path did not.

## Fix

```python
# Before
return [cur_text] + self.recursively_chunk(left_text)

# After
chunks = [cur_text] if cur_text.strip() else []
return chunks + self.recursively_chunk(left_text)
```

## Tests added

- `test_recursive_chunk_no_empty_fragments` — pattern at position 0
- `test_recursive_chunk_consecutive_delimiters` — multiple consecutive delimiters

Both assert no empty/whitespace-only strings in output.

Part of cmgzn/data-juicer#137