### PR TITLE
fix(ops): correct _supported_exec_modes for deduplicator operators

### DIFF
--- a/data_juicer/ops/base_op.py
+++ b/data_juicer/ops/base_op.py
@@ -920,7 +920,7 @@ class Filter(OP):
 
 
 class Deduplicator(OP):
-    _supported_exec_modes = ("default", "ray", "ray_partitioned")
+    _supported_exec_modes = ("default",)
 
     def __init__(self, *args, **kwargs):
         """

--- a/data_juicer/ops/deduplicator/ray_basic_deduplicator.py
+++ b/data_juicer/ops/deduplicator/ray_basic_deduplicator.py
@@ -107,6 +107,7 @@ class RayBasicDeduplicator(Filter):
 
     # TODO: Set a more reasonable value
     EMPTY_HASH_VALUE = "EMPTY"
+    _supported_exec_modes = ("ray", "ray_partitioned")
 
     def __init__(
         self,

--- a/data_juicer/ops/deduplicator/ray_bts_minhash_cpp_deduplicator.py
+++ b/data_juicer/ops/deduplicator/ray_bts_minhash_cpp_deduplicator.py
@@ -440,6 +440,7 @@ class RayBTSMinhashCppDeduplicator(Deduplicator):
     # TODO: Set a more reasonable value
     EMPTY_HASH_VALUE = "EMPTY"
     _batched_op = True
+    _supported_exec_modes = ("ray", "ray_partitioned")
 
     def __init__(
         self,

--- a/data_juicer/ops/deduplicator/ray_bts_minhash_deduplicator.py
+++ b/data_juicer/ops/deduplicator/ray_bts_minhash_deduplicator.py
@@ -308,6 +308,7 @@ class RayBTSMinhashDeduplicator(Deduplicator):
     # TODO: Set a more reasonable value
     EMPTY_HASH_VALUE = "EMPTY"
     _batched_op = True
+    _supported_exec_modes = ("ray", "ray_partitioned")
 
     def __init__(
         self,

--- a/tests/ops/test_base_op.py
+++ b/tests/ops/test_base_op.py
@@ -884,6 +884,53 @@ class TestBaseParamsSync(unittest.TestCase):
                     f"{klass.__name__}._supported_exec_modes contains invalid mode '{m}'",
                 )
 
+    def test_deduplicator_supported_exec_modes_are_exact(self):
+        """
+        Deduplicators are mode-specific: the non-Ray implementations only work
+        in default mode, and the Ray implementations only in the Ray modes.
+        Assert the exact tuples so a wrong declaration cannot regress silently.
+        """
+        from data_juicer.ops import deduplicator as dedup_module
+
+        expected = {
+            "DocumentDeduplicator": ("default",),
+            "DocumentLineDeduplicator": ("default",),
+            "DocumentMinhashDeduplicator": ("default",),
+            "DocumentSimhashDeduplicator": ("default",),
+            "ImageDeduplicator": ("default",),
+            "VideoDeduplicator": ("default",),
+            "RayBasicDeduplicator": ("ray", "ray_partitioned"),
+            "RayDocumentDeduplicator": ("ray", "ray_partitioned"),
+            "RayImageDeduplicator": ("ray", "ray_partitioned"),
+            "RayVideoDeduplicator": ("ray", "ray_partitioned"),
+            "RayBTSMinhashDeduplicator": ("ray", "ray_partitioned"),
+            "RayBTSMinhashCppDeduplicator": ("ray", "ray_partitioned"),
+        }
+
+        for name, expected_modes in expected.items():
+            klass = getattr(dedup_module, name)
+            self.assertEqual(
+                klass._supported_exec_modes,
+                expected_modes,
+                f"{name}._supported_exec_modes should be {expected_modes}",
+            )
+
+        # Guard against new deduplicators silently inheriting the wrong modes.
+        discovered = {
+            n for n in dir(dedup_module) if n.endswith("Deduplicator") and isinstance(getattr(dedup_module, n), type)
+        }
+        self.assertEqual(
+            discovered,
+            set(expected),
+            "deduplicator set changed; add the new op to the expected exec-modes map",
+        )
+
+    def test_base_deduplicator_class_is_default_only(self):
+        """The Deduplicator base class must not advertise Ray support."""
+        from data_juicer.ops.base_op import Deduplicator
+
+        self.assertEqual(Deduplicator._supported_exec_modes, ("default",))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

The `Deduplicator` base class declared `_supported_exec_modes = ("default", "ray", "ray_partitioned")`, but its `run()` method uses HuggingFace Dataset APIs (`NestedDataset`, `dataset.map(num_proc=..., with_rank=..., desc=...)`) which are incompatible with `ray.data.Dataset`. This means regular dedup operators (`ImageDeduplicator`, `VideoDeduplicator`, `DocumentMinhashDeduplicator`, etc.) would crash at runtime if configured in Ray mode, yet the preflight check would not catch it.

Conversely, Ray-only dedup operators (`RayBasicDeduplicator` and its subclasses, `RayBTSMinhashDeduplicator`, `RayBTSMinhashCppDeduplicator`) inherited `"default"` mode from their base classes but cannot run outside Ray.

## Fix

- `Deduplicator` base class: `("default", "ray", "ray_partitioned")` → `("default",)`
- `RayBasicDeduplicator`: add `_supported_exec_modes = ("ray", "ray_partitioned")` (inherited by `RayImageDeduplicator`, `RayVideoDeduplicator`, `RayDocumentDeduplicator`)
- `RayBTSMinhashDeduplicator`: add `_supported_exec_modes = ("ray", "ray_partitioned")`
- `RayBTSMinhashCppDeduplicator`: add `_supported_exec_modes = ("ray", "ray_partitioned")`

Now each operator only declares the execution modes it actually supports, and preflight/runtime checks will correctly reject unsupported configurations.