### PR TITLE
fix(analysis): use pd.api.types.is_numeric_dtype for extension dtype compat

### DIFF
--- a/data_juicer/analysis/correlation_analysis.py
+++ b/data_juicer/analysis/correlation_analysis.py
@@ -158,7 +158,7 @@ class CorrelationAnalysis:
         self.stats = pd.DataFrame(dataset[Fields.stats])
         # only keep the numeric columns
         for col_name in self.stats.columns:
-            if np.issubdtype(self.stats[col_name].dtype, np.number):
+            if pd.api.types.is_numeric_dtype(self.stats[col_name]):
                 continue
             elif is_numeric_list_series(self.stats[col_name]):
                 self.stats[col_name] = self.stats[col_name].apply(

--- a/tests/analysis/test_correlation_analysis.py
+++ b/tests/analysis/test_correlation_analysis.py
@@ -54,7 +54,7 @@ class CorrelationAnalysisTest(DataJuicerTestCaseBase):
 
     def test_correlation_analysis(self):
         corr_analyzer = CorrelationAnalysis({Fields.stats: self.df}, self.temp_output_path)
-        self.assertEqual(set(corr_analyzer.stats.columns), {'A', 'B', 'E', 'G', 'H', 'I', 'J'})
+        self.assertEqual(set(corr_analyzer.stats.columns), {'A', 'B', 'E', 'F', 'G', 'H', 'I', 'J'})
 
         ret = corr_analyzer.analyze(skip_export=True)
         self.assertFalse(os.path.exists(os.path.join(self.temp_output_path, 'stats-corr-pearson.png')))
@@ -70,6 +70,22 @@ class CorrelationAnalysisTest(DataJuicerTestCaseBase):
         corr_analyzer = CorrelationAnalysis({Fields.stats: {}}, self.temp_output_path)
         ret = corr_analyzer.analyze()
         self.assertIsNone(ret)
+
+
+    def test_extension_dtypes_no_typeerror(self):
+        """Regression: pandas extension dtypes (StringDtype, Int64) must not
+        raise TypeError in the numeric column filter."""
+        df = pd.DataFrame({
+            'numeric_col': [1, 2, 3],
+            'string_col': pd.array(['a', 'b', 'c'], dtype='string'),
+            'nullable_int': pd.array([10, 20, 30], dtype='Int64'),
+        })
+        corr_analyzer = CorrelationAnalysis(
+            {Fields.stats: df}, self.temp_output_path
+        )
+        self.assertIn('numeric_col', corr_analyzer.stats.columns)
+        self.assertIn('nullable_int', corr_analyzer.stats.columns)
+        self.assertNotIn('string_col', corr_analyzer.stats.columns)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

`CorrelationAnalysis.__init__` uses `np.issubdtype(col.dtype, np.number)` to identify numeric columns. This throws `TypeError: Cannot interpret 'string[python]'` when the stats DataFrame contains columns with pandas extension dtypes (`StringDtype`, nullable `Int64Dtype`, etc.).

This commonly occurs after Arrow/Parquet serialization round-trips (e.g. in Ray mode), where plain `object` columns come back as `string[python]` or `string[pyarrow]`.

## Reproduction

```python
import pandas as pd
from data_juicer.analysis.correlation_analysis import CorrelationAnalysis
from data_juicer.utils.constant import Fields

df = pd.DataFrame({
    'numeric': [1, 2, 3],
    'ext_string': pd.array(['a', 'b', 'c'], dtype='string'),
    'nullable_int': pd.array([10, 20, 30], dtype='Int64'),
})
# Before fix: raises TypeError
analyzer = CorrelationAnalysis({Fields.stats: df}, '/tmp/out')
```

## Fix

Replace `np.issubdtype(series.dtype, np.number)` with `pd.api.types.is_numeric_dtype(series)`, which handles both numpy native dtypes and pandas extension dtypes correctly.

This also correctly includes boolean columns in correlation analysis (point-biserial correlation is valid for booleans).

## Tests

- Added `test_extension_dtypes_no_typeerror` covering StringDtype and nullable Int64Dtype
- Updated existing test expectation to include boolean column (now correctly recognized as numeric)

Part of cmgzn/data-juicer#137