### PR TITLE
docs: introduce Juicer and announce its release

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ for s in res_ds:
 
 ## 📰 News
 
+- 🎉 [2026-08-25] We release [Juicer](docs/Juicer.md), a locally deployable data-refinement model that follows natural-language instructions for text cleaning, filtering, and semantic labeling. Explore the [model](https://huggingface.co/datajuicer/Juicer-35B-A3B) and try recipes in the [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground).
+
 <details open>
 <summary>[2026-08-07] Release v1.5.5: <b>External OP Plugins; HDFS I/O & Ray Data Optimizations; Elastic Multi-node Sharding</b></summary>
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -84,6 +84,9 @@ for s in res_ds:
 ---
 
 ## 📰 动态
+
+- 🎉 [2026-08-25] 我们发布了 [Juicer](docs/Juicer_ZH.md)，一个支持本地部署的数据精炼模型，可通过自然语言指令完成文本清洗、过滤与语义标注。欢迎下载[模型](https://huggingface.co/datajuicer/Juicer-35B-A3B)，并在 [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) 中体验数据处理配方。
+
 <details open>
 <summary>[2026-08-07] Release v1.5.5: <b>外部算子插件；HDFS I/O 与 Ray Data 优化；多节点弹性分片</b></summary>
 

--- a/docs/Juicer.md
+++ b/docs/Juicer.md
@@ -1,0 +1,60 @@
+# Juicer: Natural-Language Data Refinement Model
+
+**Juicer** is a data-refinement model built on [Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) (MoE architecture: 35B total parameters / 3B activated). It turns natural-language cleaning instructions, filtering rules, and semantic-tagging requirements into structured outputs—strict tagged text or canonical JSON.
+
+Juicer is designed for data-refinement workflows and supports local deployment to process sensitive data in your own environment.
+
+---
+
+## Resources
+
+| Resource | Link |
+|----------|------|
+| HuggingFace Model | [datajuicer/Juicer-35B-A3B](https://huggingface.co/datajuicer/Juicer-35B-A3B) |
+| ModelScope Model | [Data-Juicer/Juicer-35B-A3B](https://www.modelscope.cn/models/Data-Juicer/Juicer-35B-A3B) |
+| Juicer Playground | [data-juicer-hub/juicer_playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) |
+
+---
+
+## Quick Start
+
+### 0. Get the launch scripts
+
+The `juicer_playground` directory in data-juicer-hub provides `serve.sh`, `requirements.txt`, and `app.py`. Clone the repository and enter its Playground directory:
+
+```bash
+git clone https://github.com/datajuicer/data-juicer-hub.git
+cd data-juicer-hub/juicer_playground
+```
+
+### 1. Deploy the model
+
+Prepare the inference environment and model weights using the [Playground deployment instructions](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground#1-start-the-model). Juicer can be served as an OpenAI-compatible endpoint. On a single H20 (96 GB):
+
+```bash
+export MODEL_ID=/path/to/juicer-model
+bash serve.sh --model "$MODEL_ID" --port 8000
+```
+
+### 2. Launch the Playground
+
+The [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) provides an interactive UI to try recipes, browse showcase cases, and compare Juicer against the base model:
+
+```bash
+pip install -r requirements.txt
+export JUICER_BASE_URL=http://localhost:8000/v1
+python app.py
+# open http://localhost:7860
+```
+
+---
+
+## Evaluation
+
+Juicer is evaluated on [CDR-Bench](https://github.com/lukahhcm/data-juicer-hub/tree/CDR-Bench), covering atomic mappers/filters, compositional workflows, order-sensitive pipelines, and semantic tasks (PII, hallucination, rubric, safety).
+
+---
+
+## Learn More
+
+For full deployment options (vLLM, SGLang, Transformers), showcase cases, integration code, and AB comparison setup, visit the [Juicer Playground README](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground).

--- a/docs/Juicer_ZH.md
+++ b/docs/Juicer_ZH.md
@@ -1,0 +1,60 @@
+# Juicer：自然语言数据精炼模型
+
+**Juicer** 是基于 [Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) 构建的数据精炼模型（MoE 架构：35B 总参数 / 3B 激活参数）。它能将自然语言描述的清洗指令、过滤规则和语义标注需求转化为结构化输出——严格的标记文本或规范的 JSON。
+
+Juicer 专为数据精炼工作流设计，支持在本地环境中部署和处理敏感数据。
+
+---
+
+## 资源链接
+
+| 资源 | 链接 |
+|------|------|
+| HuggingFace 模型 | [datajuicer/Juicer-35B-A3B](https://huggingface.co/datajuicer/Juicer-35B-A3B) |
+| ModelScope 模型 | [Data-Juicer/Juicer-35B-A3B](https://www.modelscope.cn/models/Data-Juicer/Juicer-35B-A3B) |
+| Juicer Playground | [data-juicer-hub/juicer_playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) |
+
+---
+
+## 快速开始
+
+### 0. 准备启动脚本
+
+data-juicer-hub 仓库的 `juicer_playground` 目录提供 `serve.sh`、`requirements.txt` 和 `app.py`。克隆仓库并进入 Playground 目录：
+
+```bash
+git clone https://github.com/datajuicer/data-juicer-hub.git
+cd data-juicer-hub/juicer_playground
+```
+
+### 1. 部署模型
+
+按照 [Playground 部署说明](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground#1-start-the-model)准备推理环境和模型权重。Juicer 可作为 OpenAI 兼容端点提供服务。在单张 H20（96 GB）上：
+
+```bash
+export MODEL_ID=/path/to/juicer-model
+bash serve.sh --model "$MODEL_ID" --port 8000
+```
+
+### 2. 启动 Playground
+
+[Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) 提供交互式界面，可试用配方、浏览展示用例、对比 Juicer 与基座模型：
+
+```bash
+pip install -r requirements.txt
+export JUICER_BASE_URL=http://localhost:8000/v1
+python app.py
+# 打开 http://localhost:7860
+```
+
+---
+
+## 评测
+
+Juicer 在 [CDR-Bench](https://github.com/lukahhcm/data-juicer-hub/tree/CDR-Bench) 上进行评测，涵盖原子映射/过滤、组合工作流、顺序敏感管道和语义任务（PII、幻觉、量规、安全）。
+
+---
+
+## 了解更多
+
+完整的部署选项（vLLM、SGLang、Transformers）、展示用例、集成代码和 AB 对比设置，请访问 [Juicer Playground README](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground)。

--- a/docs/sphinx_doc/source/docs_index.rst
+++ b/docs/sphinx_doc/source/docs_index.rst
@@ -15,6 +15,7 @@ DOCS
 
    docs/Operators
    docs/DatasetCfg
+   docs/Juicer
    docs/*
 
 .. toctree::

--- a/docs/sphinx_doc/source/docs_index_ZH.rst
+++ b/docs/sphinx_doc/source/docs_index_ZH.rst
@@ -15,6 +15,7 @@
 
    docs/Operators
    docs/DatasetCfg_ZH
+   docs/Juicer_ZH
    docs/*
 
 .. toctree::


### PR DESCRIPTION
Juicer needs a concise introduction and a visible entry point in the Data-Juicer documentation. This PR extracts the Juicer material from #1048 so it can be reviewed and published independently.

- Add English and Chinese Juicer guides with model resources, deployment and Playground commands, and evaluation links.
- Add Juicer entries to the English and Chinese documentation navigation.
- Add a short announcement to both READMEs, following the style of earlier non-version news entries.

The announcement date is **2026-08-25**, the merge date of the initial [`juicer_playground` PR](https://github.com/datajuicer/data-juicer-hub/pull/4) (`2026-08-25T06:40:08Z`), rather than the date of this documentation update.

This branch starts from `origin/main` at `253f3fec72664cad8fce102384b4cb01b87592ca`. Its scope is six documentation files; configuration, operators, dependencies, and CI are unchanged. #1048 is left open and unchanged.

Validation:

- Checked the model information, resource links, launch arguments, and UI settings against the model card and `data-juicer-hub` source at `84de1bf8b5519b19071df296e8ff8150732f03bd`.
- Built English and Chinese Markdown documentation with the project Sphinx theme. Confirmed the Juicer pages, all three shell blocks, README announcement links, and navigation links in the generated HTML. No warnings were attributed to the new Juicer pages. The broader Markdown build still emits warnings; this check does not certify an API or all-version site build.
- Installed the Playground requirements with `uv run`, ran `python app.py` with the documented `JUICER_BASE_URL`, and received HTTP 200 from the homepage, static page, category endpoint, and case endpoint (51 cases across 8 categories). Also ran `bash serve.sh --help` and checked the documented flags against its implementation.
- `TMPDIR=/tmp uv run --no-project --python /home/cmgzn/data-juicer/.venv/bin/python python -m pre_commit run --all-files` passed.
- `git diff --check` passed.

GPU model serving and inference were not run; the Playground check verifies the UI and bundled cases, not model output.
