### PR TITLE
ci: update checkout and setup-python in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,8 +6,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-python@v7
       with:
         python-version: '3.10'
     - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Updates the pre-commit workflow to current action majors.

Changes:
- `actions/checkout@v4` -> `v7`
- `actions/setup-python@v4` -> `v7`

The pinned `python-version: '3.10'` still resolves on setup-python v7 (checked against the python-versions manifest), and the workflow does not use the `pip-install` input removed in v7.

Validation: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pre-commit.yml'))"` passes on the patched file.

Scope: `.github/workflows/pre-commit.yml` only.
