### PR TITLE
fix(hpo): read gzip JSONL stats samples

### DIFF
--- a/data_juicer/utils/constant.py
+++ b/data_juicer/utils/constant.py
@@ -1,4 +1,5 @@
 import copy
+import gzip
 import inspect
 import io
 import os
@@ -266,15 +267,15 @@ class StatsKeysMeta(type):
             tmp_dj_cfg = copy.deepcopy(dj_cfg)
             # the access has been skipped due to the use of cache
             # we will using a temp data sample to get the access log
-            if os.path.exists(dj_cfg.dataset_path) and (
-                "jsonl" in dj_cfg.dataset_path or "jsonl.zst" in dj_cfg.dataset_path
+            if os.path.exists(dj_cfg.dataset_path) and dj_cfg.dataset_path.endswith(
+                (".jsonl.zst", ".jsonl.gz", ".jsonl")
             ):
                 logger.info("Begin to track the usage of ops with a dummy data sample")
 
                 # load the first line as tmp_data
                 tmp_f_name = None
                 first_line = None
-                if "jsonl.zst" in dj_cfg.dataset_path:
+                if dj_cfg.dataset_path.endswith(".jsonl.zst"):
                     tmp_f_name = dj_cfg.dataset_path.replace(".jsonl.zst", ".tmp.jsonl")
                     # Open the file in binary mode and
                     # create a Zstandard decompression context
@@ -285,7 +286,11 @@ class StatsKeysMeta(type):
                         with dctx.stream_reader(compressed_file) as reader:
                             text_stream = io.TextIOWrapper(reader, encoding="utf-8")
                             first_line = text_stream.readline()
-                elif "jsonl" in dj_cfg.dataset_path:
+                elif dj_cfg.dataset_path.endswith(".jsonl.gz"):
+                    tmp_f_name = dj_cfg.dataset_path.replace(".jsonl.gz", ".tmp.jsonl")
+                    with gzip.open(dj_cfg.dataset_path, "rt", encoding="utf-8") as orig_file:
+                        first_line = orig_file.readline()
+                elif dj_cfg.dataset_path.endswith(".jsonl"):
                     tmp_f_name = dj_cfg.dataset_path.replace(".jsonl", ".tmp.jsonl")
                     with open(dj_cfg.dataset_path, "r", encoding="utf-8") as orig_file:
                         first_line = orig_file.readline()
@@ -309,14 +314,16 @@ class StatsKeysMeta(type):
                         op_config[op_name]["auto_op_parallelism"] = False
                         op_config[op_name]["num_proc"] = None
 
-                from data_juicer.config import get_init_configs
-                from data_juicer.core import Analyzer
+                try:
+                    from data_juicer.config import get_init_configs
+                    from data_juicer.core import Analyzer
 
-                tmp_analyzer = Analyzer(get_init_configs(tmp_dj_cfg))
-                # do not overwrite the true analysis results
-                tmp_analyzer.run(skip_export=True)
-
-                os.remove(tmp_f_name)
+                    tmp_analyzer = Analyzer(get_init_configs(tmp_dj_cfg))
+                    # do not overwrite the true analysis results
+                    tmp_analyzer.run(skip_export=True)
+                finally:
+                    if os.path.exists(tmp_f_name):
+                        os.remove(tmp_f_name)
             else:
                 raise NotImplementedError(
                     f"For now, the dummy data is supported for only jsonl type"

--- a/tests/utils/test_constant.py
+++ b/tests/utils/test_constant.py
@@ -1,10 +1,11 @@
-import os
-import unittest
-import tempfile
+import gzip
 import json
+import os
+import tempfile
+import unittest
 
-from data_juicer.core import NestedDataset
 from data_juicer.config import init_configs
+from data_juicer.core import NestedDataset
 from data_juicer.utils.constant import StatsKeys
 from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
 
@@ -13,16 +14,20 @@ test_yaml_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                               'config',
                               'demo_4_test.yaml')
 
+
 class StatsKeysTest(DataJuicerTestCaseBase):
 
     def setUp(self) -> None:
         super().setUp()
         StatsKeys._accessed_by = {}
-        
+
         # Create a temporary jsonl file for testing
         self.temp_dir = tempfile.TemporaryDirectory()
         self.temp_jsonl = os.path.join(self.temp_dir.name, "test-dataset.jsonl")
         with open(self.temp_jsonl, 'w', encoding='utf-8') as f:
+            f.write(json.dumps({"text": "hello world"}) + "\n")
+        self.temp_jsonl_gz = os.path.join(self.temp_dir.name, "test-dataset.jsonl.gz")
+        with gzip.open(self.temp_jsonl_gz, 'wt', encoding='utf-8') as f:
             f.write(json.dumps({"text": "hello world"}) + "\n")
 
     def tearDown(self) -> None:
@@ -35,7 +40,7 @@ class StatsKeysTest(DataJuicerTestCaseBase):
         # Create a temporary config with the test dataset path
         args = f'--config {test_yaml_path} --dataset_path {self.temp_jsonl}'.split()
         cfg = init_configs(args=args)
-        
+
         res = StatsKeys.get_access_log(cfg)
         self.assertEqual(len(res), 1)  # only 1 filter
         self.assertIn('language_id_score_filter', res)
@@ -49,11 +54,24 @@ class StatsKeysTest(DataJuicerTestCaseBase):
         dataset = NestedDataset.from_list([{'text': 'hello world'}])
         args = f'--config {test_yaml_path} --dataset_path {self.temp_jsonl}'.split()
         cfg = init_configs(args=args)
-        
+
         res = StatsKeys.get_access_log(cfg, dataset)
         self.assertEqual(len(res), 1)  # only 1 filter
         self.assertIn('language_id_score_filter', res)
         self.assertEqual(res['language_id_score_filter'], {'lang', 'lang_score'})
+
+    def test_basic_func_with_gzip_dataset(self):
+        plain_args = f'--config {test_yaml_path} --dataset_path {self.temp_jsonl}'.split()
+        plain_cfg = init_configs(args=plain_args)
+        plain_res = StatsKeys.get_access_log(plain_cfg)
+
+        StatsKeys._accessed_by = {}
+        gzip_args = f'--config {test_yaml_path} --dataset_path {self.temp_jsonl_gz}'.split()
+        gzip_cfg = init_configs(args=gzip_args)
+        gzip_res = StatsKeys.get_access_log(gzip_cfg)
+
+        self.assertEqual(gzip_res, plain_res)
+        self.assertFalse(os.path.exists(self.temp_jsonl_gz.replace('.jsonl.gz', '.tmp.jsonl')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

`StatsKeys.get_access_log` treated `.jsonl.gz` datasets as plain JSONL while building its HPO analysis sample, causing a `UnicodeDecodeError` before analysis started.

## Fix

- detect supported JSONL suffixes explicitly;
- read gzip JSONL through `gzip.open(..., "rt")` and write a plain `.tmp.jsonl` sample;
- remove the temporary sample even when analyzer setup or execution fails;
- add regression coverage comparing gzip and plain JSONL access logs.

## Validation

- plain JSONL, gzip JSONL, and Zstandard JSONL sample harnesses pass;
- analyzer-error cleanup harness passes;
- isort, flake8, compileall, and `git diff --check` pass.
