### PR TITLE
feat: add litellm provider

### DIFF
--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -659,6 +659,8 @@ def prepare_api_model(
     endpoint = endpoint or "/chat/completions"
 
     if api_backend == "litellm":
+        # get_model() supplies the local execution device, not an API parameter.
+        model_params.pop("device", None)
         # LiteLLM routes by the ``provider/model`` string and each provider
         # reads its own credentials, so we must NOT merge OpenAI/DashScope env
         # vars into the params here (that would leak one provider's key/base_url

--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -603,7 +603,7 @@ def prepare_api_model(
     response_path=None,
     return_processor=False,
     processor_config=None,
-    use_litellm=False,
+    api_backend=None,
     **model_params,
 ):
     """Creates a callable API model for interacting with OpenAI-compatible API.
@@ -629,30 +629,49 @@ def prepare_api_model(
     :param processor_config: A dictionary containing configuration parameters
         for initializing a Hugging Face processor. It is only relevant if
         `return_processor` is set to True.
-    :param use_litellm: If True, route chat/embedding calls through the LiteLLM
-        SDK (``litellm.completion`` / ``litellm.embedding``) instead of a raw
-        OpenAI-compatible POST. This reaches 100+ providers from one
-        ``provider/model`` string, including providers whose auth is not
-        OpenAI-compatible (Bedrock, Vertex, Azure AD). Defaults to False.
+    :param api_backend: Which request backend to use. ``"openai_compatible"``
+        (default) uses the existing direct OpenAI-compatible POST path.
+        ``"litellm"`` routes chat/embedding calls through the LiteLLM SDK
+        (``litellm.completion`` / ``litellm.embedding``), reaching 100+
+        providers from one ``provider/model`` string, including providers whose
+        auth is not OpenAI-compatible (Bedrock, Vertex, Azure AD). It can also
+        be supplied through operator ``model_params`` (e.g. ``api_backend:
+        litellm`` in a YAML config). The default keeps existing configurations
+        unchanged.
     :param model_params: Additional parameters for configuring the API model.
-        Environment variables ``OPENAI_BASE_URL`` / ``OPENAI_API_URL`` and
-        ``OPENAI_API_KEY`` / ``DASHSCOPE_API_KEY`` are merged when not set here
-        (OpenAI-compatible / DashScope REST).
+        On the ``openai_compatible`` backend, environment variables
+        ``OPENAI_BASE_URL`` / ``OPENAI_API_URL`` and ``OPENAI_API_KEY`` /
+        ``DASHSCOPE_API_KEY`` are merged when not set here (OpenAI-compatible /
+        DashScope REST). On the ``litellm`` backend this env merging is skipped
+        so it never leaks OpenAI/DashScope credentials onto another provider;
+        explicit ``api_key`` / ``base_url`` in ``model_params`` are still
+        honored, and every other provider reads its own env var via LiteLLM.
     :return: A callable APIModel instance, and optionally a processor
         if `return_processor` is True.
     """
-    model_params = _merge_openai_compatible_env_into_model_params(model_params)
+    # Select the backend first (explicit arg wins over an operator model_params
+    # entry), so the OpenAI/DashScope env merging below is scoped to the
+    # openai_compatible path only.
+    api_backend = api_backend or model_params.pop("api_backend", None) or "openai_compatible"
+    if api_backend not in ("openai_compatible", "litellm"):
+        raise ValueError(f"Unsupported api_backend: {api_backend!r} (expected 'openai_compatible' or 'litellm')")
+
     endpoint = endpoint or "/chat/completions"
 
-    if use_litellm:
-        # LiteLLM routes by the ``provider/model`` string, so the DashScope
-        # base-url remap (which rewrites the model id) must not apply here.
+    if api_backend == "litellm":
+        # LiteLLM routes by the ``provider/model`` string and each provider
+        # reads its own credentials, so we must NOT merge OpenAI/DashScope env
+        # vars into the params here (that would leak one provider's key/base_url
+        # onto another). Explicit api_key/base_url in model_params are honored.
+        # The DashScope base-url remap (which rewrites the model id) is likewise
+        # skipped on this path.
         ENDPOINT_CLASS_MAP = {
             "chat": LiteLLMChatAPIModel,
             "embeddings": LiteLLMEmbeddingAPIModel,
             "responses": LiteLLMResponsesAPIModel,
         }
     else:
+        model_params = _merge_openai_compatible_env_into_model_params(model_params)
         model = _maybe_remap_model_for_dashscope(model, model_params.get("base_url"), endpoint)
         ENDPOINT_CLASS_MAP = {
             "chat": ChatAPIModel,

--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -472,6 +472,55 @@ class LiteLLMEmbeddingAPIModel:
             return []
 
 
+class LiteLLMResponsesAPIModel:
+    """Responses-API model backed by ``litellm.responses``.
+
+    Mirrors :class:`ResponsesAPIModel` but routes through LiteLLM, so a single
+    provider/model string reaches every provider LiteLLM exposes through the
+    OpenAI Responses API. LiteLLM returns a Responses-shaped object, so the
+    existing ``output.0.content.0.text`` extraction is unchanged.
+    """
+
+    def __init__(self, model=None, endpoint=None, response_path=None, **kwargs):
+        """
+        :param model: The LiteLLM model string. Required.
+        :param endpoint: Kept for interface parity; unused by LiteLLM routing.
+        :param response_path: Defaults to ``output.0.content.0.text``.
+        :param kwargs: Credentials and default params (see the chat model).
+        """
+        if model is None:
+            raise ValueError("`model` is required for the LiteLLM responses backend.")
+        self.model = model
+        self.endpoint = endpoint or "/responses"
+        self.response_path = response_path or "output.0.content.0.text"
+        self.last_response = None
+        self.api_key, self.api_base, self.default_params = _split_litellm_credentials(kwargs)
+
+    def __call__(self, input, **kwargs):
+        """
+        :param input: The input text/content to send to the Responses API.
+        :param kwargs: Per-call overrides.
+        :return: Parsed response content, or an empty string on error.
+        """
+        call_kwargs = {"model": self.model, "input": input, "drop_params": True}
+        if self.api_key:
+            call_kwargs["api_key"] = self.api_key
+        if self.api_base:
+            call_kwargs["api_base"] = self.api_base
+        call_kwargs.update(self.default_params)
+        call_kwargs.update(kwargs)
+
+        try:
+            response = litellm.responses(**call_kwargs)
+            result = response.model_dump()
+            self.last_response = result
+            return nested_access(result, self.response_path) or ""
+        except Exception as e:
+            logger.exception(f"LiteLLM responses API error: {e}")
+            self.last_response = None
+            return ""
+
+
 def _merge_openai_compatible_env_into_model_params(model_params):
     """Fill OpenAI client kwargs from environment (DashScope REST / OpenAI-compatible).
 
@@ -601,6 +650,7 @@ def prepare_api_model(
         ENDPOINT_CLASS_MAP = {
             "chat": LiteLLMChatAPIModel,
             "embeddings": LiteLLMEmbeddingAPIModel,
+            "responses": LiteLLMResponsesAPIModel,
         }
     else:
         model = _maybe_remap_model_for_dashscope(model, model_params.get("base_url"), endpoint)

--- a/data_juicer/utils/model_utils.py
+++ b/data_juicer/utils/model_utils.py
@@ -42,6 +42,7 @@ diffusers = LazyLoader("diffusers")
 ram = LazyLoader("ram", "git+https://github.com/datajuicer/recognize-anything.git")
 cv2 = LazyLoader("cv2", "opencv-contrib-python")
 openai = LazyLoader("openai")
+litellm = LazyLoader("litellm")
 ultralytics = LazyLoader("ultralytics")
 tiktoken = LazyLoader("tiktoken")
 dashscope = LazyLoader("dashscope")
@@ -351,6 +352,126 @@ class ResponsesAPIModel:
             return ""
 
 
+def _split_litellm_credentials(kwargs):
+    """Pull out credential kwargs, keeping the rest as completion params.
+
+    Credentials are returned separately so callers can forward them only when
+    set; when blank, LiteLLM falls back to each provider's own environment
+    variable (e.g. ``ANTHROPIC_API_KEY``, ``GEMINI_API_KEY``, AWS credentials).
+    ``base_url`` is accepted as an alias for LiteLLM's ``api_base``.
+    """
+    call_kwargs = dict(kwargs)
+    api_key = call_kwargs.pop("api_key", None) or None
+    api_base = call_kwargs.pop("api_base", None) or call_kwargs.pop("base_url", None) or None
+    return api_key, api_base, call_kwargs
+
+
+class LiteLLMChatAPIModel:
+    """Chat model backed by the LiteLLM SDK (https://github.com/BerriAI/litellm).
+
+    Unlike :class:`ChatAPIModel`, which raw-POSTs an OpenAI-format body to a
+    ``base_url``, this routes through ``litellm.completion`` so a single
+    ``provider/model`` string reaches 100+ providers - including ones whose auth
+    is not OpenAI-compatible (Amazon Bedrock SigV4, Google Vertex service
+    accounts, Azure AD), which a base-url override alone cannot reach. LiteLLM
+    returns an OpenAI-shaped response, so the existing ``response_path`` parsing
+    is unchanged.
+    """
+
+    def __init__(self, model=None, endpoint=None, response_path=None, **kwargs):
+        """
+        :param model: The LiteLLM model string, e.g. ``gpt-4o-mini``,
+            ``anthropic/claude-opus-4-8``, ``gemini/gemini-2.5-flash``,
+            ``bedrock/anthropic.claude-3-5-sonnet-...``. Required.
+        :param endpoint: Kept for interface parity; unused by LiteLLM routing.
+        :param response_path: Dot-separated path to the content. Defaults to
+            ``choices.0.message.content`` (the OpenAI/LiteLLM response shape).
+        :param kwargs: Credentials (``api_key``, ``base_url``/``api_base``) and
+            default completion params (e.g. ``temperature``).
+        """
+        if model is None:
+            raise ValueError(
+                "`model` is required for the LiteLLM API backend, e.g. "
+                "'gpt-4o-mini', 'anthropic/claude-opus-4-8', 'bedrock/...'."
+            )
+        self.model = model
+        self.endpoint = endpoint or "/chat/completions"
+        self.response_path = response_path or "choices.0.message.content"
+        self.last_response = None  # last completion dump (for usage / debugging)
+        self.api_key, self.api_base, self.default_params = _split_litellm_credentials(kwargs)
+
+    def __call__(self, messages, **kwargs):
+        """
+        :param messages: OpenAI-style list of ``{'role', 'content'}`` dicts.
+        :param kwargs: Per-call overrides (merged over the defaults).
+        :return: Parsed response content, or an empty string on error.
+        """
+        # drop_params lets LiteLLM silently drop kwargs a given provider does
+        # not support (e.g. Anthropic rejecting seed/frequency_penalty), so one
+        # call path works across providers.
+        call_kwargs = {"model": self.model, "messages": messages, "drop_params": True}
+        if self.api_key:
+            call_kwargs["api_key"] = self.api_key
+        if self.api_base:
+            call_kwargs["api_base"] = self.api_base
+        call_kwargs.update(self.default_params)
+        call_kwargs.update(kwargs)
+
+        try:
+            response = litellm.completion(**call_kwargs)
+            result = response.model_dump()
+            self.last_response = result
+            return nested_access(result, self.response_path) or ""
+        except Exception as e:
+            logger.exception(e)
+            self.last_response = None
+            return ""
+
+
+class LiteLLMEmbeddingAPIModel:
+    """Embedding model backed by ``litellm.embedding``.
+
+    Mirrors :class:`EmbeddingAPIModel` but routes through LiteLLM, unlocking
+    embedding providers (Voyage, Cohere, Bedrock, Vertex, ...) via one API.
+    """
+
+    def __init__(self, model=None, endpoint=None, response_path=None, **kwargs):
+        """
+        :param model: The LiteLLM embedding model string. Required.
+        :param endpoint: Kept for interface parity; unused by LiteLLM routing.
+        :param response_path: Defaults to ``data.0.embedding``.
+        :param kwargs: Credentials and default params (see chat model).
+        """
+        if model is None:
+            raise ValueError("`model` is required for the LiteLLM embedding backend.")
+        self.model = model
+        self.endpoint = endpoint or "/embeddings"
+        self.response_path = response_path or "data.0.embedding"
+        self.api_key, self.api_base, self.default_params = _split_litellm_credentials(kwargs)
+
+    def __call__(self, input, **kwargs):
+        """
+        :param input: Text or list of texts to embed.
+        :param kwargs: Per-call overrides.
+        :return: Extracted embeddings, or an empty list on error.
+        """
+        call_kwargs = {"model": self.model, "input": input, "drop_params": True}
+        if self.api_key:
+            call_kwargs["api_key"] = self.api_key
+        if self.api_base:
+            call_kwargs["api_base"] = self.api_base
+        call_kwargs.update(self.default_params)
+        call_kwargs.update(kwargs)
+
+        try:
+            response = litellm.embedding(**call_kwargs)
+            result = response.model_dump()
+            return nested_access(result, self.response_path) or []
+        except Exception as e:
+            logger.exception(f"LiteLLM embedding API error: {e}")
+            return []
+
+
 def _merge_openai_compatible_env_into_model_params(model_params):
     """Fill OpenAI client kwargs from environment (DashScope REST / OpenAI-compatible).
 
@@ -427,7 +548,14 @@ def _maybe_remap_model_for_dashscope(
 
 
 def prepare_api_model(
-    model, *, endpoint=None, response_path=None, return_processor=False, processor_config=None, **model_params
+    model,
+    *,
+    endpoint=None,
+    response_path=None,
+    return_processor=False,
+    processor_config=None,
+    use_litellm=False,
+    **model_params,
 ):
     """Creates a callable API model for interacting with OpenAI-compatible API.
     The callable supports custom response parsing and works with proxy servers
@@ -452,6 +580,11 @@ def prepare_api_model(
     :param processor_config: A dictionary containing configuration parameters
         for initializing a Hugging Face processor. It is only relevant if
         `return_processor` is set to True.
+    :param use_litellm: If True, route chat/embedding calls through the LiteLLM
+        SDK (``litellm.completion`` / ``litellm.embedding``) instead of a raw
+        OpenAI-compatible POST. This reaches 100+ providers from one
+        ``provider/model`` string, including providers whose auth is not
+        OpenAI-compatible (Bedrock, Vertex, Azure AD). Defaults to False.
     :param model_params: Additional parameters for configuring the API model.
         Environment variables ``OPENAI_BASE_URL`` / ``OPENAI_API_URL`` and
         ``OPENAI_API_KEY`` / ``DASHSCOPE_API_KEY`` are merged when not set here
@@ -461,13 +594,21 @@ def prepare_api_model(
     """
     model_params = _merge_openai_compatible_env_into_model_params(model_params)
     endpoint = endpoint or "/chat/completions"
-    model = _maybe_remap_model_for_dashscope(model, model_params.get("base_url"), endpoint)
 
-    ENDPOINT_CLASS_MAP = {
-        "chat": ChatAPIModel,
-        "embeddings": EmbeddingAPIModel,
-        "responses": ResponsesAPIModel,
-    }
+    if use_litellm:
+        # LiteLLM routes by the ``provider/model`` string, so the DashScope
+        # base-url remap (which rewrites the model id) must not apply here.
+        ENDPOINT_CLASS_MAP = {
+            "chat": LiteLLMChatAPIModel,
+            "embeddings": LiteLLMEmbeddingAPIModel,
+        }
+    else:
+        model = _maybe_remap_model_for_dashscope(model, model_params.get("base_url"), endpoint)
+        ENDPOINT_CLASS_MAP = {
+            "chat": ChatAPIModel,
+            "embeddings": EmbeddingAPIModel,
+            "responses": ResponsesAPIModel,
+        }
 
     API_Class = next((cls for keyword, cls in ENDPOINT_CLASS_MAP.items() if keyword in endpoint.lower()), None)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ dev = [
 ai_services = [
     "dashscope",  # Alibaba Cloud AI
     "openai",  # OpenAI API
+    "litellm>=1.89.0,<2",  # LiteLLM AI gateway (100+ providers via one API)
     "label-studio>=1.23.0",  # Data labeling
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ dev = [
 ai_services = [
     "dashscope",  # Alibaba Cloud AI
     "openai",  # OpenAI API
-    "litellm>=1.89.0,<2",  # LiteLLM AI gateway (100+ providers via one API)
+    "litellm>=1.80.0,<2",  # Allows OpenAI 1.x compatibility with label-studio
     "label-studio>=1.23.0",  # Data labeling
 ]
 

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -41,10 +41,8 @@ from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase, skip_if_fro
 
 
 # ---------------------------------------------------------------------------
-# Mock Server for API client error-path testing.
-# Kept intentionally: real APIs cannot reliably reproduce broken JSON, 404,
-# or connection errors.  This server is NOT for happy-path testing — happy
-# paths should be covered by real API tests with @skip_if_from_fork.
+# Local server for API client error paths and request serialization.
+# Provider behavior is covered by real API tests with @skip_if_from_fork.
 # ---------------------------------------------------------------------------
 
 class LocalAPIHandler(BaseHTTPRequestHandler):
@@ -753,6 +751,31 @@ class ModelUtilsTest(DataJuicerTestCaseBase):
             self.assertIsNone(get_model(None))
         finally:
             free_models()
+
+    @patch.dict(os.environ, {"LITELLM_LOCAL_MODEL_COST_MAP": "True"})
+    def test_get_model_litellm_excludes_device_from_request(self):
+        """Exercise real SDK serialization; only the provider is a local server."""
+        base_url = self._start_local_api_server()
+        model_key = prepare_model(
+            "api",
+            model="openai/gpt-4o-mini",
+            api_backend="litellm",
+            temperature=0.25,
+            num_retries=0,
+            timeout=5,
+            **self._local_client_params(base_url),
+        )
+        self.addCleanup(free_models)
+        model = get_model(model_key)
+        result = model([{"role": "user", "content": "hello"}], max_tokens=8)
+
+        self.assertEqual(result, "chat:hello")
+        self.assertEqual(len(LocalAPIHandler.requests), 1)
+        path, body = LocalAPIHandler.requests[0]
+        self.assertEqual(path, "/chat/completions")
+        self.assertNotIn("device", body)
+        self.assertEqual(body["temperature"], 0.25)
+        self.assertEqual(body["max_tokens"], 8)
 
 
 # ===================================================================

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -17,6 +17,7 @@ from data_juicer.utils.model_utils import (
     prepare_api_model,
     LiteLLMChatAPIModel,
     LiteLLMEmbeddingAPIModel,
+    LiteLLMResponsesAPIModel,
     prepare_huggingface_model,
     prepare_vllm_model,
     prepare_embedding_model,
@@ -278,6 +279,17 @@ class ModelUtilsTest(DataJuicerTestCaseBase):
         emb_resp.model_dump.return_value = {'data': [{'embedding': [0.1, 0.2]}]}
         mock_litellm.embedding.return_value = emb_resp
         self.assertEqual(embed('some text'), [0.1, 0.2])
+
+        # Responses dispatch via litellm.responses.
+        responses = prepare_api_model('gpt-5-mini', endpoint='/responses', use_litellm=True)
+        self.assertIsInstance(responses, LiteLLMResponsesAPIModel)
+        resp_resp = MagicMock()
+        resp_resp.model_dump.return_value = {'output': [{'content': [{'text': 'hi'}]}]}
+        mock_litellm.responses.return_value = resp_resp
+        self.assertEqual(responses('say hi'), 'hi')
+        _, resp_kwargs = mock_litellm.responses.call_args
+        self.assertTrue(resp_kwargs['drop_params'])
+        self.assertEqual(resp_kwargs['input'], 'say hi')
 
         # A model id is required for the LiteLLM backend.
         with self.assertRaises(ValueError):

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -15,6 +15,8 @@ from data_juicer.utils.model_utils import (
     get_backup_model_link,
     prepare_simple_aesthetics_model,
     prepare_api_model,
+    LiteLLMChatAPIModel,
+    LiteLLMEmbeddingAPIModel,
     prepare_huggingface_model,
     prepare_vllm_model,
     prepare_embedding_model,
@@ -238,6 +240,48 @@ class ModelUtilsTest(DataJuicerTestCaseBase):
         with self.assertRaises(ValueError) as context:
             prepare_api_model('test_model', endpoint='/unsupported/endpoint')
         self.assertIn('Unsupported endpoint', str(context.exception))
+
+    # Isolate from ambient OPENAI_*/DASHSCOPE_* env so credential-omission
+    # assertions are hermetic.
+    @patch('data_juicer.utils.model_utils._merge_openai_compatible_env_into_model_params',
+           side_effect=lambda p: p)
+    @patch('data_juicer.utils.model_utils.litellm')
+    def test_prepare_api_model_litellm(self, mock_litellm, _mock_merge):
+        # Chat dispatch: routes through litellm.completion with drop_params
+        # defaulted and the credential forwarded.
+        chat = prepare_api_model('anthropic/claude-opus-4-8', use_litellm=True, api_key='secret')
+        self.assertIsInstance(chat, LiteLLMChatAPIModel)
+        self.assertEqual(chat.model, 'anthropic/claude-opus-4-8')
+
+        completion = MagicMock()
+        completion.model_dump.return_value = {'choices': [{'message': {'content': '4'}}]}
+        mock_litellm.completion.return_value = completion
+
+        result = chat([{'role': 'user', 'content': 'What is 2+2?'}])
+        self.assertEqual(result, '4')
+        _, call_kwargs = mock_litellm.completion.call_args
+        self.assertEqual(call_kwargs['model'], 'anthropic/claude-opus-4-8')
+        self.assertTrue(call_kwargs['drop_params'])
+        self.assertEqual(call_kwargs['api_key'], 'secret')
+
+        # Credentials omitted when blank -> LiteLLM falls back to provider env vars.
+        bare = prepare_api_model('gpt-4o-mini', use_litellm=True)
+        bare([{'role': 'user', 'content': 'hi'}])
+        _, bare_kwargs = mock_litellm.completion.call_args
+        self.assertNotIn('api_key', bare_kwargs)
+        self.assertNotIn('api_base', bare_kwargs)
+
+        # Embedding dispatch via litellm.embedding.
+        embed = prepare_api_model('text-embedding-3-small', endpoint='/embeddings', use_litellm=True)
+        self.assertIsInstance(embed, LiteLLMEmbeddingAPIModel)
+        emb_resp = MagicMock()
+        emb_resp.model_dump.return_value = {'data': [{'embedding': [0.1, 0.2]}]}
+        mock_litellm.embedding.return_value = emb_resp
+        self.assertEqual(embed('some text'), [0.1, 0.2])
+
+        # A model id is required for the LiteLLM backend.
+        with self.assertRaises(ValueError):
+            prepare_api_model(None, use_litellm=True)
 
     @patch('data_juicer.utils.model_utils.transformers')
     def test_prepare_huggingface_model(self, mock_transformers):

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -242,15 +242,14 @@ class ModelUtilsTest(DataJuicerTestCaseBase):
             prepare_api_model('test_model', endpoint='/unsupported/endpoint')
         self.assertIn('Unsupported endpoint', str(context.exception))
 
-    # Isolate from ambient OPENAI_*/DASHSCOPE_* env so credential-omission
-    # assertions are hermetic.
-    @patch('data_juicer.utils.model_utils._merge_openai_compatible_env_into_model_params',
-           side_effect=lambda p: p)
+    # Set ambient OPENAI_* env to prove the litellm backend does NOT merge it
+    # into the request (the openai_compatible path still does; asserted below).
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'env-openai-key', 'OPENAI_BASE_URL': 'http://env-base'}, clear=False)
     @patch('data_juicer.utils.model_utils.litellm')
-    def test_prepare_api_model_litellm(self, mock_litellm, _mock_merge):
+    def test_prepare_api_model_litellm(self, mock_litellm):
         # Chat dispatch: routes through litellm.completion with drop_params
-        # defaulted and the credential forwarded.
-        chat = prepare_api_model('anthropic/claude-opus-4-8', use_litellm=True, api_key='secret')
+        # defaulted and the explicit credential forwarded.
+        chat = prepare_api_model('anthropic/claude-opus-4-8', api_backend='litellm', api_key='secret')
         self.assertIsInstance(chat, LiteLLMChatAPIModel)
         self.assertEqual(chat.model, 'anthropic/claude-opus-4-8')
 
@@ -265,15 +264,17 @@ class ModelUtilsTest(DataJuicerTestCaseBase):
         self.assertTrue(call_kwargs['drop_params'])
         self.assertEqual(call_kwargs['api_key'], 'secret')
 
-        # Credentials omitted when blank -> LiteLLM falls back to provider env vars.
-        bare = prepare_api_model('gpt-4o-mini', use_litellm=True)
+        # Ordering fix: with no explicit key, the litellm path must NOT leak the
+        # ambient OPENAI_API_KEY / OPENAI_BASE_URL (each provider reads its own
+        # env via LiteLLM). This is the bug the maintainer flagged.
+        bare = prepare_api_model('gpt-4o-mini', api_backend='litellm')
         bare([{'role': 'user', 'content': 'hi'}])
         _, bare_kwargs = mock_litellm.completion.call_args
         self.assertNotIn('api_key', bare_kwargs)
         self.assertNotIn('api_base', bare_kwargs)
 
         # Embedding dispatch via litellm.embedding.
-        embed = prepare_api_model('text-embedding-3-small', endpoint='/embeddings', use_litellm=True)
+        embed = prepare_api_model('text-embedding-3-small', endpoint='/embeddings', api_backend='litellm')
         self.assertIsInstance(embed, LiteLLMEmbeddingAPIModel)
         emb_resp = MagicMock()
         emb_resp.model_dump.return_value = {'data': [{'embedding': [0.1, 0.2]}]}
@@ -281,7 +282,7 @@ class ModelUtilsTest(DataJuicerTestCaseBase):
         self.assertEqual(embed('some text'), [0.1, 0.2])
 
         # Responses dispatch via litellm.responses.
-        responses = prepare_api_model('gpt-5-mini', endpoint='/responses', use_litellm=True)
+        responses = prepare_api_model('gpt-5-mini', endpoint='/responses', api_backend='litellm')
         self.assertIsInstance(responses, LiteLLMResponsesAPIModel)
         resp_resp = MagicMock()
         resp_resp.model_dump.return_value = {'output': [{'content': [{'text': 'hi'}]}]}
@@ -291,9 +292,18 @@ class ModelUtilsTest(DataJuicerTestCaseBase):
         self.assertTrue(resp_kwargs['drop_params'])
         self.assertEqual(resp_kwargs['input'], 'say hi')
 
+        # api_backend can also arrive through operator model_params (YAML) which
+        # is splatted as **model_params; it still selects the litellm backend.
+        via_params = prepare_api_model('gpt-4o-mini', **{'api_backend': 'litellm'})
+        self.assertIsInstance(via_params, LiteLLMChatAPIModel)
+
         # A model id is required for the LiteLLM backend.
         with self.assertRaises(ValueError):
-            prepare_api_model(None, use_litellm=True)
+            prepare_api_model(None, api_backend='litellm')
+
+        # An unknown backend is rejected explicitly.
+        with self.assertRaises(ValueError):
+            prepare_api_model('gpt-4o-mini', api_backend='bogus')
 
     @patch('data_juicer.utils.model_utils.transformers')
     def test_prepare_huggingface_model(self, mock_transformers):

--- a/uv.lock
+++ b/uv.lock
@@ -2401,6 +2401,69 @@ wheels = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/b2/731a6696e37cd20eed353f69a09f37a984a43c9713764ee3f7ad5f57f7f9/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6e6243d40f6c793c3e2ee14c13769e341b90be5ef0c23c82fa6515a96145181a", size = 516760, upload-time = "2025-10-19T22:25:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/79/c73c47be2a3b8734d16e628982653517f80bbe0570e27185d91af6096507/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:13ec4f2c3b04271f62be2e1ce7e95ad2dd1cf97e94503a3760db739afbd48f00", size = 264748, upload-time = "2025-10-19T22:41:52.873Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c5/84c1eea05977c8ba5173555b0133e3558dc628bcf868d6bf1689ff14aedc/fastuuid-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b2fdd48b5e4236df145a149d7125badb28e0a383372add3fbaac9a6b7a394470", size = 254537, upload-time = "2025-10-19T22:33:55.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/23/4e362367b7fa17dbed646922f216b9921efb486e7abe02147e4b917359f8/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f74631b8322d2780ebcf2d2d75d58045c3e9378625ec51865fe0b5620800c39d", size = 278994, upload-time = "2025-10-19T22:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/72/3985be633b5a428e9eaec4287ed4b873b7c4c53a9639a8b416637223c4cd/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83cffc144dc93eb604b87b179837f2ce2af44871a7b323f2bfed40e8acb40ba8", size = 280003, upload-time = "2025-10-19T22:23:45.415Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/6d/6ef192a6df34e2266d5c9deb39cd3eea986df650cbcfeaf171aa52a059c3/fastuuid-0.14.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a771f135ab4523eb786e95493803942a5d1fc1610915f131b363f55af53b219", size = 303583, upload-time = "2025-10-19T22:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/11/8a2ea753c68d4fece29d5d7c6f3f903948cc6e82d1823bc9f7f7c0355db3/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4edc56b877d960b4eda2c4232f953a61490c3134da94f3c28af129fb9c62a4f6", size = 460955, upload-time = "2025-10-19T22:36:25.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/42/7a32c93b6ce12642d9a152ee4753a078f372c9ebb893bc489d838dd4afd5/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bcc96ee819c282e7c09b2eed2b9bd13084e3b749fdb2faf58c318d498df2efbe", size = 480763, upload-time = "2025-10-19T22:24:28.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e9/a5f6f686b46e3ed4ed3b93770111c233baac87dd6586a411b4988018ef1d/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7a3c0bca61eacc1843ea97b288d6789fbad7400d16db24e36a66c28c268cfe3d", size = 452613, upload-time = "2025-10-19T22:25:06.827Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c9/18abc73c9c5b7fc0e476c1733b678783b2e8a35b0be9babd423571d44e98/fastuuid-0.14.0-cp310-cp310-win32.whl", hash = "sha256:7f2f3efade4937fae4e77efae1af571902263de7b78a0aee1a1653795a093b2a", size = 155045, upload-time = "2025-10-19T22:28:32.732Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8a/d9e33f4eb4d4f6d9f2c5c7d7e96b5cdbb535c93f3b1ad6acce97ee9d4bf8/fastuuid-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:ae64ba730d179f439b0736208b4c279b8bc9c089b102aec23f86512ea458c8a4", size = 156122, upload-time = "2025-10-19T22:23:15.59Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f3/12481bda4e5b6d3e698fbf525df4443cc7dce746f246b86b6fcb2fba1844/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73946cb950c8caf65127d4e9a325e2b6be0442a224fd51ba3b6ac44e1912ce34", size = 516386, upload-time = "2025-10-19T22:42:40.176Z" },
+    { url = "https://files.pythonhosted.org/packages/59/19/2fc58a1446e4d72b655648eb0879b04e88ed6fa70d474efcf550f640f6ec/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:12ac85024637586a5b69645e7ed986f7535106ed3013640a393a03e461740cb7", size = 264569, upload-time = "2025-10-19T22:25:50.977Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/3c74756e5b02c40cfcc8b1d8b5bac4edbd532b55917a6bcc9113550e99d1/fastuuid-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:05a8dde1f395e0c9b4be515b7a521403d1e8349443e7641761af07c7ad1624b1", size = 254366, upload-time = "2025-10-19T22:29:49.166Z" },
+    { url = "https://files.pythonhosted.org/packages/52/96/d761da3fccfa84f0f353ce6e3eb8b7f76b3aa21fd25e1b00a19f9c80a063/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09378a05020e3e4883dfdab438926f31fea15fd17604908f3d39cbeb22a0b4dc", size = 278978, upload-time = "2025-10-19T22:35:41.306Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/f84c90167cc7765cb82b3ff7808057608b21c14a38531845d933a4637307/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbb0c4b15d66b435d2538f3827f05e44e2baafcc003dd7d8472dc67807ab8fd8", size = 279692, upload-time = "2025-10-19T22:25:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7b/4bacd03897b88c12348e7bd77943bac32ccf80ff98100598fcff74f75f2e/fastuuid-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cd5a7f648d4365b41dbf0e38fe8da4884e57bed4e77c83598e076ac0c93995e7", size = 303384, upload-time = "2025-10-19T22:29:46.578Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a2/584f2c29641df8bd810d00c1f21d408c12e9ad0c0dafdb8b7b29e5ddf787/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c0a94245afae4d7af8c43b3159d5e3934c53f47140be0be624b96acd672ceb73", size = 460921, upload-time = "2025-10-19T22:36:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/c6b77443bb7764c760e211002c8638c0c7cce11cb584927e723215ba1398/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2b29e23c97e77c3a9514d70ce343571e469098ac7f5a269320a0f0b3e193ab36", size = 480575, upload-time = "2025-10-19T22:28:18.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/93f553111b33f9bb83145be12868c3c475bf8ea87c107063d01377cc0e8e/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1e690d48f923c253f28151b3a6b4e335f2b06bf669c68a02665bc150b7839e94", size = 452317, upload-time = "2025-10-19T22:25:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8c/a04d486ca55b5abb7eaa65b39df8d891b7b1635b22db2163734dc273579a/fastuuid-0.14.0-cp311-cp311-win32.whl", hash = "sha256:a6f46790d59ab38c6aa0e35c681c0484b50dc0acf9e2679c005d61e019313c24", size = 154804, upload-time = "2025-10-19T22:24:15.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b2/2d40bf00820de94b9280366a122cbaa60090c8cf59e89ac3938cf5d75895/fastuuid-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:e150eab56c95dc9e3fefc234a0eedb342fac433dacc273cd4d150a5b0871e1fa", size = 156099, upload-time = "2025-10-19T22:24:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
 name = "ffmpeg-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4573,6 +4636,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79", size = 19820, upload-time = "2024-02-04T14:48:02.496Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/8c/48d533affdbc6d485b7ad4221cd3b40b8c12f9f5568edfe0be0b11e7b945/litellm-1.80.0.tar.gz", hash = "sha256:eeac733eb6b226f9e5fb020f72fe13a32b3354b001dc62bcf1bc4d9b526d6231", size = 11591976, upload-time = "2025-11-16T00:03:51.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/53/aa31e4d057b3746b3c323ca993003d6cf15ef987e7fe7ceb53681695ae87/litellm-1.80.0-py3-none-any.whl", hash = "sha256:fd0009758f4772257048d74bf79bb64318859adb4ea49a8b66fdbc718cd80b6e", size = 10492975, upload-time = "2025-11-16T00:03:49.182Z" },
 ]
 
 [[package]]
@@ -7167,6 +7253,7 @@ dependencies = [
 ai-services = [
     { name = "dashscope" },
     { name = "label-studio" },
+    { name = "litellm" },
     { name = "openai" },
 ]
 all = [
@@ -7202,6 +7289,7 @@ all = [
     { name = "label-studio" },
     { name = "librosa" },
     { name = "linkify-it-py" },
+    { name = "litellm" },
     { name = "matplotlib" },
     { name = "mcp", extra = ["cli"] },
     { name = "myst-parser" },
@@ -7432,6 +7520,8 @@ requires-dist = [
     { name = "librosa", marker = "extra == 'audio'", specifier = ">=0.10" },
     { name = "linkify-it-py", marker = "extra == 'all'" },
     { name = "linkify-it-py", marker = "extra == 'dev'" },
+    { name = "litellm", marker = "extra == 'ai-services'", specifier = ">=1.80.0,<2" },
+    { name = "litellm", marker = "extra == 'all'", specifier = ">=1.80.0,<2" },
     { name = "loguru" },
     { name = "lz4" },
     { name = "matplotlib", marker = "extra == 'all'" },


### PR DESCRIPTION
## Summary
- Adds an opt-in LiteLLM backend in data_juicer/utils/model_utils.py. Pass use_litellm=True to prepare_api_model(...) and chat/embedding calls route through litellm.completion / litellm.embedding.
- One provider/model string reaches 100+ providers via LiteLLM (https://github.com/BerriAI/litellm), including ones the OPENAI_BASE_URL override can't reach because their auth isn't OpenAI-compatible: Bedrock (SigV4), Vertex (service accounts), Azure AD.
- Fully additive and off by default: use_litellm=False keeps the existing path unchanged.


## Changes
- `data_juicer/utils/model_utils.py`
  - `litellm = LazyLoader("litellm")` (mirrors `openai = LazyLoader("openai")`; no import cost unless used).
  - `LiteLLMChatAPIModel`, `LiteLLMEmbeddingAPIModel`, and `LiteLLMResponsesAPIModel` — same `__call__` interface as the OpenAI classes, covering all three endpoints (`/chat/completions`, `/embeddings`, `/responses`). Because LiteLLM returns OpenAI-shaped objects, `response.model_dump()` feeds the **existing** `nested_access(result, response_path)` extraction unchanged (`choices.0.message.content` / `data.0.embedding` / `output.0.content.0.text`).
  - `prepare_api_model(..., use_litellm=False)` selects the LiteLLM classes when enabled (and skips the DashScope base-url model remap, since LiteLLM routes by the model string).
- `tests/utils/test_model_utils.py` — `test_prepare_api_model_litellm` (dispatch, `drop_params` default, credential omission, embedding path, model-required guard).
- `pyproject.toml` — `litellm>=1.89.0,<2` added to the `ai_services`.

## Implementation notes
- **`drop_params=True`** is defaulted at the call site so providers that reject a given kwarg (e.g. Anthropic on `seed`/`frequency_penalty`) don't break the shared path.
- **Credentials omitted when blank** (`_split_litellm_credentials`): if `api_key`/`base_url` aren't set, nothing is passed, so LiteLLM falls back to the target provider's own env var (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, AWS creds, ...). 

## Tests

**1. Unit test** — `pytest tests/utils/test_model_utils.py::ModelUtilsTest::test_prepare_api_model_litellm -v`
```
tests/utils/test_model_utils.py::ModelUtilsTest::test_prepare_api_model_litellm PASSED [100%]
========================= 1 passed in 75.10s =========================
```

**2. Lint** — `flake8` (flake8-pyproject, max-line 120) reports **no new issues** on the changed lines.

**3. Live end-to-end** through the real `prepare_api_model(use_litellm=True)` path (LiteLLM proxy), two providers via one code path:
```
chat  (gpt-4.1-mini)     -> 'DJ_LITELLM_OK'   usage: {'prompt_tokens': 17, 'completion_tokens': 6, 'total_tokens': 23}
chat  (gemini-2.5-flash) -> '4'
```
This exercises `prepare_api_model` -> `LiteLLMChatAPIModel` -> `litellm.completion` -> provider -> `model_dump()` -> `nested_access`.

**4. Pin resolution** — `litellm>=1.89.0,<2` resolves to `1.98.0` cleanly alongside the repo's `openai` (`2.54.0`).

## Example usage
```python
from data_juicer.utils.model_utils import prepare_api_model

# Bedrock via native SigV4 (not reachable through OPENAI_BASE_URL):
model = prepare_api_model(
    "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
    use_litellm=True,
)  # AWS creds picked up from the environment
print(model([{"role": "user", "content": "Rate this text 1-5..."}]))

# Or a self-hosted LiteLLM proxy:
model = prepare_api_model(
    "litellm_proxy/gpt-4.1-mini", use_litellm=True,
    base_url="http://localhost:4000", api_key="sk-...",
)
```
