### PR TITLE
fix(ci): support metadata 2.5 in PyPI publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -39,7 +39,7 @@ jobs:
         python -c "import data_juicer; print(data_juicer.__version__)"
         dj-process --help
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@v1.14.2
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The v1.6.0 release initially failed before upload because Twine 6.2.0 rejected the built distributions' `Metadata-Version: 2.5`. Update `pypa/gh-action-pypi-publish` to `v1.14.2`, which includes Twine 7 and supports metadata 2.5 for future releases.

Validation:

- A [dry-run GitHub Actions workflow](https://github.com/cmgzn/data-juicer/actions/runs/34303450640) built the actual v1.6.0 wheel and sdist, confirmed both use metadata 2.5, and uploaded them with `pypa/gh-action-pypi-publish@v1.14.2` to a temporary runner-local package server. Both uploaded files matched the build artifacts by SHA256.
- A subsequent [workflow run in the main repository](https://github.com/datajuicer/data-juicer/actions/runs/34303888773) checked out the original v1.6.0 release commit (`cc914ee43b825dc91273040d728114cf636a4475`) and successfully published both distributions to [PyPI](https://pypi.org/project/py-data-juicer/1.6.0/). This kept the workflow-only commit out of the v1.6.0 package source.
- Applicable local pre-commit checks passed.

Fixes the metadata validation error in [the original failed release run](https://github.com/datajuicer/data-juicer/actions/runs/34302345500/job/102311743547).
