### PR TITLE
fix(exporter): serialize dates in JSONL output

### DIFF
--- a/data_juicer/core/exporter.py
+++ b/data_juicer/core/exporter.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import date
 from multiprocessing import Pool
 from urllib.parse import urlparse
 
@@ -395,6 +396,8 @@ class Exporter:
             return {k: Exporter._row_to_json_serializable(v) for k, v in obj.items()}
         if isinstance(obj, list):
             return [Exporter._row_to_json_serializable(v) for v in obj]
+        if isinstance(obj, date):
+            return obj.isoformat()
         if hasattr(obj, "item"):  # numpy scalar
             return obj.item()
         if hasattr(obj, "tolist"):

--- a/tests/core/test_exporter.py
+++ b/tests/core/test_exporter.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime, timezone
+
 import json
 import os
 import shutil
@@ -462,11 +464,21 @@ class CoreExporterFileTest(DataJuicerTestCaseBase):
             "scalar": np.int64(7),
             "array": ListLike(),
             "nested": [ArrowLike()],
+            "date": date(2024, 1, 2),
+            "datetime": datetime(2024, 1, 2, 3, 4, 5),
+            "datetime_tz": datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
         }
 
         self.assertEqual(
             self.Exporter._row_to_json_serializable(row),
-            {"scalar": 7, "array": [1, 2], "nested": [{"nested": 3}]},
+            {
+                "scalar": 7,
+                "array": [1, 2],
+                "nested": [{"nested": 3}],
+                "date": "2024-01-02",
+                "datetime": "2024-01-02T03:04:05",
+                "datetime_tz": "2024-01-02T03:04:05+00:00",
+            },
         )
 
     def test_json_jsonl_parquet_exports_and_filtered_shards(self):


### PR DESCRIPTION
## Problem

The custom JSONL writer leaves Python date and datetime values unchanged, causing json.dumps to raise TypeError.

## Fix

Serialize date values with isoformat. This also covers datetime because it subclasses date, while leaving unsupported types unchanged.

## Tests

- python -m pytest tests/core/test_exporter.py -q (22 passed)
- pre-commit run --all-files

Fixes #1064