### PR TITLE
feat: migrate fork repos to personal maintenance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /data-juicer
 # install basic dependencies for Data-Juicer
 ENV UV_HTTP_TIMEOUT=600
 RUN uv pip install --upgrade --no-cache-dir setuptools==69.5.1 setuptools_scm -i https://pypi.tuna.tsinghua.edu.cn/simple --system \
-    && uv pip install --no-cache-dir git+https://github.com/cmgzn/recognize-anything.git -i https://pypi.tuna.tsinghua.edu.cn/simple --system
+    && uv pip install --no-cache-dir git+https://github.com/cmgzn/recognize-anything.git@889201b76458513d04afde5d4cfa376aa9e33ebf -i https://pypi.tuna.tsinghua.edu.cn/simple --system
 
 # copy source code and install
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /data-juicer
 # install basic dependencies for Data-Juicer
 ENV UV_HTTP_TIMEOUT=600
 RUN uv pip install --upgrade --no-cache-dir setuptools==69.5.1 setuptools_scm -i https://pypi.tuna.tsinghua.edu.cn/simple --system \
-    && uv pip install --no-cache-dir git+https://github.com/datajuicer/recognize-anything.git -i https://pypi.tuna.tsinghua.edu.cn/simple --system
+    && uv pip install --no-cache-dir git+https://github.com/cmgzn/recognize-anything.git -i https://pypi.tuna.tsinghua.edu.cn/simple --system
 
 # copy source code and install
 COPY . .

--- a/data_juicer/ops/mapper/image_tagging_mapper.py
+++ b/data_juicer/ops/mapper/image_tagging_mapper.py
@@ -39,7 +39,7 @@ class ImageTaggingMapper(Mapper):
         """
         kwargs["memory"] = "9GB" if kwargs.get("memory", 0) == 0 else kwargs["memory"]
         super().__init__(*args, **kwargs)
-        LazyLoader.check_packages(["ram @ git+https://github.com/datajuicer/recognize-anything.git"])
+        LazyLoader.check_packages(["ram @ git+https://github.com/cmgzn/recognize-anything.git"])
         self.model_key = prepare_model(
             model_type="recognizeAnything", pretrained_model_name_or_path="ram_plus_swin_large_14m.pth", input_size=384
         )

--- a/data_juicer/ops/mapper/image_tagging_mapper.py
+++ b/data_juicer/ops/mapper/image_tagging_mapper.py
@@ -39,7 +39,9 @@ class ImageTaggingMapper(Mapper):
         """
         kwargs["memory"] = "9GB" if kwargs.get("memory", 0) == 0 else kwargs["memory"]
         super().__init__(*args, **kwargs)
-        LazyLoader.check_packages(["ram @ git+https://github.com/cmgzn/recognize-anything.git"])
+        LazyLoader.check_packages(
+            ["ram @ git+https://github.com/cmgzn/recognize-anything.git@889201b76458513d04afde5d4cfa376aa9e33ebf"]
+        )
         self.model_key = prepare_model(
             model_type="recognizeAnything", pretrained_model_name_or_path="ram_plus_swin_large_14m.pth", input_size=384
         )

--- a/data_juicer/ops/mapper/video_captioning_from_audio_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_audio_mapper.py
@@ -37,7 +37,7 @@ class VideoCaptioningFromAudioMapper(Mapper):
         LazyLoader.check_packages(
             [
                 "transformers",
-                "transformers-stream-generator @ git+https://github.com/datajuicer/transformers-stream-generator.git",
+                "transformers-stream-generator @ git+https://github.com/cmgzn/transformers-stream-generator.git",
                 "einops",
                 "accelerate",
                 "tiktoken",

--- a/data_juicer/ops/mapper/video_captioning_from_audio_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_audio_mapper.py
@@ -37,7 +37,7 @@ class VideoCaptioningFromAudioMapper(Mapper):
         LazyLoader.check_packages(
             [
                 "transformers",
-                "transformers-stream-generator @ git+https://github.com/cmgzn/transformers-stream-generator.git",
+                "transformers-stream-generator @ git+https://github.com/cmgzn/transformers-stream-generator.git@1b356de822eb1da8e7a35d798e2b973d2f8f3fb9",
                 "einops",
                 "accelerate",
                 "tiktoken",

--- a/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
@@ -90,7 +90,7 @@ class VideoCaptioningFromSummarizerMapper(Mapper):
             [
                 "torch",
                 "transformers",
-                "transformers-stream-generator @ git+https://github.com/datajuicer/transformers-stream-generator.git",
+                "transformers-stream-generator @ git+https://github.com/cmgzn/transformers-stream-generator.git",
                 "einops",
                 "accelerate",
                 "tiktoken",  # by audio caption

--- a/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
+++ b/data_juicer/ops/mapper/video_captioning_from_summarizer_mapper.py
@@ -90,7 +90,7 @@ class VideoCaptioningFromSummarizerMapper(Mapper):
             [
                 "torch",
                 "transformers",
-                "transformers-stream-generator @ git+https://github.com/cmgzn/transformers-stream-generator.git",
+                "transformers-stream-generator @ git+https://github.com/cmgzn/transformers-stream-generator.git@1b356de822eb1da8e7a35d798e2b973d2f8f3fb9",
                 "einops",
                 "accelerate",
                 "tiktoken",  # by audio caption

--- a/data_juicer/ops/mapper/video_tagging_from_frames_mapper.py
+++ b/data_juicer/ops/mapper/video_tagging_from_frames_mapper.py
@@ -73,7 +73,7 @@ class VideoTaggingFromFramesMapper(Mapper):
         """
         kwargs["memory"] = "9GB" if kwargs.get("memory", 0) == 0 else kwargs["memory"]
         super().__init__(*args, **kwargs)
-        LazyLoader.check_packages(["ram @ git+https://github.com/datajuicer/recognize-anything.git"])
+        LazyLoader.check_packages(["ram @ git+https://github.com/cmgzn/recognize-anything.git"])
         if frame_sampling_method not in ["all_keyframes", "uniform"]:
             raise ValueError(
                 f"Frame sampling method [{frame_sampling_method}] is not "

--- a/data_juicer/ops/mapper/video_tagging_from_frames_mapper.py
+++ b/data_juicer/ops/mapper/video_tagging_from_frames_mapper.py
@@ -73,7 +73,9 @@ class VideoTaggingFromFramesMapper(Mapper):
         """
         kwargs["memory"] = "9GB" if kwargs.get("memory", 0) == 0 else kwargs["memory"]
         super().__init__(*args, **kwargs)
-        LazyLoader.check_packages(["ram @ git+https://github.com/cmgzn/recognize-anything.git"])
+        LazyLoader.check_packages(
+            ["ram @ git+https://github.com/cmgzn/recognize-anything.git@889201b76458513d04afde5d4cfa376aa9e33ebf"]
+        )
         if frame_sampling_method not in ["all_keyframes", "uniform"]:
             raise ValueError(
                 f"Frame sampling method [{frame_sampling_method}] is not "

--- a/data_juicer/utils/lazy_loader.py
+++ b/data_juicer/utils/lazy_loader.py
@@ -252,8 +252,9 @@ class LazyLoader(types.ModuleType):
             self._package_name = package_name
 
         # Standardize package_url to use git+ format
-        if package_url and "@" in package_url:
-            # Convert from package@git+ format to git+ format
+        if package_url and "@" in package_url.split("git+")[0]:
+            # Convert from package@git+ format to git+ format. Only split on the
+            # 'name @ url' separator, never on a 'url.git@ref' revision pin.
             self._package_url = package_url.split("@", 1)[1]
         else:
             self._package_url = package_url
@@ -309,7 +310,15 @@ class LazyLoader(types.ModuleType):
                     repo_url = package_spec[4:]  # Remove 'git+' prefix
                 else:
                     repo_url = package_spec
-                git.Repo.clone_from(repo_url, temp_dir)
+                # Split off a pinned revision (e.g. '...repo.git@<sha>'), which is
+                # pip syntax that git itself does not understand.
+                repo_url, _, revision = repo_url.partition(".git@")
+                if revision:
+                    repo_url += ".git"
+                repo = git.Repo.clone_from(repo_url, temp_dir)
+                if revision:
+                    logger.info(f"Checking out pinned revision {revision}...")
+                    repo.git.checkout(revision)
 
                 # Define all possible dependency files
                 dep_files = {

--- a/data_juicer/utils/lazy_loader.py
+++ b/data_juicer/utils/lazy_loader.py
@@ -252,10 +252,8 @@ class LazyLoader(types.ModuleType):
             self._package_name = package_name
 
         # Standardize package_url to use git+ format
-        if package_url and "@" in package_url.split("git+")[0]:
-            # Convert from package@git+ format to git+ format. Only split on the
-            # 'name @ url' separator, never on a 'url.git@ref' revision pin.
-            self._package_url = package_url.split("@", 1)[1]
+        if package_url and " @ " in package_url:
+            self._package_url = package_url.split(" @ ", 1)[1]
         else:
             self._package_url = package_url
         self._package_url = self._package_url.strip() if self._package_url else self._package_url

--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -39,7 +39,7 @@ nltk = LazyLoader("nltk")
 aes_pred = LazyLoader("aesthetics_predictor", "simple-aesthetics-predictor")
 vllm = LazyLoader("vllm")
 diffusers = LazyLoader("diffusers")
-ram = LazyLoader("ram", "git+https://github.com/datajuicer/recognize-anything.git")
+ram = LazyLoader("ram", "git+https://github.com/cmgzn/recognize-anything.git")
 cv2 = LazyLoader("cv2", "opencv-contrib-python")
 openai = LazyLoader("openai")
 ultralytics = LazyLoader("ultralytics")
@@ -47,7 +47,7 @@ tiktoken = LazyLoader("tiktoken")
 dashscope = LazyLoader("dashscope")
 qwen_vl_utils = LazyLoader("qwen_vl_utils", "qwen-vl-utils")
 transformers_stream_generator = LazyLoader(
-    "transformers_stream_generator", "git+https://github.com/datajuicer/transformers-stream-generator.git"
+    "transformers_stream_generator", "git+https://github.com/cmgzn/transformers-stream-generator.git"
 )
 
 MODEL_ZOO = {}

--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -39,7 +39,7 @@ nltk = LazyLoader("nltk")
 aes_pred = LazyLoader("aesthetics_predictor", "simple-aesthetics-predictor")
 vllm = LazyLoader("vllm")
 diffusers = LazyLoader("diffusers")
-ram = LazyLoader("ram", "git+https://github.com/cmgzn/recognize-anything.git")
+ram = LazyLoader("ram", "git+https://github.com/cmgzn/recognize-anything.git@889201b76458513d04afde5d4cfa376aa9e33ebf")
 cv2 = LazyLoader("cv2", "opencv-contrib-python")
 openai = LazyLoader("openai")
 ultralytics = LazyLoader("ultralytics")
@@ -47,7 +47,8 @@ tiktoken = LazyLoader("tiktoken")
 dashscope = LazyLoader("dashscope")
 qwen_vl_utils = LazyLoader("qwen_vl_utils", "qwen-vl-utils")
 transformers_stream_generator = LazyLoader(
-    "transformers_stream_generator", "git+https://github.com/cmgzn/transformers-stream-generator.git"
+    "transformers_stream_generator",
+    "git+https://github.com/cmgzn/transformers-stream-generator.git@1b356de822eb1da8e7a35d798e2b973d2f8f3fb9",
 )
 
 MODEL_ZOO = {}

--- a/tests/utils/test_lazy_loader.py
+++ b/tests/utils/test_lazy_loader.py
@@ -640,12 +640,20 @@ class LazyLoaderBehaviorTest(DataJuicerTestCaseBase):
 
         loader = LazyLoader(
             "json",
-            package_url="local-package@git+https://example.invalid/repo.git",
+            package_url="local-package @ git+https://example.invalid/repo.git",
             auto_install=False,
         )
 
         self.assertEqual(loader._package_name, "json")
         self.assertEqual(loader._package_url, "git+https://example.invalid/repo.git")
+
+        # Raw HTTPS URL with pinned SHA must not be split
+        loader2 = LazyLoader(
+            "json",
+            package_url="https://github.com/org/repo.git@abc123",
+            auto_install=False,
+        )
+        self.assertEqual(loader2._package_url, "https://github.com/org/repo.git@abc123")
 
     def test_existing_module_loads_once_and_updates_parent_globals(self):
         globals().pop("decimal", None)


### PR DESCRIPTION
Transfer recognize-anything and transformers-stream-generator fork repos from the datajuicer org to a personal fork for long-term maintenance, allowing the org-level forks to be archived.

Changes:
- Update all git URLs for recognize-anything and transformers-stream-generator to point to the new fork location
- No functional changes — same code, same fixes, just a different host