### PR TITLE
fix: include text_key and tokenizer in fused context cache keys

### DIFF
--- a/data_juicer/ops/filter/average_line_length_filter.py
+++ b/data_juicer/ops/filter/average_line_length_filter.py
@@ -41,7 +41,7 @@ class AverageLineLengthFilter(Filter):
     def compute_stats_batched(self, samples, context=False):
         samples_list = samples[self.text_key]
         samples_stats = samples[Fields.stats]
-        context_key = f"{InterVars.lines}"
+        context_key = f"{InterVars.lines}-{self.text_key}"
 
         for idx, stat in enumerate(samples_stats):
             # check if it's computed already

--- a/data_juicer/ops/filter/flagged_words_filter.py
+++ b/data_juicer/ops/filter/flagged_words_filter.py
@@ -91,7 +91,7 @@ class FlaggedWordFilter(Filter):
         # check if it's computed already
         samples_list = samples[self.text_key]
         samples_stats = samples[Fields.stats]
-        words_key = f"{InterVars.words}-{self.model_key}"
+        words_key = f"{InterVars.words}-{self.model_key}-{self.text_key}"
         tokenizer = get_model(self.model_key)
         for idx, stat in enumerate(samples_stats):
             if StatsKeys.flagged_words_ratio in stat:
@@ -107,6 +107,7 @@ class FlaggedWordFilter(Filter):
             # try to get refined words from context
             refined_words_key = (
                 f"{InterVars.refined_words}"
+                f"-{self.model_key}-{self.text_key}"
                 "-True-SPECIAL_CHARS-"
                 f"{self.use_words_aug}-"
                 f"{self.words_aug_group_sizes}-"

--- a/data_juicer/ops/filter/maximum_line_length_filter.py
+++ b/data_juicer/ops/filter/maximum_line_length_filter.py
@@ -42,7 +42,7 @@ class MaximumLineLengthFilter(Filter):
     def compute_stats_batched(self, samples, context=False):
         samples_list = samples[self.text_key]
         samples_stats = samples[Fields.stats]
-        context_key = f"{InterVars.lines}"
+        context_key = f"{InterVars.lines}-{self.text_key}"
 
         for idx, stat in enumerate(samples_stats):
             # check if it's computed already

--- a/data_juicer/ops/filter/perplexity_filter.py
+++ b/data_juicer/ops/filter/perplexity_filter.py
@@ -45,7 +45,7 @@ class PerplexityFilter(Filter):
     def compute_stats_batched(self, samples, context=False):
         samples_list = samples[self.text_key]
         samples_stats = samples[Fields.stats]
-        words_key = f"{InterVars.words}-{self.sp_model_key}"
+        words_key = f"{InterVars.words}-{self.sp_model_key}-{self.text_key}"
         tokenizer = get_model(self.sp_model_key)
 
         for idx, stat in enumerate(samples_stats):

--- a/data_juicer/ops/filter/stopwords_filter.py
+++ b/data_juicer/ops/filter/stopwords_filter.py
@@ -89,7 +89,7 @@ class StopWordsFilter(Filter):
             return sample
 
         # try to get words from context
-        words_key = f"{InterVars.words}-{self.model_key}"
+        words_key = f"{InterVars.words}-{self.model_key}-{self.text_key}"
         if context and words_key in sample[Fields.context]:
             words = sample[Fields.context][words_key]
         else:
@@ -102,7 +102,9 @@ class StopWordsFilter(Filter):
 
         # try to get refined words from context
         refined_words_key = (
-            f"{InterVars.refined_words}-True-SPECIAL_CHARS-"
+            f"{InterVars.refined_words}"
+            f"-{self.model_key}-{self.text_key}"
+            "-True-SPECIAL_CHARS-"
             f"{self.use_words_aug}-"
             f"{self.words_aug_group_sizes}-"
             f"{self.words_aug_join_char}"

--- a/data_juicer/ops/filter/word_repetition_filter.py
+++ b/data_juicer/ops/filter/word_repetition_filter.py
@@ -67,7 +67,7 @@ class WordRepetitionFilter(Filter):
     def compute_stats_batched(self, samples, context=False):
         samples_list = samples[self.text_key]
         samples_stats = samples[Fields.stats]
-        words_key = f"{InterVars.words}-{self.model_key}"
+        words_key = f"{InterVars.words}-{self.model_key}-{self.text_key}"
 
         for idx, stat in enumerate(samples_stats):
             # check if it's computed already
@@ -85,7 +85,9 @@ class WordRepetitionFilter(Filter):
                     samples[Fields.context][idx][words_key] = words
 
             # try to get refined words from context
-            refined_words_key = f"{InterVars.refined_words}-" f"True-SPECIAL_CHARS-False-[2]-"
+            refined_words_key = (
+                f"{InterVars.refined_words}-{self.model_key}-{self.text_key}-" f"True-SPECIAL_CHARS-False-[2]-"
+            )
             if context and refined_words_key in samples[Fields.context][idx]:
                 words = samples[Fields.context][idx][refined_words_key]
             else:

--- a/data_juicer/ops/filter/words_num_filter.py
+++ b/data_juicer/ops/filter/words_num_filter.py
@@ -59,7 +59,7 @@ class WordsNumFilter(Filter):
     def compute_stats_batched(self, samples, context=False):
         samples_list = samples[self.text_key]
         samples_stats = samples[Fields.stats]
-        words_key = f"{InterVars.words}-{self.model_key}"
+        words_key = f"{InterVars.words}-{self.model_key}-{self.text_key}"
 
         for idx, stat in enumerate(samples_stats):
             # check if it's computed already

--- a/tests/ops/filter/test_average_line_length_filter.py
+++ b/tests/ops/filter/test_average_line_length_filter.py
@@ -69,7 +69,7 @@ class AverageLineLengthFilterTest(DataJuicerTestCaseBase):
         tgt_context_list = [
             {
                 Fields.context: {
-                    InterVars.lines: tgt[self.text_key].splitlines()
+                    f'{InterVars.lines}-{self.text_key}': tgt[self.text_key].splitlines()
                     }
             } for tgt in self.tgt_list
         ]

--- a/tests/ops/filter/test_maximum_line_length_filter.py
+++ b/tests/ops/filter/test_maximum_line_length_filter.py
@@ -69,7 +69,7 @@ class MaximumLineLengthFilterTest(DataJuicerTestCaseBase):
         tgt_context_list = [
             {
                 Fields.context: {
-                    InterVars.lines: tgt[self.text_key].splitlines()
+                    f'{InterVars.lines}-{self.text_key}': tgt[self.text_key].splitlines()
                     }
             } for tgt in self.tgt_list
         ]

--- a/tests/ops/filter/test_ngram_streaming_frequency.py
+++ b/tests/ops/filter/test_ngram_streaming_frequency.py
@@ -57,8 +57,8 @@ def _reference_word_ratio(words, n):
 
 
 def _word_context(op, word_rows):
-    words_key = f"{InterVars.words}-{op.model_key}"
-    refined_words_key = f"{InterVars.refined_words}-True-SPECIAL_CHARS-False-[2]-"
+    words_key = f"{InterVars.words}-{op.model_key}-{op.text_key}"
+    refined_words_key = f"{InterVars.refined_words}-{op.model_key}-{op.text_key}-True-SPECIAL_CHARS-False-[2]-"
     return [
         {
             words_key: words,

--- a/tests/ops/test_op_fusion.py
+++ b/tests/ops/test_op_fusion.py
@@ -4,7 +4,7 @@ from data_juicer.core import NestedDataset
 from data_juicer.ops.base_op import Mapper, OP
 from data_juicer.ops.load import load_ops
 from data_juicer.ops.op_fusion import fuse_operators, GeneralFusedOP
-from data_juicer.utils.constant import Fields, InterVars
+from data_juicer.utils.constant import Fields
 from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
 
 
@@ -2238,7 +2238,9 @@ class FusedContextKeyIsolationTest(DataJuicerTestCaseBase):
     value and reports a statistic for a column it never looked at.
     """
 
-    def _stats_fused_vs_unfused(self, process_list, row):
+    def _fused_vs_unfused(self, process_list, row):
+        """Compute stats and the keep/drop decision, fused and unfused."""
+
         def make_batch():
             batch = {key: [value] for key, value in row.items()}
             batch[Fields.stats] = [{}]
@@ -2252,14 +2254,32 @@ class FusedContextKeyIsolationTest(DataJuicerTestCaseBase):
         fused_batch = make_batch()
         fused_ops[0].compute_stats_batched(fused_batch)
         fused_stats = fused_batch[Fields.stats][0]
+        fused_keep = bool(list(fused_ops[0].process_batched(fused_batch))[0])
 
-        unfused_stats = {}
+        # Every unfused op gets its own batch and therefore its own context,
+        # so it cannot read another op's intermediate value. That makes the
+        # unfused run the reference behaviour the fused run has to match.
+        unfused_stats, unfused_keep = {}, True
         for op in load_ops(process_list):
             batch = make_batch()
             op.compute_stats_batched(batch)
             unfused_stats.update(batch[Fields.stats][0])
+            unfused_keep &= bool(list(op.process_batched(batch))[0])
 
-        return fused_stats, unfused_stats
+        return fused_stats, unfused_stats, fused_keep, unfused_keep
+
+    def _assert_fusion_transparent(self, process_list, row, expected_stats,
+                                   expected_keep):
+        fused_stats, unfused_stats, fused_keep, unfused_keep = \
+            self._fused_vs_unfused(process_list, row)
+
+        self.assertEqual(sorted(unfused_stats), sorted(expected_stats))
+        self.assertEqual(sorted(fused_stats), sorted(expected_stats))
+        for key, expected in expected_stats.items():
+            self.assertAlmostEqual(unfused_stats[key], expected, places=6)
+            self.assertAlmostEqual(fused_stats[key], expected, places=6)
+        self.assertEqual(unfused_keep, expected_keep)
+        self.assertEqual(fused_keep, expected_keep)
 
     def test_inter_words_ops_differing_in_text_key(self):
         process_list = [{
@@ -2281,14 +2301,19 @@ class FusedContextKeyIsolationTest(DataJuicerTestCaseBase):
             }
         }]
         # 'text' is all-identical 2-grams, 'translation' has no repetition, so
-        # reading the wrong column flips word_rep_ratio from 0.0 to 1.0.
+        # reading the wrong column flips word_rep_ratio from 0.0 to 1.0, which
+        # also pushes the sample past max_ratio and drops it.
         row = {
             'text': 'ha ha ha ha ha ha ha ha',
             'translation': 'alpha beta gamma delta epsilon zeta eta theta'
         }
-        fused_stats, unfused_stats = self._stats_fused_vs_unfused(
-            process_list, row)
-        self.assertEqual(fused_stats, unfused_stats)
+        self._assert_fusion_transparent(process_list,
+                                        row,
+                                        expected_stats={
+                                            'num_words': 8,
+                                            'word_rep_ratio': 0.0
+                                        },
+                                        expected_keep=True)
 
     def test_inter_lines_ops_differing_in_text_key(self):
         process_list = [{
@@ -2299,65 +2324,58 @@ class FusedContextKeyIsolationTest(DataJuicerTestCaseBase):
             }
         }, {
             'maximum_line_length_filter': {
-                'min_len': 1,
+                'min_len': 10,
                 'max_len': 100000,
                 'text_key': 'translation'
             }
         }]
         # 'text' splits into three 1-char lines, 'translation' is one long
-        # line, so reading the wrong column reports max_line_length 1 not 30.
+        # line, so reading the wrong column reports max_line_length 1 not 30,
+        # which falls below min_len and drops the sample.
         row = {'text': 'a\nb\nc', 'translation': 'x' * 30}
-        fused_stats, unfused_stats = self._stats_fused_vs_unfused(
-            process_list, row)
-        self.assertEqual(fused_stats, unfused_stats)
+        self._assert_fusion_transparent(process_list,
+                                        row,
+                                        expected_stats={
+                                            'avg_line_length': 5 / 3,
+                                            'max_line_length': 30
+                                        },
+                                        expected_keep=True)
 
-    def test_words_keys_separate_text_key_and_tokenizer(self):
-        ops = load_ops([{
-            'words_num_filter': {
+    def test_inter_words_ops_differing_in_tokenizer(self):
+        # Tokenized word_repetition_filter followed by untokenized
+        # stopwords_filter on the same field. The tokenized version uses
+        # SentencePiece which produces different word tokens than simple
+        # whitespace splitting. With a broken cache key (missing model_key),
+        # the second op would read the first op's tokenized words and report
+        # the wrong stopwords_ratio.
+        process_list = [{
+            'word_repetition_filter': {
                 'lang': 'en',
-                'tokenization': False,
+                'rep_len': 2,
+                'tokenization': True,
                 'text_key': 'text'
             }
         }, {
-            'words_num_filter': {
+            'stopwords_filter': {
                 'lang': 'en',
-                'tokenization': False,
-                'text_key': 'translation'
-            }
-        }])
-        keys = [f'{InterVars.words}-{op.model_key}-{op.text_key}'
-                for op in ops]
-        self.assertEqual(len(set(keys)), 2,
-                         'ops reading different columns must not share a key')
-
-    def test_refined_words_keys_separate_tokenizers(self):
-        # Two ops identical except for the tokenizer. `refined_words` is
-        # derived from `words`, so it has to be keyed by model_key too.
-        untokenized, tokenized = load_ops([{
-            'flagged_words_filter': {
-                'lang': 'en',
+                'min_ratio': 0.3,
                 'tokenization': False,
                 'text_key': 'text'
             }
-        }, {
-            'flagged_words_filter': {
-                'lang': 'en',
-                'tokenization': False,
-                'text_key': 'text'
-            }
-        }])
-        tokenized.model_key = 'a-different-tokenizer'
-
-        def refined_words_key(op):
-            return (f'{InterVars.refined_words}'
-                    f'-{op.model_key}-{op.text_key}'
-                    '-True-SPECIAL_CHARS-'
-                    f'{op.use_words_aug}-'
-                    f'{op.words_aug_group_sizes}-'
-                    f'{op.words_aug_join_char}')
-
-        self.assertNotEqual(refined_words_key(untokenized),
-                            refined_words_key(tokenized))
+        }]
+        # 3 of the 9 whitespace-split words are English stopwords ('the',
+        # 'over', 'the'), so stopwords_ratio is 1/3 and the sample is kept.
+        # SentencePiece splits the same sentence into more, partly sub-word
+        # tokens that the stopwords list does not match; reading those from the
+        # shared context yields 0.0, below min_ratio, and drops the sample.
+        row = {'text': 'the quick brown fox jumps over the lazy dog'}
+        self._assert_fusion_transparent(process_list,
+                                        row,
+                                        expected_stats={
+                                            'word_rep_ratio': 0.0,
+                                            'stopwords_ratio': 1 / 3
+                                        },
+                                        expected_keep=True)
 
 
 if __name__ == '__main__':

--- a/tests/ops/test_op_fusion.py
+++ b/tests/ops/test_op_fusion.py
@@ -4,7 +4,7 @@ from data_juicer.core import NestedDataset
 from data_juicer.ops.base_op import Mapper, OP
 from data_juicer.ops.load import load_ops
 from data_juicer.ops.op_fusion import fuse_operators, GeneralFusedOP
-from data_juicer.utils.constant import Fields
+from data_juicer.utils.constant import Fields, InterVars
 from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
 
 
@@ -2225,6 +2225,139 @@ class GeneralFusedOPMapperBugTest(DataJuicerTestCaseBase):
         }
         result = fused_op.process_batched(samples)
         self.assertEqual(result['text'], ['hello_END', 'world_END'])
+
+
+class FusedContextKeyIsolationTest(DataJuicerTestCaseBase):
+    """Fusion must not change any statistic.
+
+    Ops in a fused group share one `Fields.context` dict. The cache key for
+    each intermediate variable therefore has to identify everything the
+    cached value depends on -- the source column (`text_key`) and the
+    tokenizer (`model_key`). If two ops in the same group disagree on either
+    one but build the same key, the second op silently reads the first op's
+    value and reports a statistic for a column it never looked at.
+    """
+
+    def _stats_fused_vs_unfused(self, process_list, row):
+        def make_batch():
+            batch = {key: [value] for key, value in row.items()}
+            batch[Fields.stats] = [{}]
+            batch[Fields.context] = [{}]
+            return batch
+
+        fused_ops = fuse_operators(load_ops(process_list))
+        self.assertEqual(len(fused_ops), 1,
+                         'ops under test are expected to fuse into one op')
+
+        fused_batch = make_batch()
+        fused_ops[0].compute_stats_batched(fused_batch)
+        fused_stats = fused_batch[Fields.stats][0]
+
+        unfused_stats = {}
+        for op in load_ops(process_list):
+            batch = make_batch()
+            op.compute_stats_batched(batch)
+            unfused_stats.update(batch[Fields.stats][0])
+
+        return fused_stats, unfused_stats
+
+    def test_inter_words_ops_differing_in_text_key(self):
+        process_list = [{
+            'words_num_filter': {
+                'lang': 'en',
+                'min_num': 1,
+                'max_num': 10000,
+                'tokenization': False,
+                'text_key': 'text'
+            }
+        }, {
+            'word_repetition_filter': {
+                'lang': 'en',
+                'rep_len': 2,
+                'min_ratio': 0.0,
+                'max_ratio': 1.0,
+                'tokenization': False,
+                'text_key': 'translation'
+            }
+        }]
+        # 'text' is all-identical 2-grams, 'translation' has no repetition, so
+        # reading the wrong column flips word_rep_ratio from 0.0 to 1.0.
+        row = {
+            'text': 'ha ha ha ha ha ha ha ha',
+            'translation': 'alpha beta gamma delta epsilon zeta eta theta'
+        }
+        fused_stats, unfused_stats = self._stats_fused_vs_unfused(
+            process_list, row)
+        self.assertEqual(fused_stats, unfused_stats)
+
+    def test_inter_lines_ops_differing_in_text_key(self):
+        process_list = [{
+            'average_line_length_filter': {
+                'min_len': 1,
+                'max_len': 100000,
+                'text_key': 'text'
+            }
+        }, {
+            'maximum_line_length_filter': {
+                'min_len': 1,
+                'max_len': 100000,
+                'text_key': 'translation'
+            }
+        }]
+        # 'text' splits into three 1-char lines, 'translation' is one long
+        # line, so reading the wrong column reports max_line_length 1 not 30.
+        row = {'text': 'a\nb\nc', 'translation': 'x' * 30}
+        fused_stats, unfused_stats = self._stats_fused_vs_unfused(
+            process_list, row)
+        self.assertEqual(fused_stats, unfused_stats)
+
+    def test_words_keys_separate_text_key_and_tokenizer(self):
+        ops = load_ops([{
+            'words_num_filter': {
+                'lang': 'en',
+                'tokenization': False,
+                'text_key': 'text'
+            }
+        }, {
+            'words_num_filter': {
+                'lang': 'en',
+                'tokenization': False,
+                'text_key': 'translation'
+            }
+        }])
+        keys = [f'{InterVars.words}-{op.model_key}-{op.text_key}'
+                for op in ops]
+        self.assertEqual(len(set(keys)), 2,
+                         'ops reading different columns must not share a key')
+
+    def test_refined_words_keys_separate_tokenizers(self):
+        # Two ops identical except for the tokenizer. `refined_words` is
+        # derived from `words`, so it has to be keyed by model_key too.
+        untokenized, tokenized = load_ops([{
+            'flagged_words_filter': {
+                'lang': 'en',
+                'tokenization': False,
+                'text_key': 'text'
+            }
+        }, {
+            'flagged_words_filter': {
+                'lang': 'en',
+                'tokenization': False,
+                'text_key': 'text'
+            }
+        }])
+        tokenized.model_key = 'a-different-tokenizer'
+
+        def refined_words_key(op):
+            return (f'{InterVars.refined_words}'
+                    f'-{op.model_key}-{op.text_key}'
+                    '-True-SPECIAL_CHARS-'
+                    f'{op.use_words_aug}-'
+                    f'{op.words_aug_group_sizes}-'
+                    f'{op.words_aug_join_char}')
+
+        self.assertNotEqual(refined_words_key(untokenized),
+                            refined_words_key(tokenized))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

Operators in a fused filter group share one `Fields.context` dict per sample.
`fuse_filter_group()` groups ops by intermediate variable
(`op_fusion.py:19-36`, `ALL_INTER_VARS`) and never by `text_key`, so two ops
reading different columns can land in the same group. Several ops then build a
context cache key that does not identify everything the cached value depends
on, and the second op silently reads the first op's value — reporting a
statistic for a column it never looked at.

**Samples are silently dropped as a result.** The wrong statistic is compared
against the op's threshold, so a sample that should pass the filter fails it.
Measured on unfixed code, all three collisions below flip the keep/drop decision
from kept to dropped:

| Intermediate var | Ops differ only in | Statistic         | Unfused | Fused | keep (unfused → fused) |
| ---------------- | ------------------ | ----------------- | ------- | ----- | ---------------------- |
| `INTER_WORDS`    | `text_key`         | `word_rep_ratio`  | `0.0`   | `1.0` | `True` → `False`       |
| `INTER_LINES`    | `text_key`         | `max_line_length` | `30`    | `1`   | `True` → `False`       |
| `refined_words`  | `tokenization`     | `stopwords_ratio` | `1/3`   | `0.0` | `True` → `False`       |

All three are reproduced through the repo's own `load_ops` + `fuse_operators`.

The `INTER_LINES` key was `f"{InterVars.lines}"` — no discriminator at all. The
`refined_words` keys carried neither `model_key` nor `text_key`: at default
settings `word_repetition_filter` built
`f"{InterVars.refined_words}-" f"True-SPECIAL_CHARS-False-[2]-"` while
`stopwords_filter` and `flagged_words_filter` built
`f"{InterVars.refined_words}-True-SPECIAL_CHARS-"` plus their aug settings, both
evaluating to `__dj__refined_words-True-SPECIAL_CHARS-False-[2]-`. That is where
a tokenizing and a non-tokenizing op collided. The `words` keys already carried
`model_key` and needed only `text_key`.

Preconditions: `op_fusion` must be enabled (it defaults to `False`,
`config.py:626`), two or more ops sharing an intermediate variable must be
consecutive in one filter group, and they must differ in `text_key` or
`tokenization`. Single-column pipelines share the cache correctly — that is the
intended behaviour and is unchanged.

## Fix

Added the missing discriminators to all ten affected keys across seven files:
`words_num_filter`, `perplexity_filter`, `word_repetition_filter` (×2),
`flagged_words_filter` (×2), `stopwords_filter` (×2),
`average_line_length_filter`, `maximum_line_length_filter`.

The deliberate cross-op sharing of `refined_words` between
`flagged_words_filter`, `stopwords_filter` and `word_repetition_filter` is
preserved: at default settings all three still produce the identical key
`__dj__refined_words-None-text-True-SPECIAL_CHARS-False-[2]-` (verified).

Context keys are per-batch temporaries — created at `op_fusion.py:171`, popped
at `:185` and `fused_batch_executor.py:87` — and are never persisted. Dataset
fingerprints derive from op config via `generate_fingerprint`, not from these
strings, so no cache invalidation results.

## Tests

`FusedContextKeyIsolationTest` in `tests/ops/test_op_fusion.py` covers each
collision class. Every test runs real ops through `load_ops` + `fuse_operators`
and asserts an explicit expected statistic **and** the resulting keep/drop
decision, fused against unfused:

- `test_inter_words_ops_differing_in_text_key` — `INTER_WORDS`, differing `text_key`
- `test_inter_lines_ops_differing_in_text_key` — `INTER_LINES`, differing `text_key`
- `test_inter_words_ops_differing_in_tokenizer` — `refined_words`, differing `tokenization`

The unfused reference gives every op its own batch, so it cannot read another
op's context.

Verified these are genuine regression tests by reverting all ten cache-key
f-strings to their pre-fix form: all three fail on the statistic, and the
keep/drop measurements in the table above come from that reverted tree. With the
fix restored, `tests/ops/test_op_fusion.py` passes 23/23, and the filter tests
for every op touched here pass 24/24.

**Three existing tests were changed.** They hard-coded the literal key strings
rather than the ops' behaviour, so they pinned the old format:

- `tests/ops/filter/test_ngram_streaming_frequency.py` — `_word_context()` now
  derives both keys from `op.model_key` and `op.text_key`.
- `tests/ops/filter/test_average_line_length_filter.py`,
  `tests/ops/filter/test_maximum_line_length_filter.py` — expected context key
  now includes `text_key`.

No assertion about op output was weakened or removed.

## Why this wasn't caught

`unit-test-partial.yml` is the only PR-triggered workflow, and its
`--mode partial` selects tests via `find_corresponding_test_file()`
(`unittest_utils.py:254`). Each of the five filter files has its own test file,
so `tests/ops/test_op_fusion.py` is never selected when only filters change.
`_run_equal_config` — which does assert fused == unfused — has a single call
site whose ops all use `text_key: 'text'` and `tokenization: false`, so it
could not surface this either. Putting the regression test in
`test_op_fusion.py` means that file is in the diff and CI will run it.
