### PR TITLE
fix(exporter): clear error message when export_path has no file extension

### DIFF
--- a/data_juicer/core/exporter.py
+++ b/data_juicer/core/exporter.py
@@ -179,7 +179,15 @@ class Exporter:
         :param export_path: the path to export datasets.
         :return: the suffix of export_path.
         """
-        suffix = export_path.split(".")[-1].lower()
+        parts = export_path.rsplit(".", 1)
+        if len(parts) < 2 or "/" in parts[-1]:
+            raise ValueError(
+                f"Cannot determine file format from export_path "
+                f"[{export_path}] because it has no file extension. "
+                f"Please add a suffix (e.g. .jsonl, .json, .parquet) "
+                f"or specify export_type explicitly."
+            )
+        suffix = parts[-1].lower()
         return suffix
 
     @staticmethod

--- a/tests/core/test_exporter.py
+++ b/tests/core/test_exporter.py
@@ -502,5 +502,31 @@ class CoreExporterFileTest(DataJuicerTestCaseBase):
         self.assertTrue(any(name.endswith(".jsonl") for name in shard_files))
 
 
+class ExporterNoSuffixTest(DataJuicerTestCaseBase):
+    """Regression test: export_path without extension should give clear error."""
+
+    def test_no_suffix_raises_valueerror(self):
+        with self.assertRaises(ValueError) as ctx:
+            Exporter(export_path='s3://bucket/data/result', num_proc=1)
+        self.assertIn('no file extension', str(ctx.exception))
+
+    def test_no_suffix_local_path_raises_valueerror(self):
+        with self.assertRaises(ValueError) as ctx:
+            Exporter(export_path='/tmp/output/dataset', num_proc=1)
+        self.assertIn('no file extension', str(ctx.exception))
+
+    def test_valid_suffix_still_works(self):
+        exp = Exporter(export_path='/tmp/output/data.jsonl', num_proc=1)
+        self.assertEqual(exp.suffix, 'jsonl')
+
+    def test_explicit_export_type_bypasses_suffix(self):
+        exp = Exporter(
+            export_path='s3://bucket/data/result',
+            export_type='jsonl',
+            num_proc=1,
+        )
+        self.assertEqual(exp.suffix, 'jsonl')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

When `export_path` has no file extension (e.g. `s3://bucket/data/result`), `Exporter._get_suffix()` returns the entire last path segment as a "suffix", leading to a confusing `NotImplementedError`:

```
NotImplementedError: Suffix of export path [s3://bucket/data/result] or specified
export_type [None] is not supported for now. Only support ['jsonl', 'json', 'parquet'].
```

The message implies the path format is wrong when the actual issue is simply a missing extension.

## Root Cause

`_get_suffix()` uses `export_path.split('.')[-1]` which returns the whole last segment when no dot is present:
```python
's3://bucket/data/result'.split('.')[-1]  # → 's3://bucket/data/result'
```

## Fix

Detect the no-extension case explicitly (using `rsplit('.', 1)` and checking if `/` appears in the "suffix" part) and raise a `ValueError` with actionable guidance:

```
ValueError: Cannot determine file format from export_path [s3://bucket/data/result]
because it has no file extension. Please add a suffix (e.g. .jsonl, .json, .parquet)
or specify export_type explicitly.
```

Also handles edge cases like `/path/to/v1.2/output` where the dot belongs to a directory.

## Tests

Added `ExporterNoSuffixTest` with 4 cases:
- S3 path without extension → ValueError
- Local path without extension → ValueError
- Valid suffix → works normally
- No suffix but explicit `export_type` → bypasses check

---
Tracked in: cmgzn/data-juicer#155