### PR TITLE
feat(core): add preflight validation for pipeline configs

### DIFF
--- a/data_juicer/config/config.py
+++ b/data_juicer/config/config.py
@@ -160,6 +160,13 @@ def build_base_parser() -> ArgumentParser:
         help='Type of executor, support "default", "ray", or "ray_partitioned".',
     )
     parser.add_argument(
+        "--strict_preflight",
+        type=bool,
+        default=True,
+        help="Whether to run preflight validation before pipeline execution. "
+        "Set to False to skip preflight checks (not recommended).",
+    )
+    parser.add_argument(
         "--dataset_path",
         type=str,
         default="",

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -226,6 +226,12 @@ class RayDataset(DJDataset):
         if cached_columns is None:
             cached_columns = set(self.data.columns())
 
+        if "ray" not in op._supported_exec_modes:
+            raise NotImplementedError(
+                f"Operator '{op._name or type(op).__name__}' does not support "
+                f"Ray mode. Supported modes: {op._supported_exec_modes}"
+            )
+
         if op._name in TAGGING_OPS.modules and Fields.meta not in cached_columns:
 
             def process_batch_arrow(table: pyarrow.Table):
@@ -362,17 +368,6 @@ class RayDataset(DJDataset):
                             op.process = original_process
             elif isinstance(op, (Deduplicator, Pipeline)):
                 self.data = op.run(self.data)
-            else:
-                logger.error(
-                    f"Operator '{op._name or type(op).__name__}' (type "
-                    f"'{type(op).__bases__[0].__name__}') does not support "
-                    f"Ray mode. Supported modes: {op._supported_exec_modes}"
-                )
-                raise NotImplementedError(
-                    f"Operator type '{type(op).__bases__[0].__name__}' does not "
-                    f"support executor mode 'ray'. "
-                    f"Supported modes: {op._supported_exec_modes}"
-                )
         except:  # noqa: E722
             logger.exception(f"An error occurred during Op [{op._name}].")
             raise

--- a/data_juicer/core/data/ray_dataset.py
+++ b/data_juicer/core/data/ray_dataset.py
@@ -363,8 +363,16 @@ class RayDataset(DJDataset):
             elif isinstance(op, (Deduplicator, Pipeline)):
                 self.data = op.run(self.data)
             else:
-                logger.error("Ray executor only support Filter, Mapper, Deduplicator and Pipeline OPs for now")
-                raise NotImplementedError
+                logger.error(
+                    f"Operator '{op._name or type(op).__name__}' (type "
+                    f"'{type(op).__bases__[0].__name__}') does not support "
+                    f"Ray mode. Supported modes: {op._supported_exec_modes}"
+                )
+                raise NotImplementedError(
+                    f"Operator type '{type(op).__bases__[0].__name__}' does not "
+                    f"support executor mode 'ray'. "
+                    f"Supported modes: {op._supported_exec_modes}"
+                )
         except:  # noqa: E722
             logger.exception(f"An error occurred during Op [{op._name}].")
             raise

--- a/data_juicer/core/executor/default_executor.py
+++ b/data_juicer/core/executor/default_executor.py
@@ -149,6 +149,12 @@ class DefaultExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin):
         :param skip_return: skip return for API called.
         :return: processed dataset.
         """
+        # Preflight stage 1: validate config before instantiation
+        if getattr(self.cfg, "strict_preflight", True):
+            from data_juicer.core.preflight import pre_instantiation_check
+
+            pre_instantiation_check(self.cfg.process)
+
         # 1. format data
         if dataset is not None:
             logger.info(f"Using existing dataset {dataset}")
@@ -167,6 +173,16 @@ class DefaultExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin):
         # 2. extract processes and optimize their orders
         logger.info("Preparing process operators...")
         ops = load_ops(self.cfg.process)
+
+        # Preflight stage 2: validate ops against dataset schema and environment
+        if getattr(self.cfg, "strict_preflight", True):
+            from data_juicer.core.preflight import post_instantiation_check
+
+            if isinstance(dataset, NestedDataset) and hasattr(dataset, "features") and dataset.features:
+                from data_juicer.core.data.schema import Schema
+
+                schema = Schema.from_hf_features(dataset.features)
+                post_instantiation_check(ops, schema, self.cfg)
 
         if not ops:
             logger.warning(

--- a/data_juicer/core/executor/ray_executor.py
+++ b/data_juicer/core/executor/ray_executor.py
@@ -150,6 +150,12 @@ class RayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin):
         :param skip_return: skip return for API called.
         :return: processed dataset.
         """
+        # Preflight stage 1: validate config before instantiation
+        if getattr(self.cfg, "strict_preflight", True):
+            from data_juicer.core.preflight import pre_instantiation_check
+
+            pre_instantiation_check(self.cfg.process)
+
         # LLM data contains very large single json objects (lines). PyArrow's default block_size
         # for open_json is only 1MB. We increase it massively (e.g. 256MB) to avoid the
         # 'straddling object straddles two block boundaries' ArrowInvalid error.
@@ -168,6 +174,17 @@ class RayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin):
         # 2. extract processes
         logger.info("Preparing process operators...")
         ops = load_ops(self.cfg.process, self.op_env_manager)
+
+        # Preflight stage 2: validate ops against dataset schema and environment
+        if getattr(self.cfg, "strict_preflight", True):
+            from data_juicer.core.preflight import post_instantiation_check
+
+            try:
+                dataset_schema = dataset.schema()
+            except (ValueError, AttributeError):
+                dataset_schema = None
+            if dataset_schema:
+                post_instantiation_check(ops, dataset_schema, self.cfg)
 
         if not ops:
             logger.warning(

--- a/data_juicer/core/executor/ray_executor.py
+++ b/data_juicer/core/executor/ray_executor.py
@@ -48,7 +48,7 @@ class RayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin):
 
     Run Data-Juicer data processing in a distributed cluster.
 
-        1. Support Filter, Mapper and Exact Deduplicator operators for now.
+        1. Only supports operators with _supported_exec_modes containing 'ray'.
         2. Only support loading `.json` files.
         3. Advanced functions, such as checkpoint, are not supported.
 

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -648,11 +648,18 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         self._enable_deterministic_execution()
         override_num_blocks = getattr(self.cfg, "override_num_blocks", None)
         dataset = self.datasetbuilder.load_dataset(num_proc=load_data_np, override_num_blocks=override_num_blocks)
-        columns = dataset.schema().columns
+        dataset_schema = dataset.schema()
+        columns = dataset_schema.columns
 
         # Prepare operations
         logger.info("Preparing operations...")
         ops = self._prepare_operators()
+
+        # Preflight stage 2: validate ops against dataset schema and environment
+        if getattr(self.cfg, "strict_preflight", True):
+            from data_juicer.core.preflight import post_instantiation_check
+
+            post_instantiation_check(ops, dataset_schema, self.cfg)
 
         # A resumed job must reuse the saved partition count before DAG
         # initialization. Auto mode can otherwise choose a different count if
@@ -1340,6 +1347,10 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
     def _prepare_operators(self):
         """Prepare process operators."""
+        if getattr(self.cfg, "strict_preflight", True):
+            from data_juicer.core.preflight import pre_instantiation_check
+
+            pre_instantiation_check(self.cfg.process)
         ops = load_ops(self.cfg.process)
 
         # Check for op_fusion configuration with safe attribute access

--- a/data_juicer/core/executor/ray_executor_partitioned.py
+++ b/data_juicer/core/executor/ray_executor_partitioned.py
@@ -640,6 +640,13 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
         # Note: Config validation is handled in _resume_job() if resuming
 
         # Load the full dataset using a single DatasetBuilder
+        # Preflight stage 1: validate config before any expensive I/O
+        if getattr(self.cfg, "strict_preflight", True):
+            from data_juicer.core.preflight import pre_instantiation_check
+
+            pre_instantiation_check(self.cfg.process)
+
+        # Load the full dataset using single DatasetBuilder
         logger.info("Loading dataset with single DatasetBuilder...")
 
         # Ray Dataset captures a copy of DataContext when it is created. This
@@ -1347,10 +1354,6 @@ class PartitionedRayExecutor(ExecutorBase, DAGExecutionMixin, EventLoggingMixin)
 
     def _prepare_operators(self):
         """Prepare process operators."""
-        if getattr(self.cfg, "strict_preflight", True):
-            from data_juicer.core.preflight import pre_instantiation_check
-
-            pre_instantiation_check(self.cfg.process)
         ops = load_ops(self.cfg.process)
 
         # Check for op_fusion configuration with safe attribute access

--- a/data_juicer/core/preflight.py
+++ b/data_juicer/core/preflight.py
@@ -1,0 +1,335 @@
+"""
+Preflight checks for Data-Juicer pipelines.
+
+Two-stage validation that catches configuration errors before expensive
+computation begins:
+
+1. pre_instantiation_check: validates op names, param names, param types
+   (runs before load_ops)
+2. post_instantiation_check: validates schema compatibility, environment
+   readiness (runs after load_ops, before dataset.process)
+"""
+
+import inspect
+from difflib import get_close_matches
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
+
+from data_juicer.ops.base_op import OP, OPERATORS
+
+if TYPE_CHECKING:
+    from data_juicer.core.data.schema import Schema
+
+# ---------------------------------------------------------------------------
+# Error classes
+# ---------------------------------------------------------------------------
+
+
+class PreflightError:
+    """Single preflight error entry."""
+
+    def __init__(self, op_name: str, message: str, suggestions: Optional[List[str]] = None):
+        self.op_name = op_name
+        self.message = message
+        self.suggestions = suggestions or []
+
+    def __str__(self):
+        s = f"[{self.op_name}] {self.message}"
+        if self.suggestions:
+            s += f" (did you mean: {', '.join(self.suggestions)}?)"
+        return s
+
+
+class PipelineConfigError(Exception):
+    """Raised when pre-instantiation checks find errors."""
+
+    def __init__(self, errors: List[PreflightError]):
+        self.errors = errors
+        lines = ["Pipeline configuration errors detected:"]
+        for e in errors:
+            lines.append(f"  ✗ {e}")
+        lines.append(f"\n{len(errors)} error(s) found. Fix the config and retry.")
+        lines.append("Set 'strict_preflight: false' in config to skip preflight checks.")
+        super().__init__("\n".join(lines))
+
+
+class PipelineRuntimeError(Exception):
+    """Raised when post-instantiation checks find errors."""
+
+    def __init__(self, errors: List[PreflightError]):
+        self.errors = errors
+        lines = ["Pipeline runtime preflight errors detected:"]
+        for e in errors:
+            lines.append(f"  ✗ {e}")
+        lines.append(f"\n{len(errors)} error(s) found. Fix the config and retry.")
+        lines.append("Set 'strict_preflight: false' in config to skip preflight checks.")
+        super().__init__("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# Pre-instantiation check
+# ---------------------------------------------------------------------------
+
+
+def _get_valid_params(cls: Type[OP]) -> Dict[str, Any]:
+    """
+    Get the set of valid parameter names and their type annotations
+    for an OP class. Merges:
+    1. _BASE_PARAMS from each class in the MRO (OP, Filter, etc.)
+    2. Explicit __init__ signature params from each class in the MRO
+
+    Returns: {param_name: expected_type_or_None}
+    """
+    params = {}
+
+    # Walk the MRO to collect _BASE_PARAMS and __init__ signatures
+    for klass in inspect.getmro(cls):
+        if klass is object:
+            continue
+
+        # Collect _BASE_PARAMS declared on this class
+        if "_BASE_PARAMS" in klass.__dict__:
+            for param_name, (param_type, _default) in klass._BASE_PARAMS.items():
+                if param_name not in params:
+                    params[param_name] = param_type
+
+        # Collect explicit __init__ signature params
+        if "__init__" in klass.__dict__:
+            try:
+                sig = inspect.signature(klass.__init__)
+            except (ValueError, TypeError):
+                continue
+            for name, p in sig.parameters.items():
+                if name == "self":
+                    continue
+                if p.kind in (p.VAR_POSITIONAL, p.VAR_KEYWORD):
+                    continue
+                annotation = p.annotation if p.annotation != inspect.Parameter.empty else None
+                if name not in params:
+                    params[name] = annotation
+
+    return params
+
+
+def _type_compatible(value: Any, expected_type: Any) -> bool:
+    """
+    Check if value is compatible with expected_type.
+    Lenient for numerics: int annotation accepts int; float annotation accepts int or float.
+    None type means no check.
+    """
+    if expected_type is None:
+        return True
+    if value is None:
+        return True
+
+    # Handle typing module types (Optional, Union, etc.)
+    origin = getattr(expected_type, "__origin__", None)
+    if origin is not None:
+        # For complex types (Union, Optional, List, etc.), skip checking
+        return True
+
+    # Numeric leniency: int annotation accepts int only;
+    # float annotation accepts int or float
+    if expected_type is int:
+        if isinstance(value, float) and value == int(value):
+            return True
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type is float:
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected_type is bool:
+        return isinstance(value, bool)
+    if expected_type is str:
+        return isinstance(value, str)
+
+    # For other types, use isinstance
+    try:
+        return isinstance(value, expected_type)
+    except TypeError:
+        # If isinstance fails (e.g., with some typing constructs), skip
+        return True
+
+
+def pre_instantiation_check(process_list: List[Dict]) -> None:
+    """
+    Validate pipeline config before operator instantiation.
+
+    Checks:
+    - Operator names exist in the registry (with fuzzy match suggestions)
+    - Parameter names are valid for the operator (with fuzzy match suggestions)
+    - Parameter types match annotations
+
+    Args:
+        process_list: cfg.process - list of {op_name: args_dict} dicts
+
+    Raises:
+        PipelineConfigError: if any errors are found, with all errors collected
+    """
+    if not process_list:
+        return
+
+    errors: List[PreflightError] = []
+    all_op_names = list(OPERATORS.modules.keys())
+
+    for item in process_list:
+        if not isinstance(item, dict) or len(item) != 1:
+            errors.append(PreflightError("__config__", f"Malformed process entry: {item!r}"))
+            continue
+        op_name, op_args = list(item.items())[0]
+
+        # Check 1: operator name exists
+        if op_name not in OPERATORS.modules:
+            suggestions = get_close_matches(op_name, all_op_names, n=3, cutoff=0.6)
+            errors.append(
+                PreflightError(
+                    op_name,
+                    f"Unknown operator '{op_name}' not found in registry",
+                    suggestions,
+                )
+            )
+            continue
+
+        # No args to check
+        if not op_args:
+            continue
+
+        cls = OPERATORS.modules[op_name]
+        valid_params = _get_valid_params(cls)
+        valid_param_names = list(valid_params.keys())
+
+        for param_name, param_value in op_args.items():
+            # Check 2: parameter name is valid
+            if param_name not in valid_params:
+                suggestions = get_close_matches(param_name, valid_param_names, n=2, cutoff=0.6)
+                errors.append(
+                    PreflightError(
+                        op_name,
+                        f"Unknown parameter '{param_name}'",
+                        suggestions,
+                    )
+                )
+                continue
+
+            # Check 3: parameter type matches
+            expected_type = valid_params[param_name]
+            if expected_type is not None and param_value is not None:
+                if not _type_compatible(param_value, expected_type):
+                    errors.append(
+                        PreflightError(
+                            op_name,
+                            f"Parameter '{param_name}' expects type "
+                            f"'{expected_type.__name__}', got "
+                            f"'{type(param_value).__name__}' (value: {param_value!r})",
+                        )
+                    )
+
+    if errors:
+        raise PipelineConfigError(errors)
+
+
+# ---------------------------------------------------------------------------
+# Post-instantiation check
+# ---------------------------------------------------------------------------
+
+
+def post_instantiation_check(
+    ops: List[OP],
+    dataset_schema: "Schema",
+    cfg: Optional[Any] = None,
+) -> None:
+    """
+    Validate pipeline state after operator instantiation.
+
+    Checks:
+    - Each op's text_key exists in the dataset schema (non-default only)
+    - Op type is supported by the configured executor (Ray mode restrictions)
+    - Export path accessibility (if cfg provided)
+
+    Args:
+        ops: list of instantiated OP objects
+        dataset_schema: Schema object from the dataset
+        cfg: optional global config namespace
+
+    Raises:
+        PipelineRuntimeError: if any errors are found
+    """
+    errors: List[PreflightError] = []
+    schema_columns = set(dataset_schema.columns) if dataset_schema else set()
+
+    # Determine executor type for compatibility checks
+    executor_type = getattr(cfg, "executor_type", "default") if cfg else "default"
+
+    for op in ops:
+        op_display_name = op._name or type(op).__name__
+
+        # Check: text_key exists in schema — only when user explicitly set
+        # a non-default text_key (meaning they expect that column to exist).
+        # Default text_key may not be needed by multimedia ops.
+        op_base_params = type(op)._BASE_PARAMS if hasattr(type(op), "_BASE_PARAMS") else OP._BASE_PARAMS
+        default_text_key = op_base_params.get("text_key", (str, "text"))[1]
+        if schema_columns and op.text_key != default_text_key and op.text_key not in schema_columns:
+            errors.append(
+                PreflightError(
+                    op_display_name,
+                    f"text_key '{op.text_key}' not found in dataset " f"columns: {sorted(schema_columns)}",
+                )
+            )
+
+        # Check: op type is supported by the current executor mode
+        if executor_type and executor_type not in op._supported_exec_modes:
+            op_type_name = next(
+                (b.__name__ for b in type(op).__mro__[1:] if issubclass(b, OP) and b is not OP),
+                type(op).__name__,
+            )
+            errors.append(
+                PreflightError(
+                    op_display_name,
+                    f"Operator type '{op_type_name}' does not support "
+                    f"executor mode '{executor_type}'. "
+                    f"Supported modes: {op._supported_exec_modes}",
+                )
+            )
+
+    # Check config-level constraints
+    if cfg:
+        errors.extend(_check_export_path(cfg))
+
+    if errors:
+        raise PipelineRuntimeError(errors)
+
+
+def _check_export_path(cfg) -> List[PreflightError]:
+    """Check export path accessibility."""
+    import os
+    from urllib.parse import urlparse
+
+    errors = []
+    export_path = getattr(cfg, "export_path", None)
+    if not export_path:
+        return errors
+
+    scheme = urlparse(export_path).scheme.lower()
+    if scheme in ("s3", "hdfs"):
+        # Remote paths: check credentials exist
+        if scheme == "s3":
+            has_creds = (hasattr(cfg, "export_aws_credentials") and cfg.export_aws_credentials) or os.environ.get(
+                "AWS_ACCESS_KEY_ID"
+            )
+            if not has_creds:
+                errors.append(
+                    PreflightError(
+                        "__config__",
+                        f"Export path is S3 ({export_path}) but no AWS credentials found "
+                        f"(neither export_aws_credentials config nor AWS_ACCESS_KEY_ID env var)",
+                    )
+                )
+    else:
+        # Local path: check parent directory is writable
+        export_dir = os.path.dirname(os.path.abspath(export_path))
+        if os.path.exists(export_dir) and not os.access(export_dir, os.W_OK):
+            errors.append(
+                PreflightError(
+                    "__config__",
+                    f"Export directory '{export_dir}' is not writable",
+                )
+            )
+
+    return errors

--- a/data_juicer/core/preflight.py
+++ b/data_juicer/core/preflight.py
@@ -297,7 +297,7 @@ def post_instantiation_check(
 
 
 def _check_export_path(cfg) -> List[PreflightError]:
-    """Check export path accessibility."""
+    """Check export path accessibility (local paths only)."""
     import os
     from urllib.parse import urlparse
 
@@ -307,20 +307,11 @@ def _check_export_path(cfg) -> List[PreflightError]:
         return errors
 
     scheme = urlparse(export_path).scheme.lower()
-    if scheme in ("s3", "hdfs"):
-        # Remote paths: check credentials exist
-        if scheme == "s3":
-            has_creds = (hasattr(cfg, "export_aws_credentials") and cfg.export_aws_credentials) or os.environ.get(
-                "AWS_ACCESS_KEY_ID"
-            )
-            if not has_creds:
-                errors.append(
-                    PreflightError(
-                        "__config__",
-                        f"Export path is S3 ({export_path}) but no AWS credentials found "
-                        f"(neither export_aws_credentials config nor AWS_ACCESS_KEY_ID env var)",
-                    )
-                )
+    if scheme in ("s3", "hdfs", "oss"):
+        # Remote paths: rely on the SDK's credential provider chain at export
+        # time. Preflight cannot reliably detect all valid auth mechanisms
+        # (IAM roles, Web Identity, shared credential files, etc.)
+        pass
     else:
         # Local path: check parent directory is writable
         export_dir = os.path.dirname(os.path.abspath(export_path))

--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -296,10 +296,53 @@ class OP(metaclass=OPMetaClass):
     # whether this operator is a batched operator
     _batched_op = False
 
+    # executor modes this operator supports: "default", "ray", "ray_partitioned"
+    _supported_exec_modes = ("default",)
+
     # extra requirements for this operator. Should be:
     #   1. a list of packages
     #   2. a string of the path to the requirements.txt file
     _requirements = None
+
+    # Centralized declaration of all parameters accepted by the OP base class.
+    # Format: {param_name: (type_or_None, default_value)}
+    # This serves as the authoritative source for:
+    #   - preflight parameter name validation
+    #   - preflight parameter type checking
+    #   - documentation generation
+    _BASE_PARAMS = {
+        # Data keys
+        "text_key": (str, "text"),
+        "image_key": (str, "images"),
+        "audio_key": (str, "audios"),
+        "video_key": (str, "videos"),
+        "image_bytes_key": (str, "image_bytes"),
+        "system_key": (str, "system"),
+        "instruction_key": (str, "instruction"),
+        "prompt_key": (str, "prompt"),
+        "query_key": (str, "query"),
+        "response_key": (str, "response"),
+        "history_key": (str, "history"),
+        "index_key": (None, None),
+        "work_dir": (None, None),
+        # Behavior control
+        "skip_op_error": (bool, False),
+        "auto_op_parallelism": (bool, True),
+        "batch_mode": (None, None),
+        "accelerator": (None, None),
+        "batch_size": (int, DEFAULT_BATCH_SIZE),
+        "num_proc": (None, None),
+        "turbo": (bool, False),
+        # Resource declarations
+        "cpu_required": (None, None),
+        "gpu_required": (None, None),
+        "mem_required": (None, None),
+        "num_cpus": (None, None),
+        "num_gpus": (None, None),
+        "memory": (None, None),
+        "runtime_env": (None, None),
+        "ray_execution_mode": (None, None),
+    }
 
     # Attributes excluded from cache fingerprinting only (not from
     # pickling/dill serialization).  These do not affect data
@@ -604,6 +647,8 @@ class OP(metaclass=OPMetaClass):
 
 
 class Mapper(OP):
+    _supported_exec_modes = ("default", "ray", "ray_partitioned")
+
     def __init__(self, *args, **kwargs):
         """
         Base class that conducts data editing.
@@ -715,6 +760,16 @@ class Mapper(OP):
 
 
 class Filter(OP):
+    _supported_exec_modes = ("default", "ray", "ray_partitioned")
+
+    _BASE_PARAMS = {
+        **OP._BASE_PARAMS,
+        "stats_export_path": (None, None),
+        "min_closed_interval": (bool, True),
+        "max_closed_interval": (bool, True),
+        "reversed_range": (bool, False),
+    }
+
     def __init__(self, *args, **kwargs):
         """
         Base class that removes specific info.
@@ -865,6 +920,8 @@ class Filter(OP):
 
 
 class Deduplicator(OP):
+    _supported_exec_modes = ("default", "ray", "ray_partitioned")
+
     def __init__(self, *args, **kwargs):
         """
         Base class that conducts deduplication.
@@ -1082,6 +1139,8 @@ class Aggregator(OP):
 
 class Pipeline(OP):
     """Base class for Operators that represent a data processing pipeline."""
+
+    _supported_exec_modes = ("default", "ray", "ray_partitioned")
 
     def __init__(self, *args, **kwargs):
         """

--- a/tests/core/test_preflight.py
+++ b/tests/core/test_preflight.py
@@ -1,0 +1,219 @@
+"""
+Tests for the preflight check system.
+
+These tests verify that configuration errors are caught early (at preflight)
+rather than silently passing through to runtime.
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, ".")
+
+
+
+
+class TestPreflightPreInstantiation(unittest.TestCase):
+    """
+    Tests for pre-instantiation checks (before load_ops).
+    These test the DESIRED behavior after preflight is implemented.
+    """
+
+    def test_unknown_op_name_with_suggestion(self):
+        """Should report the error with fuzzy-match suggestions."""
+        from data_juicer.core.preflight import (
+            PipelineConfigError,
+            pre_instantiation_check,
+        )
+
+        with self.assertRaises(PipelineConfigError) as ctx:
+            pre_instantiation_check([{"remove_long_wordss_mapper": {"min_len": 1}}])
+
+        error = ctx.exception
+        # Should contain the bad op name and suggestions
+        self.assertIn("remove_long_wordss_mapper", str(error))
+        self.assertIn("remove_long_words_mapper", str(error))  # suggestion
+
+    def test_completely_unknown_op_name(self):
+        """Should report error even without close matches."""
+        from data_juicer.core.preflight import (
+            PipelineConfigError,
+            pre_instantiation_check,
+        )
+
+        with self.assertRaises(PipelineConfigError) as ctx:
+            pre_instantiation_check([{"totally_fake_xyz_op": None}])
+        self.assertIn("totally_fake_xyz_op", str(ctx.exception))
+
+    def test_unknown_param_name_detected(self):
+        """Should catch typos in parameter names."""
+        from data_juicer.core.preflight import (
+            PipelineConfigError,
+            pre_instantiation_check,
+        )
+
+        with self.assertRaises(PipelineConfigError) as ctx:
+            pre_instantiation_check([{"remove_long_words_mapper": {"min_length": 1}}])
+
+        error = ctx.exception
+        self.assertIn("min_length", str(error))
+        self.assertIn("min_len", str(error))  # suggestion
+
+    def test_wrong_param_type_detected(self):
+        """Should catch type mismatches based on annotations."""
+        from data_juicer.core.preflight import (
+            PipelineConfigError,
+            pre_instantiation_check,
+        )
+
+        with self.assertRaises(PipelineConfigError) as ctx:
+            pre_instantiation_check([{"remove_long_words_mapper": {"min_len": "hello"}}])
+
+        error = ctx.exception
+        self.assertIn("min_len", str(error))
+        self.assertIn("int", str(error))
+
+    def test_numeric_type_coercion_accepted(self):
+        """int annotation should accept int-compatible float (e.g., 10.0)."""
+        from data_juicer.core.preflight import pre_instantiation_check
+
+        # Should NOT raise - 10.0 is int-compatible (YAML may parse 10 as 10.0)
+        pre_instantiation_check([{"remove_long_words_mapper": {"min_len": 10}}])
+        pre_instantiation_check([{"remove_long_words_mapper": {"min_len": 10.0}}])
+
+    def test_none_args_accepted(self):
+        """OP with null config (all defaults) should pass."""
+        from data_juicer.core.preflight import pre_instantiation_check
+
+        # Should NOT raise
+        pre_instantiation_check([{"remove_long_words_mapper": None}])
+
+    def test_valid_config_passes(self):
+        """A fully valid config should pass without errors."""
+        from data_juicer.core.preflight import pre_instantiation_check
+
+        pre_instantiation_check([
+            {"remove_long_words_mapper": {"min_len": 1, "max_len": 100}},
+            {"language_id_score_filter": {"lang": "en", "min_score": 0.8}},
+        ])
+
+    def test_multiple_errors_collected(self):
+        """All errors in the pipeline should be reported at once."""
+        from data_juicer.core.preflight import (
+            PipelineConfigError,
+            pre_instantiation_check,
+        )
+
+        with self.assertRaises(PipelineConfigError) as ctx:
+            pre_instantiation_check([
+                {"remove_long_words_mapper": {"min_length": 1}},  # typo param
+                {"fake_op_xyz": None},  # bad op name
+            ])
+
+        error = ctx.exception
+        # Both errors should be reported
+        self.assertTrue(len(error.errors) >= 2)
+
+    def test_base_op_params_accepted(self):
+        """Parameters defined in OP base class should be valid for any op."""
+        from data_juicer.core.preflight import pre_instantiation_check
+
+        # These are base class params, should be valid for any OP
+        pre_instantiation_check([
+            {"remove_long_words_mapper": {
+                "min_len": 1,
+                "text_key": "content",
+                "batch_size": 500,
+                "num_proc": 4,
+            }},
+        ])
+
+
+class TestPreflightPostInstantiation(unittest.TestCase):
+    """
+    Tests for post-instantiation checks (after load_ops, before process).
+    """
+
+    def test_missing_custom_text_key_in_schema(self):
+        """Should detect when a user-specified (non-default) text_key doesn't exist."""
+        from data_juicer.core.data.schema import Schema
+        from data_juicer.core.preflight import (
+            PipelineRuntimeError,
+            post_instantiation_check,
+        )
+        from data_juicer.ops.load import load_ops
+
+        ops = load_ops([{"remove_long_words_mapper": {"text_key": "content"}}])
+        schema = Schema(column_types={"text": str, "meta": dict}, columns=["text", "meta"])
+
+        with self.assertRaises(PipelineRuntimeError) as ctx:
+            post_instantiation_check(ops, schema)
+
+        self.assertIn("content", str(ctx.exception))
+
+    def test_default_text_key_missing_not_blocked(self):
+        """Default text_key missing should NOT block — multimedia ops may not need it."""
+        from data_juicer.core.data.schema import Schema
+        from data_juicer.core.preflight import post_instantiation_check
+        from data_juicer.ops.load import load_ops
+
+        ops = load_ops([{"remove_long_words_mapper": {"min_len": 1}}])
+        # Dataset without 'text' column — but since text_key is default, don't block
+        schema = Schema(column_types={"images": str, "meta": dict}, columns=["images", "meta"])
+
+        # Should NOT raise
+        post_instantiation_check(ops, schema)
+
+    def test_valid_schema_passes(self):
+        """When text_key exists in schema, should pass."""
+        from data_juicer.core.data.schema import Schema
+        from data_juicer.core.preflight import post_instantiation_check
+        from data_juicer.ops.load import load_ops
+
+        ops = load_ops([{"remove_long_words_mapper": {"min_len": 1}}])
+        schema = Schema(column_types={"text": str}, columns=["text"])
+
+        # Should not raise
+        post_instantiation_check(ops, schema)
+
+    def test_unsupported_op_type_in_ray_mode(self):
+        """Selector/Grouper/Aggregator should be rejected in Ray mode."""
+        from types import SimpleNamespace
+
+        from data_juicer.core.data.schema import Schema
+        from data_juicer.core.preflight import (
+            PipelineRuntimeError,
+            post_instantiation_check,
+        )
+        from data_juicer.ops.load import load_ops
+
+        ops = load_ops([{"topk_specified_field_selector": {
+            "field_key": "stats.lang_score",
+            "top_ratio": 0.5,
+        }}])
+        schema = Schema(column_types={"text": str}, columns=["text"])
+        cfg = SimpleNamespace(executor_type="ray", export_path="/tmp/out")
+
+        with self.assertRaises(PipelineRuntimeError) as ctx:
+            post_instantiation_check(ops, schema, cfg)
+
+        self.assertIn("does not support executor mode", str(ctx.exception))
+
+    def test_mapper_in_ray_mode_passes(self):
+        """Mapper should be fine in Ray mode."""
+        from types import SimpleNamespace
+
+        from data_juicer.core.data.schema import Schema
+        from data_juicer.core.preflight import post_instantiation_check
+        from data_juicer.ops.load import load_ops
+
+        ops = load_ops([{"remove_long_words_mapper": {"min_len": 1}}])
+        schema = Schema(column_types={"text": str}, columns=["text"])
+        cfg = SimpleNamespace(executor_type="ray", export_path="/tmp/out")
+
+        # Should not raise
+        post_instantiation_check(ops, schema, cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ops/test_base_op.py
+++ b/tests/ops/test_base_op.py
@@ -1,3 +1,4 @@
+import inspect
 import unittest
 
 import numpy as np
@@ -779,6 +780,109 @@ class AggregatorRunTest(DataJuicerTestCaseBase):
         op = SimpleAgg()
         result = op.run(ds)
         self.assertEqual(result[Fields.batch_meta][0], {'existing': True})
+
+
+class TestBaseParamsSync(unittest.TestCase):
+    """
+    Reflection-based tests to ensure _BASE_PARAMS stays in sync with
+    actual kwargs usage in __init__ methods.
+    """
+
+    def _extract_kwargs_keys(self, cls):
+        """Extract all kwargs access keys from a class's __init__ source.
+
+        Matches: kwargs.get("key", ...), kwargs.pop("key", ...), kwargs["key"]
+        """
+        import ast
+        import textwrap
+
+        source = inspect.getsource(cls.__init__)
+        source = textwrap.dedent(source)
+        tree = ast.parse(source)
+
+        keys = set()
+        for node in ast.walk(tree):
+            # Match: kwargs.get("key", ...) or kwargs.pop("key", ...)
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in ("get", "pop")
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "kwargs"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                keys.add(node.args[0].value)
+            # Match: kwargs["key"]
+            elif (
+                isinstance(node, ast.Subscript)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "kwargs"
+                and isinstance(node.slice, ast.Constant)
+                and isinstance(node.slice.value, str)
+            ):
+                keys.add(node.slice.value)
+        return keys
+
+    def test_op_base_params_covers_all_kwargs_access(self):
+        """Every kwargs access key in OP.__init__ must appear in OP._BASE_PARAMS."""
+        kwargs_keys = self._extract_kwargs_keys(OP)
+        base_params_keys = set(OP._BASE_PARAMS.keys())
+
+        missing = kwargs_keys - base_params_keys
+        self.assertEqual(
+            missing,
+            set(),
+            f"OP.__init__ uses kwargs for keys not in _BASE_PARAMS: {sorted(missing)}",
+        )
+
+    def test_filter_base_params_covers_all_kwargs_access(self):
+        """Every kwargs access key in Filter.__init__ must appear in Filter._BASE_PARAMS."""
+        kwargs_keys = self._extract_kwargs_keys(Filter)
+        base_params_keys = set(Filter._BASE_PARAMS.keys())
+
+        missing = kwargs_keys - base_params_keys
+        self.assertEqual(
+            missing,
+            set(),
+            f"Filter.__init__ uses kwargs for keys not in _BASE_PARAMS: {sorted(missing)}",
+        )
+
+    def test_op_base_params_no_extra_keys(self):
+        """_BASE_PARAMS should not have stale keys that aren't actually used."""
+        kwargs_keys = self._extract_kwargs_keys(OP)
+        base_params_keys = set(OP._BASE_PARAMS.keys())
+
+        extra = base_params_keys - kwargs_keys
+        if extra:
+            import warnings
+
+            warnings.warn(
+                f"OP._BASE_PARAMS has keys not found in kwargs access: {sorted(extra)}. "
+                f"Verify these are intentional."
+            )
+
+    def test_all_op_subclasses_declare_supported_exec_modes(self):
+        """
+        Every direct OP subclass must have _supported_exec_modes defined
+        and it must be a non-empty tuple of valid mode strings.
+        """
+        valid_modes = {"default", "ray", "ray_partitioned"}
+        for klass in OP.__subclasses__():
+            self.assertTrue(
+                hasattr(klass, "_supported_exec_modes"),
+                f"{klass.__name__} missing _supported_exec_modes",
+            )
+            modes = klass._supported_exec_modes
+            self.assertIsInstance(modes, tuple, f"{klass.__name__}._supported_exec_modes must be a tuple")
+            self.assertTrue(len(modes) > 0, f"{klass.__name__}._supported_exec_modes is empty")
+            for m in modes:
+                self.assertIn(
+                    m,
+                    valid_modes,
+                    f"{klass.__name__}._supported_exec_modes contains invalid mode '{m}'",
+                )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Add a two-stage preflight check system that catches configuration errors before expensive computation begins, shifting runtime failures to fail-fast errors.

## Behavior Changes (Before → After)

### 1. Unknown operator name (e.g. `remove_long_wordss_mapper`)
- **Before**: `load_ops()` raises bare `KeyError('remove_long_wordss_mapper')` — no context, no suggestion
- **After**: Preflight raises `PipelineConfigError` with message: `Unknown operator 'remove_long_wordss_mapper' not found in registry (did you mean: remove_long_words_mapper?)`

### 2. Unknown parameter name (e.g. `min_length` instead of `min_len`)
- **Before**: Silently swallowed by `**kwargs` — parameter has no effect, user thinks it's configured
- **After**: Preflight raises `PipelineConfigError`: `Unknown parameter 'min_length' (did you mean: min_len?)`

### 3. Wrong parameter type (e.g. `max_len: "hello"`)
- **Before**: Stored as-is, crashes at runtime during `process_batched()` with `TypeError`
- **After**: Preflight raises `PipelineConfigError`: `Parameter 'max_len' expects type 'int', got 'str' (value: 'hello')`

### 4. Unsupported op type in Ray mode (e.g. Selector in ray executor)
- **Before**: Pipeline starts, data loads, ops instantiate → hits `NotImplementedError` inside `_run_single_op()` after computation has begun
- **After**: Preflight raises `PipelineRuntimeError`: `Operator type 'Selector' does not support executor mode 'ray'. Supported modes: ('default',)`

### 5. Custom text_key not in dataset columns (e.g. `text_key: "content"` but dataset only has `text`)
- **Before**: No validation — op runs and either gets `KeyError` or processes empty data silently
- **After**: Preflight raises `PipelineRuntimeError`: `text_key 'content' not found in dataset columns: ['text', ...]`

### 6. Malformed process entry in config (e.g. string instead of dict)
- **Before**: `AttributeError: 'str' object has no attribute 'items'` in `load_ops()`
- **After**: Preflight raises `PipelineConfigError`: `Malformed process entry: 'some_string'`

### Unchanged behaviors
- Default `text_key` missing from schema → **not blocked** (multimedia ops may not need it)
- `op_fusion + use_checkpoint` → **not blocked** (system auto-resolves by disabling checkpoint)
- `dataset.schema()` failure in `ray_executor.py` → **gracefully skipped** (preflight stage 2 not run, same as pre-PR)
- `dataset.schema()` failure in `ray_executor_partitioned.py` → **still crashes** (unchanged — columns required for export)

## Architecture

### Stage 1 — Pre-instantiation (before load_ops)
- Unknown operator names (with fuzzy-match suggestions via `difflib.get_close_matches`)
- Unknown parameter names (with fuzzy-match suggestions)
- Parameter type mismatches (lenient: `10.0` accepted for int annotations)
- Malformed process entries

### Stage 2 — Post-instantiation (after load_ops, before process)
- Custom text_key not found in dataset schema
- Op type incompatible with current executor mode (`_supported_exec_modes`)
- Export path accessibility (S3 credentials, local writability)

### Key design decisions
- Errors only (no warnings), hard stop, both stages collect all errors at once
- `strict_preflight: false` config option as escape hatch (mentioned in error messages)
- `_BASE_PARAMS` on OP/Filter declares valid params for static checking
- `_supported_exec_modes` on each OP subclass declares executor compatibility
- Respects existing `**kwargs` transparency pattern for operator flexibility
- Supports custom ops loaded via `load_custom_operators` (uses OPERATORS registry)

## Files changed
- `data_juicer/core/preflight.py` — new preflight validation module
- `data_juicer/ops/base_op.py` — added `_BASE_PARAMS`, `_supported_exec_modes`
- `data_juicer/config/config.py` — added `--strict_preflight` argument
- `data_juicer/core/executor/default_executor.py` — integrated both stages
- `data_juicer/core/executor/ray_executor.py` — integrated both stages
- `data_juicer/core/executor/ray_executor_partitioned.py` — integrated both stages
- `data_juicer/core/data/ray_dataset.py` — updated runtime error to reference `_supported_exec_modes`
- `tests/core/test_preflight.py` — 14 preflight tests
- `tests/ops/test_base_op.py` — 4 sync guard tests