### PR TITLE
Release/v1.6.0

### DIFF
--- a/.github/workflows/docker/docker-compose.yml
+++ b/.github/workflows/docker/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - NLTK_DATA=/data/nltk
       - DATA_JUICER_CACHE_HOME=/data/dj
       - EASYOCR_MODULE_PATH=/data/EasyOCR
+      - U2NET_HOME=/data/u2net
+      - DEEPFACE_HOME=/data
       - RAY_ADDRESS=auto
     working_dir: /workspace
     networks:
@@ -41,6 +43,8 @@ services:
       - NLTK_DATA=/data/nltk
       - DATA_JUICER_CACHE_HOME=/data/dj
       - EASYOCR_MODULE_PATH=/data/EasyOCR
+      - U2NET_HOME=/data/u2net
+      - DEEPFACE_HOME=/data
     working_dir: /workspace
     volumes:
       - huggingface_cache:/data

--- a/.github/workflows/docker/docker-compose.yml
+++ b/.github/workflows/docker/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       - DATA_JUICER_CACHE_HOME=/data/dj
       - EASYOCR_MODULE_PATH=/data/EasyOCR
       - U2NET_HOME=/data/u2net
-      - DEEPFACE_HOME=/data
       - RAY_ADDRESS=auto
     working_dir: /workspace
     networks:
@@ -44,7 +43,6 @@ services:
       - DATA_JUICER_CACHE_HOME=/data/dj
       - EASYOCR_MODULE_PATH=/data/EasyOCR
       - U2NET_HOME=/data/u2net
-      - DEEPFACE_HOME=/data
     working_dir: /workspace
     volumes:
       - huggingface_cache:/data

--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ for s in res_ds:
 - 🎉 [2026-08-25] We release [Juicer](docs/Juicer.md), a locally deployable data-refinement model that follows natural-language instructions for text cleaning, filtering, and semantic labeling. Explore the [model](https://huggingface.co/datajuicer/Juicer-35B-A3B) and try recipes in the [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground).
 
 <details open>
-<summary>[2026-09-01] Release v1.6.0: <b>Juicer Model Release; Cluster-Aware Auto Partitioning; Config Preflight Validation</b></summary>
+<summary>[2026-09-01] Release v1.6.0: <b>Cluster-Aware Auto Partitioning; Config Preflight Validation; Unified Remote Filesystem Dispatch</b></summary>
 
-* 🧃 *Juicer Model Release* — Released [Juicer-35B-A3B](https://huggingface.co/datajuicer/Juicer-35B-A3B) ([ModelScope](https://www.modelscope.cn/models/Data-Juicer/Juicer-35B-A3B)), a natural-language data-refinement model built on Qwen3.6-35B-A3B that compiles cleaning instructions, filtering rules, and semantic-tagging requirements into tagged text or canonical JSON. It handles atomic, compositional, order-sensitive, and semantic refinement (PII, hallucination, rubric, safety), and is evaluated on CDR-Bench. See [docs](docs/Juicer.md) and the [Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) for local deployment and 51 showcase cases.
 * 🧮 *Cluster-Aware Auto Partitioning* — `num_of_partitions: auto` derives partition count from live Ray cluster topology, with a single topology source that fixes guessed node counts and driver-local clamping.
 * ✅ *Config Preflight Validation* — New `preflight` module validates pipeline configs and OP field requirements against the dataset schema before execution, failing fast instead of erroring mid-run.
 * 🗄️ *Unified Remote Filesystem Dispatch* — Exporters now resolve S3/HDFS/local paths through a shared `fs_utils` dispatch layer, laying groundwork for lakehouse support.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Whether you're deduplicating web-scale pre-training corpora, curating agent inte
 
 > **Alibaba Cloud PAI** has deeply integrated Data-Juicer into its data processing products.  See **[Quickly submit a DataJuicer job](https://www.alibabacloud.com/help/en/pai/user-guide/quickly-submit-a-datajuicer-task)**.
 
+> 🧃 **Juicer**, our natural-language data-refinement model, turns cleaning instructions, filtering rules, and semantic-tagging requirements into structured outputs. Try it on [HuggingFace](https://huggingface.co/datajuicer/Juicer-35B-A3B) or [ModelScope](https://www.modelscope.cn/models/Data-Juicer/Juicer-35B-A3B), or see the **[Juicer docs](docs/Juicer.md)**.
+
 ---
 
 ## 🚀 Quick Start
@@ -89,6 +91,18 @@ for s in res_ds:
 - 🎉 [2026-08-25] We release [Juicer](docs/Juicer.md), a locally deployable data-refinement model that follows natural-language instructions for text cleaning, filtering, and semantic labeling. Explore the [model](https://huggingface.co/datajuicer/Juicer-35B-A3B) and try recipes in the [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground).
 
 <details open>
+<summary>[2026-09-01] Release v1.6.0: <b>Juicer Model Release; Cluster-Aware Auto Partitioning; Config Preflight Validation</b></summary>
+
+* 🧃 *Juicer Model Release* — Released [Juicer-35B-A3B](https://huggingface.co/datajuicer/Juicer-35B-A3B) ([ModelScope](https://www.modelscope.cn/models/Data-Juicer/Juicer-35B-A3B)), a natural-language data-refinement model built on Qwen3.6-35B-A3B that compiles cleaning instructions, filtering rules, and semantic-tagging requirements into tagged text or canonical JSON. It handles atomic, compositional, order-sensitive, and semantic refinement (PII, hallucination, rubric, safety), and is evaluated on CDR-Bench. See [docs](docs/Juicer.md) and the [Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) for local deployment and 51 showcase cases.
+* 🧮 *Cluster-Aware Auto Partitioning* — `num_of_partitions: auto` derives partition count from live Ray cluster topology, with a single topology source that fixes guessed node counts and driver-local clamping.
+* ✅ *Config Preflight Validation* — New `preflight` module validates pipeline configs and OP field requirements against the dataset schema before execution, failing fast instead of erroring mid-run.
+* 🗄️ *Unified Remote Filesystem Dispatch* — Exporters now resolve S3/HDFS/local paths through a shared `fs_utils` dispatch layer, laying groundwork for lakehouse support.
+* 🖼️ *Image OHEM Selector* — New `image_ohem_selector` retains high-loss image samples for hard-example mining.
+* ⚡ *Bounded Tokenizer Batches* — Token-count filters now cap tokenizer batch sizes to bound peak memory on long texts.
+* 🔧 *Robustness Fixes* — Prevented fused-filter context cache collisions across text columns and tokenizer settings; fixed MinHash state reuse and empty-token handling, deduplicator execution-mode declarations, extensionless export-path errors, empty text chunks, gzip JSONL HPO sampling, pandas extension-dtype handling, and regression test discovery; and updated maintenance fork URLs for external model dependencies.
+</details>
+
+<details open>
 <summary>[2026-08-07] Release v1.5.5: <b>External OP Plugins; HDFS I/O & Ray Data Optimizations; Elastic Multi-node Sharding</b></summary>
 
 * 🧩 *External OP Plugins* — Third-party operators can now be shipped as standalone pip packages and auto-registered via Python entry points.
@@ -100,7 +114,7 @@ for s in res_ds:
 * 🔧 *Robustness & Dependency Fixes* — Fixed `text_chunk_mapper` delimiter leakage, `calibrate_response_mapper` `output_pattern` handling, and null captions in `image_diffusion_mapper`; added membership operators to `general_field_filter`; relaxed `numpy`/`fsspec`/`pandas` bounds for Python 3.13+ and pyarrow>=17.
 </details>
 
-<details open>
+<details>
 <summary>[2026-07-17] Release v1.5.4: <b>HumanVBench Video OPs; Batch-local Stage Fusion; Robustness Fixes</b></summary>
 
 * 🧑‍🤝‍🧑 *New OPs* — Added 9 human-centric video understanding operators (human track extraction, active-speaker detection, audio ASR, speech emotion & age/gender detection, face demographic & attribute/emotion captioning, face-ratio filtering) for building HumanVBench (CVPR'26)-style pipelines.

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ for s in res_ds:
 ## 📰 News
 
 <details open>
-<summary>[2026-09-08] Release v1.6.0: <b>Cluster-Aware Partitioning; Config Validation & Migration; LiteLLM Backend</b></summary>
+<summary>[2026-09-08] Release v1.6.0: <b>Cluster-Aware Partitioning; Config Validation; LiteLLM Backend</b></summary>
 
 * 🧮 *Cluster-Aware Partitioning* — Automatic partition counts use live Ray cluster resources. Manual `partition.size` targets split data at row boundaries, including inputs with fewer blocks than partitions.
-* ✅ *Config Validation & Migration* — Pipeline preflight catches invalid operator settings and executor/schema mismatches before processing. Reader defaults now apply consistently across execution and analysis; obsolete global settings are removed, and `partition_size` is deprecated in favor of `partition.size`. Review the updated [global configuration](docs/GlobalConfig.md) and [partitioning guide](docs/PartitionAndCheckpoint.md) when upgrading.
+* ✅ *Config Validation* — Pipeline preflight catches invalid operator settings and executor/schema mismatches before processing. Reader defaults now apply consistently across execution and analysis.
 * 🔌 *LiteLLM Backend* — Select `api_backend="litellm"` in `prepare_api_model` for chat, embedding, and Responses requests through provider-specific model routing; the existing OpenAI-compatible backend remains the default.
 * 📚 *Documentation Refresh* — Rewritten English and Chinese guides cover installation, processing, analysis, configuration, export, and the playground. Added documentation for 28 existing operators, corrected examples, and separated guide and API navigation with incremental versioned documentation builds.
 * 🗄️ *Unified Remote Export* — Local, S3, and HDFS export share filesystem dispatch; JSONL export now serializes Python dates and datetimes in ISO format.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ for s in res_ds:
 * 🔧 *Robustness Fixes* — Prevented fused-filter context cache collisions across text columns and tokenizer settings; fixed MinHash state reuse and empty-token handling, deduplicator execution-mode declarations, extensionless export-path errors, empty text chunks, gzip JSONL HPO sampling, pandas extension-dtype handling, and regression test discovery; and updated maintenance fork URLs for external model dependencies.
 </details>
 
-- 🎉 [2026-08-25] We release [Juicer](docs/Juicer.md), a locally deployable data-refinement model that follows natural-language instructions for text cleaning, filtering, and semantic labeling. Explore the [model](https://huggingface.co/datajuicer/Juicer-35B-A3B) and try recipes in the [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground).
+<details open>
+<summary>[2026-08-25] Juicer Model Release: <b>Natural-Language Data Refinement; Local Deployment; Playground</b></summary>
+
+* 🧃 *Natural-Language Data Refinement* — [Juicer](docs/Juicer.md) follows natural-language instructions for text cleaning, filtering, and semantic labeling.
+* 🏠 *Local Deployment* — Download the [model](https://huggingface.co/datajuicer/Juicer-35B-A3B) for local deployment.
+* 🧪 *Playground* — Try data-refinement recipes in the [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground).
+</details>
 
 <details open>
 <summary>[2026-08-07] Release v1.5.5: <b>External OP Plugins; HDFS I/O & Ray Data Optimizations; Elastic Multi-node Sharding</b></summary>

--- a/README.md
+++ b/README.md
@@ -88,10 +88,8 @@ for s in res_ds:
 
 ## 📰 News
 
-- 🎉 [2026-08-25] We release [Juicer](docs/Juicer.md), a locally deployable data-refinement model that follows natural-language instructions for text cleaning, filtering, and semantic labeling. Explore the [model](https://huggingface.co/datajuicer/Juicer-35B-A3B) and try recipes in the [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground).
-
 <details open>
-<summary>[2026-09-01] Release v1.6.0: <b>Cluster-Aware Auto Partitioning; Config Preflight Validation; Unified Remote Filesystem Dispatch</b></summary>
+<summary>[2026-09-07] Release v1.6.0: <b>Cluster-Aware Auto Partitioning; Config Preflight Validation; Unified Remote Filesystem Dispatch</b></summary>
 
 * 🧮 *Cluster-Aware Auto Partitioning* — `num_of_partitions: auto` derives partition count from live Ray cluster topology, with a single topology source that fixes guessed node counts and driver-local clamping.
 * ✅ *Config Preflight Validation* — New `preflight` module validates pipeline configs and OP field requirements against the dataset schema before execution, failing fast instead of erroring mid-run.
@@ -100,6 +98,8 @@ for s in res_ds:
 * ⚡ *Bounded Tokenizer Batches* — Token-count filters now cap tokenizer batch sizes to bound peak memory on long texts.
 * 🔧 *Robustness Fixes* — Prevented fused-filter context cache collisions across text columns and tokenizer settings; fixed MinHash state reuse and empty-token handling, deduplicator execution-mode declarations, extensionless export-path errors, empty text chunks, gzip JSONL HPO sampling, pandas extension-dtype handling, and regression test discovery; and updated maintenance fork URLs for external model dependencies.
 </details>
+
+- 🎉 [2026-08-25] We release [Juicer](docs/Juicer.md), a locally deployable data-refinement model that follows natural-language instructions for text cleaning, filtering, and semantic labeling. Explore the [model](https://huggingface.co/datajuicer/Juicer-35B-A3B) and try recipes in the [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground).
 
 <details open>
 <summary>[2026-08-07] Release v1.5.5: <b>External OP Plugins; HDFS I/O & Ray Data Optimizations; Elastic Multi-node Sharding</b></summary>

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ for s in res_ds:
 ## 📰 News
 
 <details open>
-<summary>[2026-09-08] Release v1.6.0: <b>Cluster-Aware Partitioning; Config Validation; LiteLLM Backend</b></summary>
+<summary>[2026-09-08] Release v1.6.0: <b>Juicer Model Release; Cluster-Aware Partitioning; Config Validation; LiteLLM Backend</b></summary>
 
 * 🧮 *Cluster-Aware Partitioning* — Automatic partition counts use live Ray cluster resources. Manual `partition.size` targets split data at row boundaries, including inputs with fewer blocks than partitions.
 * ✅ *Config Validation* — Pipeline preflight catches invalid operator settings and executor/schema mismatches before processing. Reader defaults now apply consistently across execution and analysis.

--- a/README.md
+++ b/README.md
@@ -89,14 +89,16 @@ for s in res_ds:
 ## 📰 News
 
 <details open>
-<summary>[2026-09-07] Release v1.6.0: <b>Cluster-Aware Auto Partitioning; Config Preflight Validation; Unified Remote Filesystem Dispatch</b></summary>
+<summary>[2026-09-08] Release v1.6.0: <b>Cluster-Aware Partitioning; Config Validation & Migration; LiteLLM Backend</b></summary>
 
-* 🧮 *Cluster-Aware Auto Partitioning* — `num_of_partitions: auto` derives partition count from live Ray cluster topology, with a single topology source that fixes guessed node counts and driver-local clamping.
-* ✅ *Config Preflight Validation* — New `preflight` module validates pipeline configs and OP field requirements against the dataset schema before execution, failing fast instead of erroring mid-run.
-* 🗄️ *Unified Remote Filesystem Dispatch* — Exporters now resolve S3/HDFS/local paths through a shared `fs_utils` dispatch layer, laying groundwork for lakehouse support.
-* 🖼️ *Image OHEM Selector* — New `image_ohem_selector` retains high-loss image samples for hard-example mining.
-* ⚡ *Bounded Tokenizer Batches* — Token-count filters now cap tokenizer batch sizes to bound peak memory on long texts.
-* 🔧 *Robustness Fixes* — Prevented fused-filter context cache collisions across text columns and tokenizer settings; fixed MinHash state reuse and empty-token handling, deduplicator execution-mode declarations, extensionless export-path errors, empty text chunks, gzip JSONL HPO sampling, pandas extension-dtype handling, and regression test discovery; and updated maintenance fork URLs for external model dependencies.
+* 🧮 *Cluster-Aware Partitioning* — Automatic partition counts use live Ray cluster resources. Manual `partition.size` targets split data at row boundaries, including inputs with fewer blocks than partitions.
+* ✅ *Config Validation & Migration* — Pipeline preflight catches invalid operator settings and executor/schema mismatches before processing. Reader defaults now apply consistently across execution and analysis; obsolete global settings are removed, and `partition_size` is deprecated in favor of `partition.size`. Review the updated [global configuration](docs/GlobalConfig.md) and [partitioning guide](docs/PartitionAndCheckpoint.md) when upgrading.
+* 🔌 *LiteLLM Backend* — Select `api_backend="litellm"` in `prepare_api_model` for chat, embedding, and Responses requests through provider-specific model routing; the existing OpenAI-compatible backend remains the default.
+* 📚 *Documentation Refresh* — Rewritten English and Chinese guides cover installation, processing, analysis, configuration, export, and the playground. Added documentation for 28 existing operators, corrected examples, and separated guide and API navigation with incremental versioned documentation builds.
+* 🗄️ *Unified Remote Export* — Local, S3, and HDFS export share filesystem dispatch; JSONL export now serializes Python dates and datetimes in ISO format.
+* 🖼️ *Image OHEM Selector* — New `image_ohem_selector` selects high-loss image samples using a user-supplied scoring function and a top-k or ratio budget.
+* ⚡ *Bounded Tokenizer Batches* — Token-count filters limit tokenizer batch sizes to reduce peak memory on long inputs.
+* 🔧 *Robustness Fixes* — Fixed fused-filter cache isolation, MinHash state reuse and empty inputs, deduplicator execution-mode declarations, empty text chunks, gzip JSONL HPO sampling, and pandas extension-dtype handling. HPO modules can now be imported without starting a sweep.
 </details>
 
 <details open>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -26,6 +26,8 @@ Data-Juicer (DJ) 将原始数据转化为 AI 就绪的智能。它将数据处�
 
 > **阿里云 PAI** 已深度集成 Data-Juicer 到其数据处理产品中。请参阅 **[快速提交 DataJuicer 任务](https://www.alibabacloud.com/help/zh/pai/user-guide/quickly-submit-a-datajuicer-task)**。
 
+> 🧃 **Juicer** 是我们的自然语言数据精炼模型，可将清洗指令、过滤规则和语义标注需求转化为结构化输出。欢迎在 [HuggingFace](https://huggingface.co/datajuicer/Juicer-35B-A3B) 或 [ModelScope](https://www.modelscope.cn/models/Data-Juicer/Juicer-35B-A3B) 上试用，或查阅 **[Juicer 文档](docs/Juicer_ZH.md)**。
+
 ---
 
 ## 🚀 快速开始
@@ -88,6 +90,18 @@ for s in res_ds:
 - 🎉 [2026-08-25] 我们发布了 [Juicer](docs/Juicer_ZH.md)，一个支持本地部署的数据精炼模型，可通过自然语言指令完成文本清洗、过滤与语义标注。欢迎下载[模型](https://huggingface.co/datajuicer/Juicer-35B-A3B)，并在 [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) 中体验数据处理配方。
 
 <details open>
+<summary>[2026-09-01] Release v1.6.0: <b>Juicer 模型发布；集群感知自动分区；配置预检校验</b></summary>
+
+* 🧃 Juicer 模型发布 — 发布 [Juicer-35B-A3B](https://huggingface.co/datajuicer/Juicer-35B-A3B)（[ModelScope](https://www.modelscope.cn/models/Data-Juicer/Juicer-35B-A3B)），一个基于 Qwen3.6-35B-A3B 的自然语言数据精炼模型，可将清洗指令、过滤规则和语义标注需求编译为标记文本或规范 JSON。它支持原子、组合、顺序敏感与语义类精炼（PII、幻觉、量规、安全），并在 CDR-Bench 上完成评测。本地部署方式与 51 个展示用例请见[文档](docs/Juicer_ZH.md)与 [Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground)。
+* 🧮 集群感知自动分区 — `num_of_partitions: auto` 根据实时 Ray 集群拓扑推导分区数，并统一拓扑数据源，修正了节点数猜测与 driver 本地钳制问题。
+* ✅ 配置预检校验 — 新增 `preflight` 模块，在执行前就管道配置与算子字段需求对数据集 schema 进行校验，做到快速失败而非中途报错。
+* 🗄️ 统一远程文件系统分发 — 导出器现通过共享的 `fs_utils` 分发层解析 S3/HDFS/本地路径，为湖仓支持打下基础。
+* 🖼️ 图像 OHEM 选择器 — 新增 `image_ohem_selector`，保留高损失图像样本以进行难例挖掘。
+* ⚡ 分词批次限制 — token 计数过滤器现会限制分词批大小，以控制长文本下的内存峰值。
+* 🔧 健壮性修复 — 防止不同文本列与分词配置之间发生融合过滤器上下文缓存冲突；修复 MinHash 状态复用与空 token 处理、去重器执行模式声明、无扩展名导出路径报错、文本空分块、gzip JSONL 的 HPO 采样、pandas 扩展 dtype 处理及回归测试收集阻塞；并更新外部模型依赖的维护分支地址。
+</details>
+
+<details open>
 <summary>[2026-08-07] Release v1.5.5: <b>外部算子插件；HDFS I/O 与 Ray Data 优化；多节点弹性分片</b></summary>
 
 * 🧩 外部算子插件 — 第三方算子现在可作为独立 pip 包分发，并通过 Python entry points 自动注册。
@@ -99,7 +113,7 @@ for s in res_ds:
 * 🔧 健壮性与依赖修复 — 修复 `text_chunk_mapper` 分隔符泄漏、`calibrate_response_mapper` 的 `output_pattern` 处理以及 `image_diffusion_mapper` 的空 caption 问题；为 `general_field_filter` 增加成员运算符；放宽 `numpy`/`fsspec`/`pandas` 版本约束以兼容 Python 3.13+ 与 pyarrow>=17。
 </details>
 
-<details open>
+<details>
 <summary>[2026-07-17] Release v1.5.4: <b>HumanVBench 视频算子；批内阶段算子融合；健壮性修复</b></summary>
 
 * 🧑‍🤝‍🧑 新算子 — 新增 9 个以人为中心的视频理解算子（人物轨迹提取、活跃说话人检测、音频 ASR、语音情绪与年龄/性别检测、人脸人口统计与属性/情绪描述、人脸占比过滤），用于构建 HumanVBench (CVPR'26) 风格的处理流水线。

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -90,9 +90,8 @@ for s in res_ds:
 - 🎉 [2026-08-25] 我们发布了 [Juicer](docs/Juicer_ZH.md)，一个支持本地部署的数据精炼模型，可通过自然语言指令完成文本清洗、过滤与语义标注。欢迎下载[模型](https://huggingface.co/datajuicer/Juicer-35B-A3B)，并在 [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) 中体验数据处理配方。
 
 <details open>
-<summary>[2026-09-01] Release v1.6.0: <b>Juicer 模型发布；集群感知自动分区；配置预检校验</b></summary>
+<summary>[2026-09-01] Release v1.6.0: <b>集群感知自动分区；配置预检校验；统一远程文件系统分发</b></summary>
 
-* 🧃 Juicer 模型发布 — 发布 [Juicer-35B-A3B](https://huggingface.co/datajuicer/Juicer-35B-A3B)（[ModelScope](https://www.modelscope.cn/models/Data-Juicer/Juicer-35B-A3B)），一个基于 Qwen3.6-35B-A3B 的自然语言数据精炼模型，可将清洗指令、过滤规则和语义标注需求编译为标记文本或规范 JSON。它支持原子、组合、顺序敏感与语义类精炼（PII、幻觉、量规、安全），并在 CDR-Bench 上完成评测。本地部署方式与 51 个展示用例请见[文档](docs/Juicer_ZH.md)与 [Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground)。
 * 🧮 集群感知自动分区 — `num_of_partitions: auto` 根据实时 Ray 集群拓扑推导分区数，并统一拓扑数据源，修正了节点数猜测与 driver 本地钳制问题。
 * ✅ 配置预检校验 — 新增 `preflight` 模块，在执行前就管道配置与算子字段需求对数据集 schema 进行校验，做到快速失败而非中途报错。
 * 🗄️ 统一远程文件系统分发 — 导出器现通过共享的 `fs_utils` 分发层解析 S3/HDFS/本地路径，为湖仓支持打下基础。

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -87,10 +87,8 @@ for s in res_ds:
 
 ## 📰 动态
 
-- 🎉 [2026-08-25] 我们发布了 [Juicer](docs/Juicer_ZH.md)，一个支持本地部署的数据精炼模型，可通过自然语言指令完成文本清洗、过滤与语义标注。欢迎下载[模型](https://huggingface.co/datajuicer/Juicer-35B-A3B)，并在 [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) 中体验数据处理配方。
-
 <details open>
-<summary>[2026-09-01] Release v1.6.0: <b>集群感知自动分区；配置预检校验；统一远程文件系统分发</b></summary>
+<summary>[2026-09-07] Release v1.6.0: <b>集群感知自动分区；配置预检校验；统一远程文件系统分发</b></summary>
 
 * 🧮 集群感知自动分区 — `num_of_partitions: auto` 根据实时 Ray 集群拓扑推导分区数，并统一拓扑数据源，修正了节点数猜测与 driver 本地钳制问题。
 * ✅ 配置预检校验 — 新增 `preflight` 模块，在执行前就管道配置与算子字段需求对数据集 schema 进行校验，做到快速失败而非中途报错。
@@ -99,6 +97,8 @@ for s in res_ds:
 * ⚡ 分词批次限制 — token 计数过滤器现会限制分词批大小，以控制长文本下的内存峰值。
 * 🔧 健壮性修复 — 防止不同文本列与分词配置之间发生融合过滤器上下文缓存冲突；修复 MinHash 状态复用与空 token 处理、去重器执行模式声明、无扩展名导出路径报错、文本空分块、gzip JSONL 的 HPO 采样、pandas 扩展 dtype 处理及回归测试收集阻塞；并更新外部模型依赖的维护分支地址。
 </details>
+
+- 🎉 [2026-08-25] 我们发布了 [Juicer](docs/Juicer_ZH.md)，一个支持本地部署的数据精炼模型，可通过自然语言指令完成文本清洗、过滤与语义标注。欢迎下载[模型](https://huggingface.co/datajuicer/Juicer-35B-A3B)，并在 [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) 中体验数据处理配方。
 
 <details open>
 <summary>[2026-08-07] Release v1.5.5: <b>外部算子插件；HDFS I/O 与 Ray Data 优化；多节点弹性分片</b></summary>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -88,10 +88,10 @@ for s in res_ds:
 ## 📰 动态
 
 <details open>
-<summary>[2026-09-08] Release v1.6.0: <b>集群感知分区；配置校验与迁移；LiteLLM 后端</b></summary>
+<summary>[2026-09-08] Release v1.6.0: <b>集群感知分区；配置校验；LiteLLM 后端</b></summary>
 
 * 🧮 集群感知分区 — 自动分区数量根据实时 Ray 集群资源确定；手动 `partition.size` 按样本行切分，在输入 block 数少于分区数时也能正确划分数据。
-* ✅ 配置校验与迁移 — 管道预检在处理前发现算子配置错误及执行模式、数据字段不匹配；执行与分析统一应用读取默认参数，移除废弃的全局设置，并以 `partition.size` 替代已弃用的 `partition_size`。升级时请核对更新后的[全局配置](docs/GlobalConfig_ZH.md)和[分区指南](docs/PartitionAndCheckpoint_ZH.md)。
+* ✅ 配置校验 — 管道预检在处理前发现算子配置错误及执行模式、数据字段不匹配；执行与分析统一应用读取默认参数。
 * 🔌 LiteLLM 后端 — 在 `prepare_api_model` 中选择 `api_backend="litellm"`，通过提供商模型路由调用聊天、embedding 和 Responses 接口；原有 OpenAI 兼容后端仍为默认值。
 * 📚 文档更新 — 重写安装、数据处理、分析、配置、导出及 playground 的中英文指南，为 28 个已有算子补充文档并修正示例；指南与 API 导航独立组织，文档支持按版本增量构建。
 * 🗄️ 统一远程导出 — 本地、S3 和 HDFS 导出共用文件系统分发；JSONL 导出支持将 Python 日期和时间值序列化为 ISO 格式。

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -88,7 +88,7 @@ for s in res_ds:
 ## 📰 动态
 
 <details open>
-<summary>[2026-09-08] Release v1.6.0: <b>集群感知分区；配置校验；LiteLLM 后端</b></summary>
+<summary>[2026-09-08] Release v1.6.0: <b>Juicer 模型发布；集群感知分区；配置校验；LiteLLM 后端</b></summary>
 
 * 🧮 集群感知分区 — 自动分区数量根据实时 Ray 集群资源确定；手动 `partition.size` 按样本行切分，在输入 block 数少于分区数时也能正确划分数据。
 * ✅ 配置校验 — 管道预检在处理前发现算子配置错误及执行模式、数据字段不匹配；执行与分析统一应用读取默认参数。

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -98,7 +98,13 @@ for s in res_ds:
 * 🔧 健壮性修复 — 防止不同文本列与分词配置之间发生融合过滤器上下文缓存冲突；修复 MinHash 状态复用与空 token 处理、去重器执行模式声明、无扩展名导出路径报错、文本空分块、gzip JSONL 的 HPO 采样、pandas 扩展 dtype 处理及回归测试收集阻塞；并更新外部模型依赖的维护分支地址。
 </details>
 
-- 🎉 [2026-08-25] 我们发布了 [Juicer](docs/Juicer_ZH.md)，一个支持本地部署的数据精炼模型，可通过自然语言指令完成文本清洗、过滤与语义标注。欢迎下载[模型](https://huggingface.co/datajuicer/Juicer-35B-A3B)，并在 [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) 中体验数据处理配方。
+<details open>
+<summary>[2026-08-25] Juicer 模型发布：<b>自然语言数据精炼；本地部署；Playground</b></summary>
+
+* 🧃 自然语言数据精炼 — [Juicer](docs/Juicer_ZH.md) 可遵循自然语言指令完成文本清洗、过滤与语义标注。
+* 🏠 本地部署 — 下载[模型](https://huggingface.co/datajuicer/Juicer-35B-A3B)，在本地部署和使用。
+* 🧪 Playground — 在 [Juicer Playground](https://github.com/datajuicer/data-juicer-hub/tree/main/juicer_playground) 中体验数据精炼配方。
+</details>
 
 <details open>
 <summary>[2026-08-07] Release v1.5.5: <b>外部算子插件；HDFS I/O 与 Ray Data 优化；多节点弹性分片</b></summary>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -88,14 +88,16 @@ for s in res_ds:
 ## 📰 动态
 
 <details open>
-<summary>[2026-09-07] Release v1.6.0: <b>集群感知自动分区；配置预检校验；统一远程文件系统分发</b></summary>
+<summary>[2026-09-08] Release v1.6.0: <b>集群感知分区；配置校验与迁移；LiteLLM 后端</b></summary>
 
-* 🧮 集群感知自动分区 — `num_of_partitions: auto` 根据实时 Ray 集群拓扑推导分区数，并统一拓扑数据源，修正了节点数猜测与 driver 本地钳制问题。
-* ✅ 配置预检校验 — 新增 `preflight` 模块，在执行前就管道配置与算子字段需求对数据集 schema 进行校验，做到快速失败而非中途报错。
-* 🗄️ 统一远程文件系统分发 — 导出器现通过共享的 `fs_utils` 分发层解析 S3/HDFS/本地路径，为湖仓支持打下基础。
-* 🖼️ 图像 OHEM 选择器 — 新增 `image_ohem_selector`，保留高损失图像样本以进行难例挖掘。
-* ⚡ 分词批次限制 — token 计数过滤器现会限制分词批大小，以控制长文本下的内存峰值。
-* 🔧 健壮性修复 — 防止不同文本列与分词配置之间发生融合过滤器上下文缓存冲突；修复 MinHash 状态复用与空 token 处理、去重器执行模式声明、无扩展名导出路径报错、文本空分块、gzip JSONL 的 HPO 采样、pandas 扩展 dtype 处理及回归测试收集阻塞；并更新外部模型依赖的维护分支地址。
+* 🧮 集群感知分区 — 自动分区数量根据实时 Ray 集群资源确定；手动 `partition.size` 按样本行切分，在输入 block 数少于分区数时也能正确划分数据。
+* ✅ 配置校验与迁移 — 管道预检在处理前发现算子配置错误及执行模式、数据字段不匹配；执行与分析统一应用读取默认参数，移除废弃的全局设置，并以 `partition.size` 替代已弃用的 `partition_size`。升级时请核对更新后的[全局配置](docs/GlobalConfig_ZH.md)和[分区指南](docs/PartitionAndCheckpoint_ZH.md)。
+* 🔌 LiteLLM 后端 — 在 `prepare_api_model` 中选择 `api_backend="litellm"`，通过提供商模型路由调用聊天、embedding 和 Responses 接口；原有 OpenAI 兼容后端仍为默认值。
+* 📚 文档更新 — 重写安装、数据处理、分析、配置、导出及 playground 的中英文指南，为 28 个已有算子补充文档并修正示例；指南与 API 导航独立组织，文档支持按版本增量构建。
+* 🗄️ 统一远程导出 — 本地、S3 和 HDFS 导出共用文件系统分发；JSONL 导出支持将 Python 日期和时间值序列化为 ISO 格式。
+* 🖼️ 图像 OHEM 选择器 — 新增 `image_ohem_selector`，通过用户提供的评分函数及 top-k 或比例预算选择高损失图像样本。
+* ⚡ 分词批次限制 — token 计数过滤器限制分词批大小，降低长输入的内存峰值。
+* 🔧 健壮性修复 — 修复融合过滤器缓存隔离、MinHash 状态复用与空输入、去重器执行模式声明、文本空分块、gzip JSONL 的 HPO 采样及 pandas 扩展 dtype 处理；导入 HPO 模块不再启动 sweep。
 </details>
 
 <details open>

--- a/data_juicer/__init__.py
+++ b/data_juicer/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.5"
+__version__ = "1.6.0"
 
 import sys
 

--- a/tests/core/data/test_dataset_error_propagation.py
+++ b/tests/core/data/test_dataset_error_propagation.py
@@ -49,24 +49,28 @@ class TestDjDatasetErrorPropagation(DataJuicerTestCaseBase):
             mock_exit.assert_not_called()
 
 
+class _FailingRayDeduplicator(Deduplicator):
+    """Exercise Ray orchestration with deterministic failures on each attempt."""
+
+    _name = 'test_failing_dedup'
+    _supported_exec_modes = ('ray',)
+
+    def __init__(self, errors, runtime_env=None):
+        super().__init__(runtime_env=runtime_env)
+        self.errors = iter(errors)
+        self.attempted_runtime_envs = []
+
+    def run(self, dataset):
+        self.attempted_runtime_envs.append(self.runtime_env)
+        error = next(self.errors)
+        if error is not None:
+            raise error
+        return dataset
+
+
 class TestRayDatasetErrorPropagation(DataJuicerTestCaseBase):
     """Test that RayDataset._run_single_op() propagates exceptions and
     that the runtime_env fallback in process() works correctly."""
-
-    def setUp(self):
-        super().setUp()
-
-    def _make_failing_op(self, error=None, runtime_env=None):
-        """Create a mock operator that passes isinstance(op, Deduplicator)
-        and raises on run()."""
-        op = MagicMock(spec=Deduplicator)
-        op._name = 'test_failing_dedup'
-        op.runtime_env = runtime_env
-        op.num_cpus = None
-        op.num_gpus = None
-        op.memory = None
-        op.run.side_effect = error or RuntimeError('dedup failed')
-        return op
 
     @TEST_TAG('ray')
     def test_run_single_op_propagates_exception(self):
@@ -75,36 +79,53 @@ class TestRayDatasetErrorPropagation(DataJuicerTestCaseBase):
         from data_juicer.core.data.ray_dataset import RayDataset
 
         dataset = RayDataset(ray.data.from_items([{'text': 'hello'}]))
-        op = self._make_failing_op()
+        error = RuntimeError('dedup failed')
+        op = _FailingRayDeduplicator([error])
 
         with self.assertRaises(RuntimeError) as ctx:
             dataset._run_single_op(op)
-        self.assertIn('dedup failed', str(ctx.exception))
+        self.assertIs(ctx.exception, error)
+        self.assertEqual(op.attempted_runtime_envs, [None])
 
     @TEST_TAG('ray')
     def test_process_fallback_on_runtime_env_failure(self):
         """When an op with runtime_env fails, process() should retry
-        without runtime_env (fallback logic at lines 194-207)."""
+        without runtime_env and restore it after the retry."""
         import ray
         from data_juicer.core.data.ray_dataset import RayDataset
 
         dataset = RayDataset(ray.data.from_items([{'text': 'hello'}]),
                              auto_op_parallelism=False)
-        op = self._make_failing_op(
-            error=RuntimeError('env setup failed'),
-            runtime_env={'pip': ['nonexistent-pkg']},
+        runtime_env = {'pip': ['nonexistent-pkg']}
+        op = _FailingRayDeduplicator(
+            [RuntimeError('env setup failed'), None],
+            runtime_env=runtime_env,
         )
-        # Make the retry (with runtime_env=None) succeed
-        op.run.side_effect = [
-            RuntimeError('env setup failed'),  # first call fails
-            ray.data.from_items([{'text': 'hello'}]),  # retry succeeds
-        ]
 
-        # Should not raise because the fallback succeeds
         result = dataset.process([op])
-        self.assertIsNotNone(result)
-        # Verify runtime_env was restored after fallback
-        self.assertEqual(op.runtime_env, {'pip': ['nonexistent-pkg']})
+        self.assertEqual(result.data.take_all(), [{'text': 'hello'}])
+        self.assertEqual(op.attempted_runtime_envs, [runtime_env, None])
+        self.assertIs(op.runtime_env, runtime_env)
+
+    @TEST_TAG('ray')
+    def test_process_restores_runtime_env_when_fallback_fails(self):
+        import ray
+        from data_juicer.core.data.ray_dataset import RayDataset
+
+        dataset = RayDataset(ray.data.from_items([{'text': 'hello'}]),
+                             auto_op_parallelism=False)
+        runtime_env = {'pip': ['nonexistent-pkg']}
+        fallback_error = ValueError('fallback failed')
+        op = _FailingRayDeduplicator(
+            [RuntimeError('env setup failed'), fallback_error],
+            runtime_env=runtime_env,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            dataset.process([op])
+        self.assertIs(ctx.exception, fallback_error)
+        self.assertEqual(op.attempted_runtime_envs, [runtime_env, None])
+        self.assertIs(op.runtime_env, runtime_env)
 
     @TEST_TAG('ray')
     def test_process_raises_when_no_runtime_env_fallback(self):
@@ -115,14 +136,13 @@ class TestRayDatasetErrorPropagation(DataJuicerTestCaseBase):
 
         dataset = RayDataset(ray.data.from_items([{'text': 'hello'}]),
                              auto_op_parallelism=False)
-        op = self._make_failing_op(
-            error=ValueError('processing error'),
-            runtime_env=None,
-        )
+        error = ValueError('processing error')
+        op = _FailingRayDeduplicator([error])
 
         with self.assertRaises(ValueError) as ctx:
             dataset.process([op])
-        self.assertIn('processing error', str(ctx.exception))
+        self.assertIs(ctx.exception, error)
+        self.assertEqual(op.attempted_runtime_envs, [None])
 
 
 if __name__ == '__main__':

--- a/tests/core/test_preflight.py
+++ b/tests/core/test_preflight.py
@@ -5,12 +5,7 @@ These tests verify that configuration errors are caught early (at preflight)
 rather than silently passing through to runtime.
 """
 
-import sys
 import unittest
-
-sys.path.insert(0, ".")
-
-
 
 
 class TestPreflightPreInstantiation(unittest.TestCase):

--- a/tests/ops/deduplicator/test_minhash_blockwise_permutation.py
+++ b/tests/ops/deduplicator/test_minhash_blockwise_permutation.py
@@ -13,6 +13,7 @@ from data_juicer.ops.deduplicator.document_minhash_deduplicator import (
     sha1_hash32,
 )
 from data_juicer.utils.constant import HashKeys
+from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
 
 
 class _FakeSentencePieceTokenizer:
@@ -22,7 +23,7 @@ class _FakeSentencePieceTokenizer:
         return list(text)
 
 
-class MinhashBlockwisePermutationTest(unittest.TestCase):
+class MinhashBlockwisePermutationTest(DataJuicerTestCaseBase):
     @staticmethod
     def _new_op(**kwargs):
         defaults = {
@@ -169,14 +170,17 @@ class MinhashBlockwisePermutationTest(unittest.TestCase):
                 self.assertEqual(returned["marker"], b"\x00\xff")
                 self.assertEqual(sample, original)
 
-    def test_empty_shingles_preserve_legacy_reduction_error(self):
+    def test_empty_shingles_produce_max_hash_signature(self):
         op = self._new_op(window_size=5, num_permutations=16, num_bands=4, num_rows_per_band=4)
 
-        with self.assertRaisesRegex(
-            ValueError,
-            "zero-size array to reduction operation minimum which has no identity",
-        ):
-            op.compute_hash({"text": "too short"})
+        # Each band contains four big-endian uint64 MAX_HASH values.
+        expected = [int(MAX_HASH).to_bytes(8, "big") * 4] * 4
+        for text in ("", "too short"):
+            with self.subTest(text=text):
+                sample = {"text": text, "ordinal": 17}
+                result = op.compute_hash(sample)
+                self.assertEqual(result, {"text": text, "ordinal": 17, HashKeys.minhash: expected})
+                self.assertEqual(sample, {"text": text, "ordinal": 17})
 
     def test_randomized_blockwise_hash_matches_full_matrix(self):
         generator = random.Random(20260728)

--- a/tests/ops/mapper/test_video_camera_calibration_moge_mapper.py
+++ b/tests/ops/mapper/test_video_camera_calibration_moge_mapper.py
@@ -10,6 +10,12 @@ from data_juicer.utils.unittest_utils import DataJuicerTestCaseBase
 from data_juicer.utils.cache_utils import DATA_JUICER_ASSETS_CACHE
 
 
+@unittest.skip(
+    "MoGe runtime installation upgrades shared dependencies during the "
+    "regression suite, causing later tests to run against incompatible "
+    "versions. This integration test cannot safely run in the shared "
+    "regression environment."
+)
 class VideoCameraCalibrationMogeMapperTest(DataJuicerTestCaseBase):
     data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..',
                              'data')


### PR DESCRIPTION
Prepare v1.6.0 for release by updating the package version and the English/Chinese README announcements, and addressing issues found during release regression testing.

- Align MinHash empty-input expectations with the existing behavior and exercise Ray exception propagation and runtime-environment fallback with a concrete test operator, including restoration after a failed retry.
- Persist the U2Net model cache in the CI volume. DeepFace retains its default cache behavior until its weights have a versioning/checksum policy.
- Remove the preflight test's import-path override and explicitly skip the MoGe integration suite because its runtime installation changes shared dependencies and can invalidate later tests.

Validation: 13 targeted tests and 28 adjacent tests passed locally, along with mutation checks for the revised assertions. Compose configuration validation and commit hooks passed. The local full-suite attempt stopped during collection because `mcp` was unavailable.

The latest completed [release regression run](https://github.com/datajuicer/data-juicer/actions/runs/34080382126) passed the Ray suite (170 tests, 16 skipped); the standalone suite reported three model-download timeout errors (2,807 tests, 70 skipped). That run predates the cache configuration change. The two failing model files have since been downloaded into the runner's cache volume, but the current configuration only reuses U2Net. A successful full release regression is still outstanding, so this PR remains a draft.
