### PR TITLE
feat: support OrcaRouter as a named OpenAI-compatible provider

### DIFF
--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -355,15 +355,20 @@ def _merge_openai_compatible_env_into_model_params(model_params):
     """Fill OpenAI client kwargs from environment (DashScope REST / OpenAI-compatible).
 
     Supported env vars:
-    - ``OPENAI_API_KEY``, ``DASHSCOPE_API_KEY``, or ``SK`` -> ``api_key``
-    - ``OPENAI_BASE_URL``, ``OPENAI_API_URL``, or ``DASHSCOPE_BASE_URL`` -> ``base_url``
-      (trailing slash stripped)
+    - ``OPENAI_API_KEY``, ``DASHSCOPE_API_KEY``, ``ORCAROUTER_API_KEY``, or ``SK`` -> ``api_key``
+    - ``OPENAI_BASE_URL``, ``OPENAI_API_URL``, ``DASHSCOPE_BASE_URL``, or
+      ``ORCAROUTER_BASE_URL`` -> ``base_url`` (trailing slash stripped)
 
     Explicit keys in ``model_params`` take precedence.
     """
     out = dict(model_params) if model_params else {}
     if not out.get("api_key"):
-        key = os.environ.get("OPENAI_API_KEY") or os.environ.get("DASHSCOPE_API_KEY") or os.environ.get("SK")
+        key = (
+            os.environ.get("OPENAI_API_KEY")
+            or os.environ.get("DASHSCOPE_API_KEY")
+            or os.environ.get("ORCAROUTER_API_KEY")
+            or os.environ.get("SK")
+        )
         if key:
             out["api_key"] = key
     if not out.get("base_url"):
@@ -371,6 +376,7 @@ def _merge_openai_compatible_env_into_model_params(model_params):
             os.environ.get("OPENAI_BASE_URL")
             or os.environ.get("OPENAI_API_URL")
             or os.environ.get("DASHSCOPE_BASE_URL")
+            or os.environ.get("ORCAROUTER_BASE_URL")
         )
         if base:
             out["base_url"] = base.rstrip("/")

--- a/docs/operators/mapper/llm_extract_mapper.md
+++ b/docs/operators/mapper/llm_extract_mapper.md
@@ -91,6 +91,17 @@ export OPENAI_API_KEY=<你的 DashScope API Key>
 
 `OPENAI_API_URL` 与 `OPENAI_BASE_URL` 等价（任选其一）。
 
+### 🐋 OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) 是 OpenAI 兼容的 AI 网关，同样可通过环境变量接入，无需在 recipe 里写 key：
+
+```bash
+export ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+export ORCAROUTER_API_KEY=<你的 OrcaRouter API Key>
+```
+
+与 DashScope 类似，`ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` 会被自动合并进 OpenAI 客户端配置；显式传入的 `api_key` / `base_url` 优先。设置后把 `api_or_hf_model` 指定为 OrcaRouter 上可用的模型（如 `deepseek/deepseek-chat`）即可。
+
 ## 📊 Cost / usage 成本与用量
 
 Each sample gets `meta[llm_semantic_usage]` with:

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -733,5 +733,60 @@ class DashScopeOpenAICompatTest(DataJuicerTestCaseBase):
             )
 
 
+class OrcaRouterOpenAICompatTest(DataJuicerTestCaseBase):
+    """Env merge for OrcaRouter as a named OpenAI-compatible provider."""
+
+    def test_merge_env_from_orcarouter(self):
+        from data_juicer.utils.model_utils import _merge_openai_compatible_env_into_model_params
+
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "",
+                "DASHSCOPE_API_KEY": "",
+                "ORCAROUTER_API_KEY": "sk-orca-test",
+                "ORCAROUTER_BASE_URL": "https://api.orcarouter.ai/v1/",
+            },
+            clear=False,
+        ):
+            m = _merge_openai_compatible_env_into_model_params({})
+        self.assertEqual(m.get("api_key"), "sk-orca-test")
+        self.assertEqual(m["base_url"], "https://api.orcarouter.ai/v1")
+
+    def test_orcarouter_explicit_params_take_precedence(self):
+        from data_juicer.utils.model_utils import _merge_openai_compatible_env_into_model_params
+
+        with patch.dict(
+            os.environ,
+            {
+                "ORCAROUTER_API_KEY": "sk-orca-env",
+                "ORCAROUTER_BASE_URL": "https://api.orcarouter.ai/v1",
+            },
+            clear=False,
+        ):
+            m = _merge_openai_compatible_env_into_model_params(
+                {"api_key": "explicit-key", "base_url": "https://example.com/v1"}
+            )
+        self.assertEqual(m.get("api_key"), "explicit-key")
+        self.assertEqual(m["base_url"], "https://example.com/v1")
+
+    def test_orcarouter_env_ignored_when_openai_set(self):
+        from data_juicer.utils.model_utils import _merge_openai_compatible_env_into_model_params
+
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "openai-key",
+                "OPENAI_BASE_URL": "https://api.openai.com/v1",
+                "ORCAROUTER_API_KEY": "sk-orca-env",
+                "ORCAROUTER_BASE_URL": "https://api.orcarouter.ai/v1",
+            },
+            clear=False,
+        ):
+            m = _merge_openai_compatible_env_into_model_params({})
+        self.assertEqual(m.get("api_key"), "openai-key")
+        self.assertEqual(m["base_url"], "https://api.openai.com/v1")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add [OrcaRouter](https://www.orcarouter.ai) as a named OpenAI-compatible provider in `prepare_api_model`, mirroring the existing DashScope wiring in `_merge_openai_compatible_env_into_model_params`. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents — like OpenRouter, it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` env-var support means Data-Juicer's API operators (`llm_extract_mapper`, `llm_condition_filter`, etc.) can target OrcaRouter directly, without treating it as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Verification:
- `flake8` (CI config) + `black --check` (25.1.0) + `isort` clean on `data_juicer/utils/model_utils.py`
- New `OrcaRouterOpenAICompatTest` unit tests cover env merge, explicit-param precedence, and OPENAI_* fallback
- Live-tested against `https://api.orcarouter.ai/v1` via `prepare_api_model` (`deepseek/deepseek-v4-flash-0731`) — 200, response `ok`

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
