### PR TITLE
deps: bump nltk to 3.10.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ vision = [
 
 # Natural Language Processing
 nlp = [
-    "nltk==3.9.1",  # NLP toolkit
+    "nltk==3.10.3",  # NLP toolkit
     "easyocr==1.7.1",  # OCR
     "fasttext-predict",  # FastText (no numpy dependency, numpy 2.x safe)
     "kenlm",  # Language modeling

--- a/uv.lock
+++ b/uv.lock
@@ -5631,7 +5631,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/71/6c/a485fcaf573db12b5
 
 [[package]]
 name = "nltk"
-version = "3.9.1"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -5639,9 +5639,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/87/db8be88ad32c2d042420b6fd9ffd4a149f9a0d7f0e86b3f543be2eeeedd2/nltk-3.9.1.tar.gz", hash = "sha256:87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868", size = 2904691, upload-time = "2024-08-18T19:48:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258487Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/66/7d9e26593edda06e8cb531874633f7c2372279c3b0f46235539fe546df8b/nltk-3.9.1-py3-none-any.whl", hash = "sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1", size = 1505442, upload-time = "2024-08-18T19:48:21.909Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478418Z" },
 ]
 
 [[package]]
@@ -7446,8 +7446,8 @@ requires-dist = [
     { name = "nlpaug", marker = "extra == 'nlp'" },
     { name = "nlpcda", marker = "extra == 'all'" },
     { name = "nlpcda", marker = "extra == 'nlp'" },
-    { name = "nltk", marker = "extra == 'all'", specifier = "==3.9.1" },
-    { name = "nltk", marker = "extra == 'nlp'", specifier = "==3.9.1" },
+    { name = "nltk", marker = "extra == 'all'", specifier = "==3.10.3" },
+    { name = "nltk", marker = "extra == 'nlp'", specifier = "==3.10.3" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "onnxruntime", marker = "extra == 'all'" },
     { name = "onnxruntime", marker = "extra == 'generic'" },


### PR DESCRIPTION
Updates `nltk` from 3.9.1 to 3.10.3 in the `nlp` and `all` extras and the matching `uv.lock` entry.

Evidence:
- `pyproject.toml` pinned `nltk==3.9.1` (nlp extra)
- OSV reports 62 advisories for `nltk@3.9.1`, including GHSA-7p94-766c-hgjp (CRITICAL), GHSA-m4rf-3fr8-xwx3 (CRITICAL), GHSA-2ww3-fxvq-293j, GHSA-5gh2-94qg-qppq, GHSA-6hwm-xvph-95vm and PYSEC-2026-3722 through PYSEC-2026-3741
- updated version: `3.10.3` (latest release)

Validation:
- `uv lock --check` passes (base branch passes it too)
- `pip-audit` for `nltk==3.10.3` reports only PYSEC-2026-3740, which has no fixed release yet and also affects 3.9.1
- `nltk 3.10.3` installs and imports cleanly on Python 3.14

Scope: `pyproject.toml` and `uv.lock` only, nltk entry only.
